### PR TITLE
Add one-file Yjs document session

### DIFF
--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import type { OneFileDocumentSession } from '@kb-2/doc-session';
 import { readFile, stat } from 'node:fs/promises';
 import { extname, join, relative, resolve, sep } from 'node:path';
 
@@ -7,6 +8,7 @@ import { readDaemonStatus } from './status.js';
 
 export interface CreateAppOptions {
   statusFile: string;
+  demoDocumentSession?: OneFileDocumentSession;
   webBuildDir?: string;
   webProxyTarget?: string;
 }
@@ -24,6 +26,29 @@ export function createApp(options: CreateAppOptions): Hono {
       status
     });
   });
+
+  if (options.demoDocumentSession) {
+    api.get('/demo-document', async (context) => {
+      const content = await options.demoDocumentSession!.getContent();
+
+      return context.json({
+        ok: true,
+        document: 'demo-vault/hello-world.md',
+        content
+      });
+    });
+
+    api.post('/demo-document/reset', async (context) => {
+      const requestedContent = await readOptionalJsonContent(context.req.raw);
+      const content = await options.demoDocumentSession!.reset(requestedContent);
+
+      return context.json({
+        ok: true,
+        document: 'demo-vault/hello-world.md',
+        content
+      });
+    });
+  }
 
   app.route('/api', api);
 
@@ -51,6 +76,15 @@ export function createApp(options: CreateAppOptions): Hono {
   }
 
   return app;
+}
+
+async function readOptionalJsonContent(request: Request): Promise<string | undefined> {
+  if (!request.headers.get('content-type')?.includes('application/json')) {
+    return undefined;
+  }
+
+  const body = await request.json().catch(() => undefined) as { content?: unknown } | undefined;
+  return typeof body?.content === 'string' ? body.content : undefined;
 }
 
 async function proxyUi(webProxyTarget: string, request: Request): Promise<Response> {

--- a/apps/daemon/src/config.test.ts
+++ b/apps/daemon/src/config.test.ts
@@ -42,6 +42,7 @@ describe('daemon config', () => {
       webProxyTarget: 'http://127.0.0.1:5173',
       kb2Home,
       daemonHome: join(kb2Home, 'daemon'),
+      demoDocumentFile: join(kb2Home, 'demo-vault', 'hello-world.md'),
       statusFile: join(kb2Home, 'daemon', 'status.json'),
       startedAt: now.toISOString(),
       pid: 1234

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -12,6 +12,7 @@ export interface DaemonConfig {
   webProxyTarget?: string;
   kb2Home: string;
   daemonHome: string;
+  demoDocumentFile: string;
   statusFile: string;
   startedAt: string;
   pid: number;
@@ -66,6 +67,7 @@ export function createDaemonConfig(options: ResolveConfigOptions = {}): DaemonCo
   const homeDir = options.homeDir ?? homedir();
   const kb2Home = resolveKb2Home(env, homeDir);
   const daemonHome = join(kb2Home, 'daemon');
+  const demoDocumentFile = join(kb2Home, 'demo-vault', 'hello-world.md');
 
   return {
     serviceName: SERVICE_NAME,
@@ -74,6 +76,7 @@ export function createDaemonConfig(options: ResolveConfigOptions = {}): DaemonCo
     webProxyTarget: resolveWebProxyTarget(env),
     kb2Home,
     daemonHome,
+    demoDocumentFile,
     statusFile: join(daemonHome, 'status.json'),
     startedAt: (options.now ?? new Date()).toISOString(),
     pid: options.pid ?? process.pid

--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdtemp, rm } from 'node:fs/promises';
+import { access, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -37,7 +37,40 @@ describe('daemon startup', () => {
 
     await close(blocker);
   });
+
+  it('creates and serves the demo document on startup', async () => {
+    const port = await reservePort();
+    process.env = {
+      ...originalEnv,
+      KB2_HOME: kb2Home,
+      KB2_HOST: '127.0.0.1',
+      KB2_PORT: String(port)
+    };
+
+    const started = await startDaemon();
+    const response = await fetch(`http://127.0.0.1:${port}/api/demo-document`);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: true,
+      document: 'demo-vault/hello-world.md'
+    });
+    expect(typeof body.content).toBe('string');
+    expect(body.content).toContain('Hello KB-2');
+    await expect(readFile(started.config.demoDocumentFile, 'utf8')).resolves.toBe(body.content);
+
+    await started.close();
+  });
 });
+
+async function reservePort(): Promise<number> {
+  const server = createServer();
+  await listen(server);
+  const port = (server.address() as AddressInfo).port;
+  await close(server);
+  return port;
+}
 
 function listen(server: ReturnType<typeof createServer>): Promise<void> {
   return new Promise((resolve, reject) => {

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { serve } from '@hono/node-server';
+import { DEMO_DOCUMENT_YJS_PATH, OneFileDocumentSession, bindYjsWebSocket } from '@kb-2/doc-session';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { WebSocketServer } from 'ws';
 
 import { createApp } from './app.js';
 import { createDaemonConfig, type DaemonConfig } from './config.js';
@@ -14,8 +16,12 @@ export interface StartedDaemon {
 
 export async function startDaemon(): Promise<StartedDaemon> {
   const config = createDaemonConfig();
+  const demoDocumentSession = new OneFileDocumentSession(config.demoDocumentFile);
+  await demoDocumentSession.open();
+
   const app = createApp({
     statusFile: config.statusFile,
+    demoDocumentSession,
     webBuildDir: fileURLToPath(new URL('../../web/build', import.meta.url)),
     webProxyTarget: config.webProxyTarget
   });
@@ -29,6 +35,8 @@ export async function startDaemon(): Promise<StartedDaemon> {
       }
     };
 
+    const activeDocumentConnections = new Set<Promise<void>>();
+    const webSocketServer = new WebSocketServer({ noServer: true });
     const server = serve(
       {
         fetch: app.fetch,
@@ -50,17 +58,11 @@ export async function startDaemon(): Promise<StartedDaemon> {
           resolve({
             config,
             status,
-            close: () =>
-              new Promise((closeResolve, closeReject) => {
-                server.close((error) => {
-                  if (error) {
-                    closeReject(error);
-                    return;
-                  }
-
-                  closeResolve();
-                });
-              })
+            close: async () => {
+              await closeWebSocketServer(webSocketServer, activeDocumentConnections);
+              await closeServer(server);
+              await demoDocumentSession.close();
+            }
           });
         } catch (error) {
           server.close();
@@ -69,12 +71,94 @@ export async function startDaemon(): Promise<StartedDaemon> {
       }
     );
 
+    server.on('upgrade', (request, socket, head) => {
+      const pathname = request.url ? new URL(request.url, `http://${request.headers.host ?? 'localhost'}`).pathname : '';
+      if (pathname !== DEMO_DOCUMENT_YJS_PATH) {
+        socket.destroy();
+        return;
+      }
+
+      webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
+        void (async () => {
+          try {
+            const binding = await bindYjsWebSocket(demoDocumentSession, webSocket);
+            activeDocumentConnections.add(binding.closed);
+            binding.closed.finally(() => {
+              activeDocumentConnections.delete(binding.closed);
+            }).catch(() => undefined);
+          } catch (error) {
+            console.error(error);
+            webSocket.close(1011, 'Document session failed to open');
+          }
+        })();
+      });
+    });
+
     server.once('error', fail);
   });
 }
 
+async function closeWebSocketServer(server: WebSocketServer, activeDocumentConnections: Set<Promise<void>>): Promise<void> {
+  for (const client of server.clients) {
+    client.close(1001, 'Daemon shutting down');
+  }
+
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      Promise.allSettled(activeDocumentConnections).then(() => resolve(), reject);
+    });
+  });
+}
+
+function closeServer(server: ReturnType<typeof serve>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  startDaemon().catch((error: unknown) => {
+  let startedDaemon: StartedDaemon | undefined;
+  let shuttingDown = false;
+
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.once(signal, () => {
+      if (shuttingDown) {
+        return;
+      }
+
+      shuttingDown = true;
+      if (!startedDaemon) {
+        process.exitCode = signal === 'SIGINT' ? 130 : 143;
+        return;
+      }
+
+      startedDaemon.close().then(
+        () => {
+          process.exitCode = signal === 'SIGINT' ? 130 : 143;
+        },
+        (error: unknown) => {
+          console.error(error);
+          process.exitCode = 1;
+        }
+      );
+    });
+  }
+
+  startDaemon().then((daemon) => {
+    startedDaemon = daemon;
+  }).catch((error: unknown) => {
     console.error(error);
     process.exitCode = 1;
   });

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -1,4 +1,5 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { OneFileDocumentSession } from '@kb-2/doc-session';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { join } from 'node:path';
@@ -115,6 +116,50 @@ describe('daemon routing', () => {
     expect(body).toEqual({ ok: false, error: 'Not found' });
 
     await rm(webBuildDir, { force: true, recursive: true });
+  });
+
+  it('reads and resets the one-file demo document through the daemon API', async () => {
+    const config = createDaemonConfig({
+      env: {
+        KB2_HOME: kb2Home
+      }
+    });
+    const documentSession = new OneFileDocumentSession(config.demoDocumentFile, { defaultContent: 'route seed\n' });
+    await documentSession.open();
+
+    const app = createApp({
+      statusFile: config.statusFile,
+      demoDocumentSession: documentSession
+    });
+
+    const readResponse = await app.request('/api/demo-document');
+    const readBody = await readResponse.json();
+
+    expect(readResponse.status).toBe(200);
+    expect(readBody).toEqual({
+      ok: true,
+      document: 'demo-vault/hello-world.md',
+      content: 'route seed\n'
+    });
+
+    const resetResponse = await app.request('/api/demo-document/reset', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ content: 'route reset\n' })
+    });
+    const resetBody = await resetResponse.json();
+
+    expect(resetResponse.status).toBe(200);
+    expect(resetBody).toEqual({
+      ok: true,
+      document: 'demo-vault/hello-world.md',
+      content: 'route reset\n'
+    });
+    await expect(readFile(config.demoDocumentFile, 'utf8')).resolves.toBe('route reset\n');
+
+    await documentSession.close();
   });
 
   it('proxies non-API requests to the configured Vite dev server', async () => {

--- a/apps/daemon/tsconfig.build.json
+++ b/apps/daemon/tsconfig.build.json
@@ -8,7 +8,7 @@
     "sourceMap": true,
     "types": ["node"],
     "paths": {
-      "@kb-2/doc-session": ["packages/doc-session/dist/index.d.ts"]
+      "@kb-2/doc-session": ["./packages/doc-session/dist/index.d.ts"]
     }
   },
   "exclude": ["src/**/*.test.ts"]

--- a/apps/daemon/tsconfig.build.json
+++ b/apps/daemon/tsconfig.build.json
@@ -6,7 +6,10 @@
     "outDir": "dist",
     "rootDir": "src",
     "sourceMap": true,
-    "types": ["node"]
+    "types": ["node"],
+    "paths": {
+      "@kb-2/doc-session": ["packages/doc-session/dist/index.d.ts"]
+    }
   },
   "exclude": ["src/**/*.test.ts"]
 }

--- a/apps/daemon/vitest.config.ts
+++ b/apps/daemon/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@kb-2/doc-session': fileURLToPath(new URL('../../packages/doc-session/src/index.ts', import.meta.url))
+    }
+  },
   test: {
     environment: 'node',
     globals: true

--- a/nx.json
+++ b/nx.json
@@ -8,6 +8,7 @@
   "targetDefaults": {
     "build": {
       "cache": true,
+      "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
     },
     "test": {

--- a/package.json
+++ b/package.json
@@ -12,14 +12,20 @@
     "dev": "node scripts/dev.mjs",
     "dev:daemon": "pnpm --filter @kb-2/daemon dev",
     "dev:web": "pnpm --filter @kb-2/web dev",
+    "smoke:yjs": "node scripts/yjs-smoke.mjs",
     "test": "nx run-many -t test",
     "typecheck": "nx run-many -t typecheck"
   },
   "devDependencies": {
+    "@types/ws": "8.18.1",
     "@types/node": "25.9.2",
+    "lib0": "0.2.117",
     "nx": "22.7.5",
     "tsx": "4.22.4",
     "typescript": "6.0.3",
-    "vitest": "4.1.8"
+    "vitest": "4.1.8",
+    "ws": "8.21.0",
+    "y-protocols": "1.0.7",
+    "yjs": "13.6.31"
   }
 }

--- a/packages/doc-session/package.json
+++ b/packages/doc-session/package.json
@@ -1,27 +1,32 @@
 {
-  "name": "@kb-2/daemon",
+  "name": "@kb-2/doc-session",
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "bin": {
-    "kb2d": "./dist/main.js"
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
     "dist"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "dev": "tsx src/main.ts",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@kb-2/doc-session": "workspace:*",
-    "@hono/node-server": "2.0.4",
-    "hono": "4.12.25",
-    "ws": "8.21.0"
+    "lib0": "0.2.117",
+    "y-protocols": "1.0.7",
+    "yjs": "13.6.31"
   },
   "devDependencies": {
+    "vitest": "4.1.8",
+    "ws": "8.21.0",
     "@types/ws": "8.18.1"
   }
 }

--- a/packages/doc-session/project.json
+++ b/packages/doc-session/project.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "doc-session",
+  "sourceRoot": "packages/doc-session/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/doc-session build"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/doc-session test"
+      }
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/doc-session typecheck"
+      }
+    }
+  }
+}

--- a/packages/doc-session/src/index.ts
+++ b/packages/doc-session/src/index.ts
@@ -1,0 +1,11 @@
+export {
+  DEFAULT_DEMO_DOCUMENT_CONTENT,
+  OneFileDocumentSession,
+  type DocumentSessionWarning,
+  type OneFileDocumentSessionOptions
+} from './session.js';
+export {
+  DEMO_DOCUMENT_YJS_PATH,
+  bindYjsWebSocket,
+  type YjsWebSocketLike
+} from './websocket.js';

--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -1,0 +1,92 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import * as Y from 'yjs';
+
+import { OneFileDocumentSession, type DocumentSessionWarning } from './session.js';
+
+describe('OneFileDocumentSession', () => {
+  let kb2Home: string;
+  let filePath: string;
+
+  beforeEach(async () => {
+    kb2Home = await mkdtemp(join(tmpdir(), 'kb2-doc-session-'));
+    filePath = join(kb2Home, 'demo-vault', 'hello-world.md');
+  });
+
+  afterEach(async () => {
+    await rm(kb2Home, { force: true, recursive: true });
+  });
+
+  it('creates the configured file when it is missing', async () => {
+    const session = new OneFileDocumentSession(filePath, { defaultContent: 'seed\n' });
+
+    await session.open();
+
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('seed\n');
+    await expect(session.getContent()).resolves.toBe('seed\n');
+    await session.close();
+  });
+
+  it('cold boots the Yjs document from the materialized Markdown file', async () => {
+    await writeFileWithParents(filePath, 'from disk\n');
+    const session = new OneFileDocumentSession(filePath);
+
+    await session.open();
+
+    await expect(session.getContent()).resolves.toBe('from disk\n');
+    await session.close();
+  });
+
+  it('materializes Yjs edits to the filesystem', async () => {
+    const session = new OneFileDocumentSession(filePath, { defaultContent: '' });
+    await session.open();
+
+    const clientDoc = new Y.Doc();
+    clientDoc.getText('markdown').insert(0, 'written through Yjs\n');
+    Y.applyUpdate(session.ydoc, Y.encodeStateAsUpdate(clientDoc), clientDoc);
+    await session.flush();
+
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('written through Yjs\n');
+    await session.close();
+  });
+
+  it('rebuilds a fresh session from the last materialized content', async () => {
+    const firstSession = new OneFileDocumentSession(filePath, { defaultContent: '' });
+    await firstSession.open();
+    await firstSession.reset('after restart\n');
+    await firstSession.close();
+
+    const secondSession = new OneFileDocumentSession(filePath);
+    await secondSession.open();
+
+    await expect(secondSession.getContent()).resolves.toBe('after restart\n');
+    await secondSession.close();
+  });
+
+  it('warns on direct filesystem changes and preserves the active session state', async () => {
+    const warnings: DocumentSessionWarning[] = [];
+    const session = new OneFileDocumentSession(filePath, {
+      defaultContent: 'active\n',
+      warn: (warning) => warnings.push(warning)
+    });
+    await session.open();
+
+    await writeFile(filePath, 'external stale edit\n', 'utf8');
+    await session.reset('active wins\n');
+
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('active wins\n');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      type: 'external-change-detected',
+      filePath
+    });
+    await session.close();
+  });
+});
+
+async function writeFileWithParents(pathname: string, content: string): Promise<void> {
+  await mkdir(dirname(pathname), { recursive: true });
+  await writeFile(pathname, content, 'utf8');
+}

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -1,0 +1,191 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+import * as Y from 'yjs';
+
+export const DEFAULT_DEMO_DOCUMENT_CONTENT = [
+  '# Hello KB-2',
+  '',
+  'This Markdown file is served by the local KB-2 daemon.',
+  ''
+].join('\n');
+
+const Y_TEXT_NAME = 'markdown';
+
+export interface DocumentSessionWarning {
+  type: 'external-change-detected';
+  filePath: string;
+  expectedHash: string;
+  actualHash: string | undefined;
+}
+
+export interface OneFileDocumentSessionOptions {
+  defaultContent?: string;
+  warn?: (warning: DocumentSessionWarning) => void;
+}
+
+export class OneFileDocumentSession {
+  readonly filePath: string;
+
+  private readonly defaultContent: string;
+  private readonly warn: (warning: DocumentSessionWarning) => void;
+  private readonly doc = new Y.Doc();
+  private readonly text = this.doc.getText(Y_TEXT_NAME);
+  private opened = false;
+  private openPromise: Promise<void> | undefined;
+  private lastWrittenHash: string | undefined;
+  private persistRequested = false;
+  private persistPromise: Promise<void> | undefined;
+
+  constructor(filePath: string, options: OneFileDocumentSessionOptions = {}) {
+    this.filePath = filePath;
+    this.defaultContent = options.defaultContent ?? DEFAULT_DEMO_DOCUMENT_CONTENT;
+    this.warn = options.warn ?? ((warning) => {
+      console.warn(`KB-2 external document change detected at ${warning.filePath}; preserving active Yjs session state.`);
+    });
+  }
+
+  get ydoc(): Y.Doc {
+    return this.doc;
+  }
+
+  async open(): Promise<void> {
+    if (this.opened) {
+      return;
+    }
+
+    if (!this.openPromise) {
+      this.openPromise = this.loadFromFile().finally(() => {
+        this.openPromise = undefined;
+      });
+    }
+
+    await this.openPromise;
+  }
+
+  private async loadFromFile(): Promise<void> {
+    const content = await this.readOrCreateFile();
+    this.text.insert(0, content);
+    this.lastWrittenHash = hashContent(content);
+    this.doc.on('update', this.handleDocumentUpdate);
+    this.opened = true;
+  }
+
+  async getContent(): Promise<string> {
+    await this.open();
+    return this.currentContent();
+  }
+
+  async reset(content = this.defaultContent): Promise<string> {
+    await this.open();
+
+    this.doc.transact(() => {
+      this.text.delete(0, this.text.length);
+      this.text.insert(0, content);
+    }, this);
+
+    await this.flush();
+    return this.currentContent();
+  }
+
+  async flush(): Promise<void> {
+    if (this.persistPromise) {
+      await this.persistPromise;
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.flush();
+    this.doc.off('update', this.handleDocumentUpdate);
+  }
+
+  private readonly handleDocumentUpdate = (): void => {
+    void this.requestPersist();
+  };
+
+  private requestPersist(): Promise<void> {
+    this.persistRequested = true;
+
+    if (!this.persistPromise) {
+      this.persistPromise = this.persistLoop().finally(() => {
+        this.persistPromise = undefined;
+      });
+    }
+
+    return this.persistPromise;
+  }
+
+  private async persistLoop(): Promise<void> {
+    while (this.persistRequested) {
+      this.persistRequested = false;
+      await this.materialize();
+    }
+  }
+
+  private async materialize(): Promise<void> {
+    const content = this.currentContent();
+    const diskContent = await readOptionalFile(this.filePath);
+    const diskHash = diskContent === undefined ? undefined : hashContent(diskContent);
+
+    if (this.lastWrittenHash !== undefined && diskHash !== this.lastWrittenHash) {
+      this.warn({
+        type: 'external-change-detected',
+        filePath: this.filePath,
+        expectedHash: this.lastWrittenHash,
+        actualHash: diskHash
+      });
+    }
+
+    await atomicWriteFile(this.filePath, content);
+    this.lastWrittenHash = hashContent(content);
+  }
+
+  private async readOrCreateFile(): Promise<string> {
+    const existing = await readOptionalFile(this.filePath);
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    await atomicWriteFile(this.filePath, this.defaultContent);
+    return this.defaultContent;
+  }
+
+  private currentContent(): string {
+    return this.text.toString();
+  }
+}
+
+async function atomicWriteFile(filePath: string, content: string): Promise<void> {
+  const directory = dirname(filePath);
+  await mkdir(directory, { recursive: true });
+
+  const temporaryPath = join(directory, `.${process.pid}.${randomUUID()}.tmp`);
+  try {
+    await writeFile(temporaryPath, content, 'utf8');
+    await rename(temporaryPath, filePath);
+  } catch (error) {
+    await rm(temporaryPath, { force: true });
+    throw error;
+  }
+}
+
+async function readOptionalFile(filePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(filePath, 'utf8');
+  } catch (error) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+function hashContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -101,7 +101,9 @@ export class OneFileDocumentSession {
   }
 
   private readonly handleDocumentUpdate = (): void => {
-    void this.requestPersist();
+    this.requestPersist().catch((error: unknown) => {
+      console.warn(`KB-2 failed to persist document update for ${this.filePath}; keeping active Yjs session open.`, error);
+    });
   };
 
   private requestPersist(): Promise<void> {

--- a/packages/doc-session/src/websocket.test.ts
+++ b/packages/doc-session/src/websocket.test.ts
@@ -1,0 +1,251 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import * as decoding from 'lib0/decoding';
+import * as encoding from 'lib0/encoding';
+import { WebSocket, WebSocketServer } from 'ws';
+import * as syncProtocol from 'y-protocols/sync';
+import * as Y from 'yjs';
+
+import { OneFileDocumentSession } from './session.js';
+import { DEMO_DOCUMENT_YJS_PATH, bindYjsWebSocket } from './websocket.js';
+
+const messageSync = 0;
+
+describe('Yjs WebSocket session', () => {
+  let kb2Home: string;
+
+  beforeEach(async () => {
+    kb2Home = await mkdtemp(join(tmpdir(), 'kb2-yjs-ws-'));
+  });
+
+  afterEach(async () => {
+    await rm(kb2Home, { force: true, recursive: true });
+  });
+
+  it('syncs two clients and persists their merged edits', async () => {
+    const filePath = join(kb2Home, 'demo-vault', 'hello-world.md');
+    const session = new OneFileDocumentSession(filePath, { defaultContent: '' });
+    await session.open();
+
+    const server = createServer();
+    const webSocketServer = new WebSocketServer({ noServer: true });
+    server.on('upgrade', (request, socket, head) => {
+      if (request.url !== DEMO_DOCUMENT_YJS_PATH) {
+        socket.destroy();
+        return;
+      }
+
+      webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
+        void bindYjsWebSocket(session, webSocket);
+      });
+    });
+    await listen(server);
+
+    const port = (server.address() as AddressInfo).port;
+    const clientA = await connectYjsClient(`ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`);
+    const clientB = await connectYjsClient(`ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`);
+
+    clientA.text.insert(0, 'A');
+    clientB.text.insert(0, 'B');
+
+    await waitForSharedContent([clientA, clientB], (content) => content.includes('A') && content.includes('B') && content.length === 2);
+    await session.flush();
+
+    const diskContent = await readFile(filePath, 'utf8');
+    expect(diskContent).toHaveLength(2);
+    expect(diskContent).toContain('A');
+    expect(diskContent).toContain('B');
+
+    clientA.close();
+    clientB.close();
+    await closeWebSocketServer(webSocketServer);
+    await closeServer(server);
+    await session.close();
+  });
+
+  it('closes malformed sync frames without crashing the session', async () => {
+    const filePath = join(kb2Home, 'demo-vault', 'hello-world.md');
+    const session = new OneFileDocumentSession(filePath, { defaultContent: '' });
+    await session.open();
+
+    const server = createServer();
+    const webSocketServer = new WebSocketServer({ noServer: true });
+    server.on('upgrade', (request, socket, head) => {
+      if (request.url !== DEMO_DOCUMENT_YJS_PATH) {
+        socket.destroy();
+        return;
+      }
+
+      webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
+        void bindYjsWebSocket(session, webSocket);
+      });
+    });
+    await listen(server);
+
+    const port = (server.address() as AddressInfo).port;
+    const socket = new WebSocket(`ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`);
+    await new Promise<void>((resolve, reject) => {
+      socket.once('open', () => resolve());
+      socket.once('error', reject);
+    });
+
+    const closeCode = new Promise<number>((resolve) => {
+      socket.once('close', (code) => resolve(code));
+    });
+    socket.send(new Uint8Array([255]));
+
+    await expect(closeCode).resolves.toBe(1003);
+    await expect(session.getContent()).resolves.toBe('');
+
+    await closeWebSocketServer(webSocketServer);
+    await closeServer(server);
+    await session.close();
+  });
+});
+
+interface YjsClient {
+  doc: Y.Doc;
+  text: Y.Text;
+  close: () => void;
+}
+
+async function connectYjsClient(url: string): Promise<YjsClient> {
+  const doc = new Y.Doc();
+  const text = doc.getText('markdown');
+  const socket = new WebSocket(url);
+  socket.binaryType = 'arraybuffer';
+
+  doc.on('update', (update, origin) => {
+    if (origin === socket || socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    sendSync(socket, (encoder) => {
+      syncProtocol.writeUpdate(encoder, update);
+    });
+  });
+
+  socket.on('message', (data) => {
+    const message = toUint8Array(data);
+    const decoder = decoding.createDecoder(message);
+    const encoder = encoding.createEncoder();
+    const messageType = decoding.readVarUint(decoder);
+
+    if (messageType !== messageSync) {
+      return;
+    }
+
+    encoding.writeVarUint(encoder, messageSync);
+    syncProtocol.readSyncMessage(decoder, encoder, doc, socket);
+    if (encoding.length(encoder) > 1) {
+      socket.send(encoding.toUint8Array(encoder));
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    socket.once('open', () => resolve());
+    socket.once('error', reject);
+  });
+
+  sendSync(socket, (encoder) => {
+    syncProtocol.writeSyncStep1(encoder, doc);
+  });
+
+  return {
+    doc,
+    text,
+    close: () => socket.close()
+  };
+}
+
+function sendSync(socket: WebSocket, write: (encoder: encoding.Encoder) => void): void {
+  const encoder = encoding.createEncoder();
+  encoding.writeVarUint(encoder, messageSync);
+  write(encoder);
+  socket.send(encoding.toUint8Array(encoder));
+}
+
+function toUint8Array(data: WebSocket.RawData): Uint8Array {
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
+  }
+
+  if (data instanceof Uint8Array) {
+    return data;
+  }
+
+  return Buffer.concat(data);
+}
+
+async function waitForSharedContent(
+  clients: YjsClient[],
+  predicate: (content: string) => boolean
+): Promise<void> {
+  if (clients.every((client) => predicate(client.text.toString()))) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for shared Yjs content: ${clients.map((client) => client.text.toString()).join(', ')}`));
+    }, 2000);
+
+    const onUpdate = () => {
+      if (!clients.every((client) => predicate(client.text.toString()))) {
+        return;
+      }
+
+      cleanup();
+      resolve();
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      for (const client of clients) {
+        client.doc.off('update', onUpdate);
+      }
+    };
+
+    for (const client of clients) {
+      client.doc.on('update', onUpdate);
+    }
+  });
+}
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function closeWebSocketServer(server: WebSocketServer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}

--- a/packages/doc-session/src/websocket.ts
+++ b/packages/doc-session/src/websocket.ts
@@ -1,0 +1,124 @@
+import * as decoding from 'lib0/decoding';
+import * as encoding from 'lib0/encoding';
+import * as syncProtocol from 'y-protocols/sync';
+
+import type { OneFileDocumentSession } from './session.js';
+
+export const DEMO_DOCUMENT_YJS_PATH = '/api/demo-document/yjs';
+
+const messageSync = 0;
+const socketOpen = 1;
+
+export interface YjsWebSocketLike {
+  readyState: number;
+  send(data: Uint8Array, callback?: (error?: Error) => void): void;
+  close(code?: number, reason?: string): void;
+  on(event: 'message', listener: (data: unknown) => void): this;
+  on(event: 'close', listener: () => void): this;
+  on(event: 'error', listener: () => void): this;
+}
+
+export interface BoundYjsWebSocket {
+  closed: Promise<void>;
+}
+
+export async function bindYjsWebSocket(
+  session: OneFileDocumentSession,
+  socket: YjsWebSocketLike
+): Promise<BoundYjsWebSocket> {
+  await session.open();
+  let cleanupStarted = false;
+  let resolveClosed!: () => void;
+  let rejectClosed!: (error: unknown) => void;
+  const closed = new Promise<void>((resolve, reject) => {
+    resolveClosed = resolve;
+    rejectClosed = reject;
+  });
+
+  const updateHandler = (update: Uint8Array, origin: unknown) => {
+    if (origin === socket) {
+      return;
+    }
+
+    sendSync(socket, (encoder) => {
+      syncProtocol.writeUpdate(encoder, update);
+    });
+  };
+
+  const cleanup = () => {
+    if (cleanupStarted) {
+      return;
+    }
+
+    cleanupStarted = true;
+    session.ydoc.off('update', updateHandler);
+    session.flush().then(resolveClosed, rejectClosed);
+  };
+
+  socket.on('message', (data) => {
+    try {
+      const message = toUint8Array(data);
+      if (!message) {
+        return;
+      }
+
+      const decoder = decoding.createDecoder(message);
+      const encoder = encoding.createEncoder();
+      const messageType = decoding.readVarUint(decoder);
+
+      if (messageType !== messageSync) {
+        return;
+      }
+
+      encoding.writeVarUint(encoder, messageSync);
+      syncProtocol.readSyncMessage(decoder, encoder, session.ydoc, socket);
+
+      if (encoding.length(encoder) > 1) {
+        sendEncoded(socket, encoder);
+      }
+    } catch {
+      socket.close(1003, 'Invalid Yjs sync message');
+    }
+  });
+
+  socket.on('close', cleanup);
+  socket.on('error', cleanup);
+  session.ydoc.on('update', updateHandler);
+
+  sendSync(socket, (encoder) => {
+    syncProtocol.writeSyncStep1(encoder, session.ydoc);
+  });
+
+  return { closed };
+}
+
+function sendSync(socket: YjsWebSocketLike, write: (encoder: encoding.Encoder) => void): void {
+  const encoder = encoding.createEncoder();
+  encoding.writeVarUint(encoder, messageSync);
+  write(encoder);
+  sendEncoded(socket, encoder);
+}
+
+function sendEncoded(socket: YjsWebSocketLike, encoder: encoding.Encoder): void {
+  if (socket.readyState !== socketOpen) {
+    return;
+  }
+
+  socket.send(encoding.toUint8Array(encoder));
+}
+
+function toUint8Array(data: unknown): Uint8Array | undefined {
+  if (data instanceof Uint8Array) {
+    return data;
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
+  }
+
+  if (Array.isArray(data)) {
+    return Buffer.concat(data);
+  }
+
+  return undefined;
+}

--- a/packages/doc-session/tsconfig.build.json
+++ b/packages/doc-session/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "dist/tsconfig.build.tsbuildinfo",
+    "types": ["node"]
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/doc-session/tsconfig.json
+++ b/packages/doc-session/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/doc-session/vitest.config.ts
+++ b/packages/doc-session/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,12 @@ importers:
       '@types/node':
         specifier: 25.9.2
         version: 25.9.2
+      '@types/ws':
+        specifier: 8.18.1
+        version: 8.18.1
+      lib0:
+        specifier: 0.2.117
+        version: 0.2.117
       nx:
         specifier: 22.7.5
         version: 22.7.5
@@ -53,15 +59,34 @@ importers:
       vitest:
         specifier: 4.1.8
         version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      ws:
+        specifier: 8.21.0
+        version: 8.21.0
+      y-protocols:
+        specifier: 1.0.7
+        version: 1.0.7(yjs@13.6.31)
+      yjs:
+        specifier: 13.6.31
+        version: 13.6.31
 
   apps/daemon:
     dependencies:
       '@hono/node-server':
         specifier: 2.0.4
         version: 2.0.4(hono@4.12.25)
+      '@kb-2/doc-session':
+        specifier: workspace:*
+        version: link:../../packages/doc-session
       hono:
         specifier: 4.12.25
         version: 4.12.25
+      ws:
+        specifier: 8.21.0
+        version: 8.21.0
+    devDependencies:
+      '@types/ws':
+        specifier: 8.18.1
+        version: 8.18.1
 
   apps/web:
     dependencies:
@@ -93,6 +118,28 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/doc-session:
+    dependencies:
+      lib0:
+        specifier: 0.2.117
+        version: 0.2.117
+      y-protocols:
+        specifier: 1.0.7
+        version: 1.0.7(yjs@13.6.31)
+      yjs:
+        specifier: 13.6.31
+        version: 13.6.31
+    devDependencies:
+      '@types/ws':
+        specifier: 8.18.1
+        version: 8.18.1
+      vitest:
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      ws:
+        specifier: 8.21.0
+        version: 8.21.0
 
 packages:
 
@@ -919,6 +966,9 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
@@ -1286,6 +1336,9 @@ packages:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
 
+  isomorphic.js@0.2.5:
+    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -1301,6 +1354,11 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  lib0@0.2.117:
+    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -1865,6 +1923,24 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  y-protocols@1.0.7:
+    resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.0.0
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -1881,6 +1957,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yjs@13.6.31:
+    resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
@@ -2411,6 +2491,10 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.2
+
   '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2780,6 +2864,8 @@ snapshots:
     dependencies:
       is-docker: 2.2.1
 
+  isomorphic.js@0.2.5: {}
+
   jiti@2.7.0: {}
 
   json5@2.2.3: {}
@@ -2787,6 +2873,10 @@ snapshots:
   jsonc-parser@3.2.0: {}
 
   kleur@4.1.5: {}
+
+  lib0@0.2.117:
+    dependencies:
+      isomorphic.js: 0.2.5
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -3399,6 +3489,13 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  ws@8.21.0: {}
+
+  y-protocols@1.0.7(yjs@13.6.31):
+    dependencies:
+      lib0: 0.2.117
+      yjs: 13.6.31
+
   y18n@5.0.8: {}
 
   yaml@2.9.0: {}
@@ -3414,5 +3511,9 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yjs@13.6.31:
+    dependencies:
+      lib0: 0.2.117
 
   zimmerframe@1.1.4: {}

--- a/scripts/yjs-smoke.mjs
+++ b/scripts/yjs-smoke.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+import * as decoding from 'lib0/decoding';
+import * as encoding from 'lib0/encoding';
+import { WebSocket } from 'ws';
+import * as syncProtocol from 'y-protocols/sync';
+import * as Y from 'yjs';
+
+const messageSync = 0;
+const port = process.env.KB2_PORT || '8787';
+const host = process.env.KB2_HOST || '127.0.0.1';
+const url = process.env.KB2_YJS_URL || `ws://${host}:${port}/api/demo-document/yjs`;
+
+const clientA = await connectYjsClient(url);
+const clientB = await connectYjsClient(url);
+
+await waitForSharedContent([clientA, clientB], (content) => content.includes('Hello KB-2'));
+
+const stamp = Date.now();
+clientA.text.insert(clientA.text.length, `- smoke client A ${stamp}\n`);
+clientB.text.insert(clientB.text.length, `- smoke client B ${stamp}\n`);
+
+await waitForSharedContent([clientA, clientB], (content) => content.includes('smoke client A') && content.includes('smoke client B'));
+
+console.log(`Connected two Yjs clients to ${url}`);
+console.log(clientA.text.toString());
+
+clientA.close();
+clientB.close();
+
+function connectYjsClient(targetUrl) {
+  const doc = new Y.Doc();
+  const text = doc.getText('markdown');
+  const socket = new WebSocket(targetUrl);
+  socket.binaryType = 'arraybuffer';
+
+  doc.on('update', (update, origin) => {
+    if (origin === socket || socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    sendSync(socket, (encoder) => {
+      syncProtocol.writeUpdate(encoder, update);
+    });
+  });
+
+  socket.on('message', (data) => {
+    const message = toUint8Array(data);
+    const decoder = decoding.createDecoder(message);
+    const encoder = encoding.createEncoder();
+    const messageType = decoding.readVarUint(decoder);
+
+    if (messageType !== messageSync) {
+      return;
+    }
+
+    encoding.writeVarUint(encoder, messageSync);
+    syncProtocol.readSyncMessage(decoder, encoder, doc, socket);
+    if (encoding.length(encoder) > 1) {
+      socket.send(encoding.toUint8Array(encoder));
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    socket.once('open', () => {
+      sendSync(socket, (encoder) => {
+        syncProtocol.writeSyncStep1(encoder, doc);
+      });
+
+      resolve({
+        doc,
+        text,
+        close: () => socket.close()
+      });
+    });
+    socket.once('error', reject);
+  });
+}
+
+function sendSync(socket, write) {
+  const encoder = encoding.createEncoder();
+  encoding.writeVarUint(encoder, messageSync);
+  write(encoder);
+  socket.send(encoding.toUint8Array(encoder));
+}
+
+function toUint8Array(data) {
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
+  }
+
+  if (data instanceof Uint8Array) {
+    return data;
+  }
+
+  return Buffer.concat(data);
+}
+
+async function waitForSharedContent(clients, predicate) {
+  if (clients.every((client) => predicate(client.text.toString()))) {
+    return;
+  }
+
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for shared Yjs content: ${clients.map((client) => client.text.toString()).join(', ')}`));
+    }, 5000);
+
+    const onUpdate = () => {
+      if (!clients.every((client) => predicate(client.text.toString()))) {
+        return;
+      }
+
+      cleanup();
+      resolve();
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      for (const client of clients) {
+        client.doc.off('update', onUpdate);
+      }
+    };
+
+    for (const client of clients) {
+      client.doc.on('update', onUpdate);
+    }
+  });
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,10 +3,8 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
     "paths": {
-      "@kb-2/doc-session": ["packages/doc-session/src/index.ts"]
+      "@kb-2/doc-session": ["./packages/doc-session/src/index.ts"]
     },
     "strict": true,
     "esModuleInterop": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,11 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
+    "paths": {
+      "@kb-2/doc-session": ["packages/doc-session/src/index.ts"]
+    },
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## What changed

- Added `@kb-2/doc-session` as the one-file Yjs/Y.Text session package for `$KB2_HOME/demo-vault/hello-world.md`.
- Added serial immediate persistence with atomic temp-file + rename writes, trailing coalescing, and a content-hash guard that warns and preserves active session state on external disk edits.
- Added daemon API/WebSocket wiring: `GET /api/demo-document`, `POST /api/demo-document/reset`, and `WS /api/demo-document/yjs` using the standard `y-protocols` sync protocol.
- Added `scripts/yjs-smoke.mjs` for a checked-in two-client smoke flow.
- Added deterministic Nx build ordering so `daemon:build` depends on `doc-session:build` when consuming package `dist` declarations.
- Added persistence rejection handling so failed background materialization logs a warning and keeps the active Yjs session alive.

## Verification

### pnpm check

Ran `pnpm check`.

Actual result:

```text
$ pnpm typecheck && pnpm test && pnpm build
NX Successfully ran target typecheck for 3 projects
NX Successfully ran target test for 3 projects
doc-session: 2 test files passed, 7 tests passed
daemon: 4 test files passed, 17 tests passed
web: No test files found, exiting with code 0
NX Successfully ran target build for 3 projects
```

### Build-order repro from review

Ran `rm -rf packages/doc-session/dist && nx run daemon:build --skip-nx-cache`.

Actual result:

```text
NX Running target build for project daemon and 1 task it depends on:
> nx run doc-session:build
$ tsc -p tsconfig.build.json
> nx run daemon:build
$ tsc -p tsconfig.build.json
NX Successfully ran target build for project daemon and 1 task it depends on
```

### Manual verification

Used temp state only: `KB2_HOME=/tmp/kb2-yjs-smoke.xiuBji`, `KB2_PORT=8787`.

Initial API read:

```text
curl -s http://localhost:8787/api/demo-document
{"ok":true,"document":"demo-vault/hello-world.md","content":"# Hello KB-2\n\nThis Markdown file is served by the local KB-2 daemon.\n"}
```

Initial file:

```text
cat /tmp/kb2-yjs-smoke.xiuBji/demo-vault/hello-world.md
# Hello KB-2

This Markdown file is served by the local KB-2 daemon.
```

Two-client smoke:

```text
KB2_PORT=8787 pnpm smoke:yjs
Connected two Yjs clients to ws://127.0.0.1:8787/api/demo-document/yjs
# Hello KB-2

This Markdown file is served by the local KB-2 daemon.
- smoke client A 1781129846193
- smoke client B 1781129846193
```

Persisted file/API after smoke and after daemon restart both showed:

```text
# Hello KB-2

This Markdown file is served by the local KB-2 daemon.
- smoke client A 1781129846193
- smoke client B 1781129846193
```

The temp verification homes were removed after verification.