### PR TITLE
Port KB-1 editor to Yjs session

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,17 +10,25 @@
     "typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
+    "@fontsource-variable/geist": "^5.2.8",
+    "@fontsource/source-serif-4": "5.2.9",
+    "@kb-2/editor": "workspace:*",
     "@kb-2/ui": "workspace:*",
-    "svelte": "catalog:"
+    "lib0": "0.2.117",
+    "svelte": "catalog:",
+    "y-protocols": "1.0.7",
+    "yjs": "13.6.31"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "catalog:",
     "@sveltejs/kit": "catalog:",
     "@sveltejs/vite-plugin-svelte": "catalog:",
     "@tailwindcss/vite": "catalog:",
+    "@types/ws": "8.18.1",
     "svelte-check": "catalog:",
     "tailwindcss": "catalog:",
     "vite": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "ws": "8.21.0"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "yjs": "13.6.31"
   },
   "devDependencies": {
+    "@kb-2/doc-session": "workspace:*",
     "@sveltejs/adapter-static": "catalog:",
     "@sveltejs/kit": "catalog:",
     "@sveltejs/vite-plugin-svelte": "catalog:",

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,1 +1,6 @@
+@import '@fontsource/source-serif-4/400.css';
+@import '@fontsource/source-serif-4/600.css';
+@import '@fontsource/source-serif-4/400-italic.css';
+@import '@fontsource/source-serif-4/600-italic.css';
+@import '@fontsource-variable/geist/wght.css';
 @import '@kb-2/ui/styles.css';

--- a/apps/web/src/lib/yjs/demo-document-provider.test.ts
+++ b/apps/web/src/lib/yjs/demo-document-provider.test.ts
@@ -1,0 +1,231 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import * as decoding from 'lib0/decoding';
+import * as encoding from 'lib0/encoding';
+import { WebSocket, WebSocketServer } from 'ws';
+import * as syncProtocol from 'y-protocols/sync';
+import * as Y from 'yjs';
+import { afterEach, beforeEach, describe, it } from 'vitest';
+
+import { OneFileDocumentSession } from '../../../../../packages/doc-session/src/session';
+import { bindYjsWebSocket } from '../../../../../packages/doc-session/src/websocket';
+import {
+  createDemoDocumentProvider,
+  DEMO_DOCUMENT_TEXT_NAME,
+  DEMO_DOCUMENT_YJS_PATH,
+} from './demo-document-provider';
+
+const messageSync = 0;
+
+describe('demo document provider', () => {
+  let kb2Home: string;
+  let originalEnv: NodeJS.ProcessEnv;
+  let server: Server | undefined;
+  let webSocketServer: WebSocketServer | undefined;
+  let session: OneFileDocumentSession | undefined;
+
+  beforeEach(async () => {
+    originalEnv = { ...process.env };
+    kb2Home = await mkdtemp(join(tmpdir(), 'kb2-web-provider-'));
+    (globalThis as { WebSocket?: unknown }).WebSocket = WebSocket;
+  });
+
+  afterEach(async () => {
+    if (webSocketServer) {
+      await closeWebSocketServer(webSocketServer);
+      webSocketServer = undefined;
+    }
+    if (server) {
+      await closeServer(server);
+      server = undefined;
+    }
+    if (session) {
+      await session.close();
+      session = undefined;
+    }
+    process.env = originalEnv;
+    await rm(kb2Home, { recursive: true, force: true });
+    delete (globalThis as { WebSocket?: unknown }).WebSocket;
+  });
+
+  it('converges with a raw y-protocols client through the daemon and persists to disk', async () => {
+    const filePath = join(kb2Home, 'demo-vault', 'hello-world.md');
+    session = new OneFileDocumentSession(filePath);
+    await session.open();
+
+    server = createServer();
+    webSocketServer = new WebSocketServer({ noServer: true });
+    server.on('upgrade', (request, socket, head) => {
+      if (request.url !== DEMO_DOCUMENT_YJS_PATH) {
+        socket.destroy();
+        return;
+      }
+
+      webSocketServer!.handleUpgrade(request, socket, head, (webSocket) => {
+        void bindYjsWebSocket(session!, webSocket);
+      });
+    });
+    await listen(server);
+    const port = (server.address() as AddressInfo).port;
+
+    const url = `ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`;
+    const provider = createDemoDocumentProvider({ url });
+    const raw = await connectRawYjsClient(url);
+
+    await waitForContent(
+      [provider.text, raw.text],
+      (content) => content.includes('Hello KB-2'),
+    );
+
+    provider.text.insert(provider.text.length, '\nprovider edit');
+    raw.text.insert(raw.text.length, '\nraw client edit');
+
+    await waitForContent(
+      [provider.text, raw.text],
+      (content) => content.includes('provider edit') && content.includes('raw client edit'),
+    );
+
+    await waitForDiskContent(
+      filePath,
+      (content) => content.includes('provider edit') && content.includes('raw client edit'),
+    );
+
+    raw.close();
+    provider.destroy();
+  });
+});
+
+interface RawYjsClient {
+  doc: Y.Doc;
+  text: Y.Text;
+  close: () => void;
+}
+
+async function connectRawYjsClient(url: string): Promise<RawYjsClient> {
+  const doc = new Y.Doc();
+  const text = doc.getText(DEMO_DOCUMENT_TEXT_NAME);
+  const socket = new WebSocket(url);
+  socket.binaryType = 'arraybuffer';
+
+  doc.on('update', (update, origin) => {
+    if (origin === socket || socket.readyState !== WebSocket.OPEN) return;
+    sendSync(socket, (encoder) => {
+      syncProtocol.writeUpdate(encoder, update);
+    });
+  });
+
+  socket.on('message', (data) => {
+    const message = toUint8Array(data);
+    const decoder = decoding.createDecoder(message);
+    const encoder = encoding.createEncoder();
+    const messageType = decoding.readVarUint(decoder);
+    if (messageType !== messageSync) return;
+
+    encoding.writeVarUint(encoder, messageSync);
+    syncProtocol.readSyncMessage(decoder, encoder, doc, socket);
+    if (encoding.length(encoder) > 1) {
+      socket.send(encoding.toUint8Array(encoder));
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    socket.once('open', () => resolve());
+    socket.once('error', reject);
+  });
+
+  sendSync(socket, (encoder) => {
+    syncProtocol.writeSyncStep1(encoder, doc);
+  });
+
+  return {
+    doc,
+    text,
+    close: () => {
+      socket.close();
+      doc.destroy();
+    },
+  };
+}
+
+function sendSync(socket: WebSocket, write: (encoder: encoding.Encoder) => void): void {
+  const encoder = encoding.createEncoder();
+  encoding.writeVarUint(encoder, messageSync);
+  write(encoder);
+  socket.send(encoding.toUint8Array(encoder));
+}
+
+function toUint8Array(data: WebSocket.RawData): Uint8Array {
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  if (data instanceof Uint8Array) return data;
+  return Buffer.concat(data);
+}
+
+async function waitForContent(
+  texts: Y.Text[],
+  predicate: (content: string) => boolean,
+): Promise<void> {
+  await waitUntil(() => texts.every((text) => predicate(text.toString())), () =>
+    `Timed out waiting for Yjs content: ${texts.map((text) => text.toString()).join(' | ')}`,
+  );
+}
+
+async function waitForDiskContent(
+  filePath: string,
+  predicate: (content: string) => boolean,
+): Promise<void> {
+  await waitUntil(async () => {
+    const content = await readFile(filePath, 'utf8');
+    return predicate(content);
+  }, () => `Timed out waiting for disk content at ${filePath}`);
+}
+
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  errorMessage: () => string,
+): Promise<void> {
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(errorMessage());
+}
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function closeWebSocketServer(server: WebSocketServer): Promise<void> {
+  for (const client of server.clients) {
+    client.close();
+  }
+
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/apps/web/src/lib/yjs/demo-document-provider.test.ts
+++ b/apps/web/src/lib/yjs/demo-document-provider.test.ts
@@ -11,8 +11,7 @@ import * as syncProtocol from 'y-protocols/sync';
 import * as Y from 'yjs';
 import { afterEach, beforeEach, describe, it } from 'vitest';
 
-import { OneFileDocumentSession } from '../../../../../packages/doc-session/src/session';
-import { bindYjsWebSocket } from '../../../../../packages/doc-session/src/websocket';
+import { bindYjsWebSocket, OneFileDocumentSession } from '@kb-2/doc-session';
 import {
   createDemoDocumentProvider,
   DEMO_DOCUMENT_TEXT_NAME,

--- a/apps/web/src/lib/yjs/demo-document-provider.ts
+++ b/apps/web/src/lib/yjs/demo-document-provider.ts
@@ -88,7 +88,7 @@ export function createDemoDocumentProvider(
   });
 
   socket.addEventListener('close', () => {
-    options.onStatus?.(destroyed ? 'closed' : 'closed');
+    options.onStatus?.('closed');
   });
 
   return {
@@ -116,4 +116,3 @@ function toUint8Array(data: unknown): Uint8Array | undefined {
   if (data instanceof Blob) return undefined;
   return undefined;
 }
-

--- a/apps/web/src/lib/yjs/demo-document-provider.ts
+++ b/apps/web/src/lib/yjs/demo-document-provider.ts
@@ -1,0 +1,119 @@
+import * as decoding from 'lib0/decoding';
+import * as encoding from 'lib0/encoding';
+import * as syncProtocol from 'y-protocols/sync';
+import * as Y from 'yjs';
+
+export const DEMO_DOCUMENT_YJS_PATH = '/api/demo-document/yjs';
+export const DEMO_DOCUMENT_TEXT_NAME = 'markdown';
+
+const messageSync = 0;
+
+export type DemoDocumentProviderStatus =
+  | 'connecting'
+  | 'open'
+  | 'closed'
+  | 'error';
+
+export interface DemoDocumentProvider {
+  doc: Y.Doc;
+  text: Y.Text;
+  destroy: () => void;
+}
+
+export interface DemoDocumentProviderOptions {
+  url?: string;
+  onStatus?: (status: DemoDocumentProviderStatus) => void;
+  onError?: (error: unknown) => void;
+}
+
+export function createDemoDocumentProvider(
+  options: DemoDocumentProviderOptions = {},
+): DemoDocumentProvider {
+  const doc = new Y.Doc();
+  const text = doc.getText(DEMO_DOCUMENT_TEXT_NAME);
+  const socket = new WebSocket(options.url ?? yjsWebSocketUrl());
+  socket.binaryType = 'arraybuffer';
+
+  let destroyed = false;
+  options.onStatus?.('connecting');
+
+  const sendSync = (write: (encoder: encoding.Encoder) => void): void => {
+    if (socket.readyState !== WebSocket.OPEN) return;
+    const encoder = encoding.createEncoder();
+    encoding.writeVarUint(encoder, messageSync);
+    write(encoder);
+    socket.send(encoding.toUint8Array(encoder));
+  };
+
+  const updateHandler = (update: Uint8Array, origin: unknown): void => {
+    if (origin === socket || destroyed) return;
+    sendSync((encoder) => {
+      syncProtocol.writeUpdate(encoder, update);
+    });
+  };
+
+  doc.on('update', updateHandler);
+
+  socket.addEventListener('open', () => {
+    options.onStatus?.('open');
+    sendSync((encoder) => {
+      syncProtocol.writeSyncStep1(encoder, doc);
+    });
+  });
+
+  socket.addEventListener('message', (event) => {
+    try {
+      const message = toUint8Array(event.data);
+      if (!message) return;
+
+      const decoder = decoding.createDecoder(message);
+      const encoder = encoding.createEncoder();
+      const messageType = decoding.readVarUint(decoder);
+      if (messageType !== messageSync) return;
+
+      encoding.writeVarUint(encoder, messageSync);
+      syncProtocol.readSyncMessage(decoder, encoder, doc, socket);
+      if (encoding.length(encoder) > 1) {
+        socket.send(encoding.toUint8Array(encoder));
+      }
+    } catch (error) {
+      options.onError?.(error);
+      socket.close(1003, 'Invalid Yjs sync message');
+    }
+  });
+
+  socket.addEventListener('error', (event) => {
+    options.onStatus?.('error');
+    options.onError?.(event);
+  });
+
+  socket.addEventListener('close', () => {
+    options.onStatus?.(destroyed ? 'closed' : 'closed');
+  });
+
+  return {
+    doc,
+    text,
+    destroy: () => {
+      destroyed = true;
+      doc.off('update', updateHandler);
+      socket.close(1000, 'Editor unmounted');
+      doc.destroy();
+      options.onStatus?.('closed');
+    },
+  };
+}
+
+function yjsWebSocketUrl(): string {
+  const url = new URL(DEMO_DOCUMENT_YJS_PATH, window.location.href);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  return url.href;
+}
+
+function toUint8Array(data: unknown): Uint8Array | undefined {
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  if (data instanceof Uint8Array) return data;
+  if (data instanceof Blob) return undefined;
+  return undefined;
+}
+

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,5 +1,189 @@
 <script lang="ts">
-  import StatusShell from '$lib/components/StatusShell.svelte';
+  import { createDemoDocumentProvider } from '$lib/yjs/demo-document-provider';
+  import type {
+    DemoDocumentProvider,
+    DemoDocumentProviderStatus,
+  } from '$lib/yjs/demo-document-provider';
+  import { PlaintextEditor, type LivePath, type OrgPerson } from '@kb-2/editor';
+  import { LiveStatusChip } from '@kb-2/ui';
+  import { onMount } from 'svelte';
+
+  let provider = $state<DemoDocumentProvider | null>(null);
+  let status = $state<DemoDocumentProviderStatus>('connecting');
+  let error = $state<string | null>(null);
+
+  const livePaths: LivePath[] = [
+    { path: 'demo-vault/hello-world.md', noteId: 'demo-document' },
+  ];
+
+  const orgPeople: OrgPerson[] = [
+    {
+      id: 'demo-yoh',
+      email: 'yoh@example.com',
+      name: 'Yoh',
+      image: null,
+    },
+  ];
+
+  const statusLabel = $derived(
+    status === 'open'
+      ? 'Daemon · live'
+      : status === 'connecting'
+        ? 'Daemon · connecting'
+        : status === 'error'
+          ? 'Daemon · error'
+          : 'Daemon · closed',
+  );
+
+  onMount(() => {
+    const nextProvider = createDemoDocumentProvider({
+      onStatus: (nextStatus) => {
+        status = nextStatus;
+      },
+      onError: (caught) => {
+        error = caught instanceof Error ? caught.message : String(caught);
+      },
+    });
+    provider = nextProvider;
+
+    return () => {
+      nextProvider.destroy();
+      provider = null;
+    };
+  });
 </script>
 
-<StatusShell />
+<svelte:head>
+  <title>KB-2 Editor</title>
+</svelte:head>
+
+<main class="editor-page">
+  <header class="topbar">
+    <div class="title-group">
+      <span class="eyebrow">demo-vault</span>
+      <h1>hello-world.md</h1>
+    </div>
+    <a class="status-link" href="/status" aria-label="Open daemon status">
+      <LiveStatusChip label={statusLabel} />
+    </a>
+  </header>
+
+  <section class="document-shell" aria-label="Demo Markdown document">
+    {#if provider}
+      <PlaintextEditor
+        ydoc={provider.doc}
+        ytext={provider.text}
+        livePaths={livePaths}
+        orgPeople={orgPeople}
+        scroll="self"
+      />
+    {:else}
+      <div class="loading">Opening document…</div>
+    {/if}
+  </section>
+
+  {#if error}
+    <p class="error">{error}</p>
+  {/if}
+</main>
+
+<style>
+  .editor-page {
+    min-height: 100vh;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    background: var(--rd-bg);
+    color: var(--rd-ink-2);
+    font-family: var(--rd-ui);
+  }
+
+  .topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 16px 22px 12px;
+    border-bottom: 1px solid var(--rd-rule);
+    background: color-mix(in srgb, var(--rd-panel) 82%, transparent);
+  }
+
+  .title-group {
+    min-width: 0;
+  }
+
+  .eyebrow {
+    display: block;
+    color: var(--rd-ink-4);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1.2;
+  }
+
+  h1 {
+    margin: 1px 0 0;
+    color: var(--rd-ink-1);
+    font-size: 16px;
+    font-weight: 650;
+    line-height: 1.2;
+    letter-spacing: 0;
+  }
+
+  .status-link {
+    flex: none;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .document-shell {
+    min-height: 0;
+    display: grid;
+    grid-template-columns: minmax(24px, 1fr) minmax(0, 760px) minmax(24px, 1fr);
+    padding: 22px 0 0;
+    overflow: hidden;
+  }
+
+  .document-shell :global(.kb2-editor-shell),
+  .loading {
+    grid-column: 2;
+    min-width: 0;
+    border-left: 1px solid var(--rd-rule);
+    border-right: 1px solid var(--rd-rule);
+    background: var(--rd-panel);
+  }
+
+  .document-shell :global(.plaintext-editor .cm-content) {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  .loading {
+    padding: 24px;
+    color: var(--rd-ink-4);
+    font-size: 13px;
+  }
+
+  .error {
+    position: fixed;
+    left: 16px;
+    bottom: 16px;
+    margin: 0;
+    max-width: min(520px, calc(100vw - 32px));
+    border: 1px solid color-mix(in srgb, var(--destructive) 40%, transparent);
+    border-radius: 6px;
+    background: var(--rd-panel);
+    color: var(--destructive);
+    padding: 8px 10px;
+    font-size: 12px;
+  }
+
+  @media (max-width: 720px) {
+    .topbar {
+      padding: 12px 14px 10px;
+    }
+
+    .document-shell {
+      grid-template-columns: 12px minmax(0, 1fr) 12px;
+      padding-top: 12px;
+    }
+  }
+</style>

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@kb-2/editor",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "svelte": "./src/lib/index.ts",
+  "exports": {
+    ".": {
+      "svelte": "./src/lib/index.ts",
+      "types": "./src/lib/index.ts",
+      "default": "./src/lib/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "typecheck": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "dependencies": {
+    "@codemirror/commands": "6.10.3",
+    "@codemirror/lang-css": "6.3.1",
+    "@codemirror/lang-html": "6.4.11",
+    "@codemirror/lang-javascript": "6.2.5",
+    "@codemirror/lang-json": "6.0.2",
+    "@codemirror/lang-markdown": "6.5.0",
+    "@codemirror/lang-python": "6.2.1",
+    "@codemirror/language": "6.11.3",
+    "@codemirror/state": "6.6.0",
+    "@codemirror/view": "6.41.1",
+    "@kb-2/ui": "workspace:*",
+    "@lezer/common": "1.5.2",
+    "@lezer/highlight": "1.2.3",
+    "@lezer/markdown": "1.6.3",
+    "svelte": "catalog:",
+    "yjs": "13.6.31"
+  },
+  "devDependencies": {
+    "@storybook/svelte": "catalog:",
+    "@sveltejs/vite-plugin-svelte": "catalog:",
+    "svelte-check": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/editor/project.json
+++ b/packages/editor/project.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "editor",
+  "sourceRoot": "packages/editor/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/editor build"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/editor test"
+      }
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/editor typecheck"
+      }
+    }
+  }
+}
+

--- a/packages/editor/src/lib/MentionChip.stories.ts
+++ b/packages/editor/src/lib/MentionChip.stories.ts
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import MentionChipStory from './stories/MentionChipStory.svelte';
+
+const meta = {
+  title: 'App/Editor/MentionChip',
+  component: MentionChipStory,
+} satisfies Meta<typeof MentionChipStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Variants: Story = {};

--- a/packages/editor/src/lib/MentionChip.svelte
+++ b/packages/editor/src/lib/MentionChip.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+  import { Avatar, type AccentName } from '@kb-2/ui';
+
+  /**
+   * Editor-side mention chip. Mounted via a CM6 `WidgetType` (see
+   * `plaintext-mention-widget.ts`) in place of the source range
+   * `[Name](mention:email)` when the cursor is outside the link.
+   *
+   * Path β implementation (no `UserAvatar`, no `PersonHoverCard`,
+   * no Svelte query contexts): the chip's parent (`PlaintextEditor`)
+   * already resolves the mention against `orgPeople` at decoration-
+   * build time and passes the resolved `id` / `image` / `letter` /
+   * `accent` through the widget props. That avoids the QueryClient-
+   * context bridging problem (Tanstack's context key is module-
+   * private and can't be threaded through Svelte 5's `mount({context})`
+   * map). Hover-card is deferred; clicks already pass through to the
+   * editor so caret-placement-on-click still works.
+   *
+   * Visual contract:
+   *   - rounded pill (5px radius), 1.4em height, accent border + tint
+   *   - inline-flex with avatar slot + display-name label
+   *   - mounts <Avatar kind="human"> at size 14 (≈ 0.875em on a 16px
+   *     editor body, matching the old 1.1em pseudo-element slot)
+   *   - stale variant: slate accent, line-through, muted color,
+   *     reduced avatar opacity
+   *   - `font: inherit` on the chip — the label picks up the surrounding
+   *     prose typography (serif + regular weight in PlaintextEditor),
+   *     so a chip in a paragraph reads as a colored pill around the
+   *     same typographic voice as the line it sits on, not a UI label
+   *     dropped into prose.
+   *   - `vertical-align: middle` aligns the pill's center with the
+   *     parent text's midline (baseline + x-height/2). Same rule the
+   *     editor's broken-image / loading-spinner widgets use.
+   */
+
+  interface Props {
+    accent: AccentName;
+    letter: string;
+    image: string | null;
+    displayName: string;
+    title: string;
+    stale: boolean;
+  }
+
+  let { accent, letter, image, displayName, title, stale }: Props = $props();
+</script>
+
+<span
+  class="chip"
+  class:stale
+  style="--rd-accent: var(--rd-{accent}); --rd-accent-bg: var(--rd-{accent}-bg);"
+  {title}
+>
+  <span class="avatar-slot">
+    <Avatar
+      kind="human"
+      {accent}
+      size={14}
+      {letter}
+      {image}
+      ariaLabel={displayName}
+    />
+  </span>
+  <span class="label">{displayName}</span>
+</span>
+
+<style>
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25em;
+    height: 1.4em;
+    padding: 0 0.4em 0 0.3em;
+    border-radius: 5px;
+    /* `vertical-align: middle` aligns the chip's center with the parent
+       text's midline (baseline + x-height/2). Earlier `-0.25em` shifted
+       the inline-flex center down past the prose baseline, making the
+       pill visibly droop below the surrounding text. `middle` is the
+       canonical inline-pill alignment — same rule used by the
+       broken-image / loading-spinner widgets further down in
+       PlaintextEditor.svelte. */
+    vertical-align: middle;
+    text-decoration: none;
+    color: var(--rd-accent);
+    background: light-dark(
+      color-mix(in srgb, var(--rd-accent) 11%, transparent),
+      color-mix(in srgb, var(--rd-accent) 22%, transparent)
+    );
+    border: 1px solid
+      light-dark(
+        color-mix(in srgb, var(--rd-accent) 38%, transparent),
+        color-mix(in srgb, var(--rd-accent) 60%, transparent)
+      );
+    line-height: 1;
+    /* Typography inherits from the surrounding prose so the chip's text
+       reads as the same typographic voice as the line it sits on. The
+       editor body is `var(--rd-serif)` at the default weight (Source
+       Serif 4 regular). Earlier the chip forced `var(--rd-ui)` + weight
+       600 + UI-specific tracking, which looked like a bold UI label
+       dropped into a serif paragraph. */
+    font: inherit;
+  }
+
+  .avatar-slot {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  .label {
+    /* Label inherits prose typography from .chip (font: inherit), so no
+       extra font rules here. Kept as its own element so we can future-
+       proof for per-segment effects (e.g. muting just the label in
+       stale). */
+    white-space: nowrap;
+  }
+
+  .chip.stale {
+    color: var(--rd-ink-3, #6b7785);
+    background: color-mix(in srgb, var(--rd-accent) 8%, transparent);
+    border-color: color-mix(in srgb, var(--rd-accent) 30%, transparent);
+    text-decoration: line-through;
+  }
+  .chip.stale .avatar-slot {
+    opacity: 0.6;
+  }
+</style>

--- a/packages/editor/src/lib/PlaintextEditor.stories.ts
+++ b/packages/editor/src/lib/PlaintextEditor.stories.ts
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import PlaintextEditorStory from './stories/PlaintextEditorStory.svelte';
+
+const meta = {
+  title: 'App/Editor/PlaintextEditor',
+  component: PlaintextEditorStory,
+} satisfies Meta<typeof PlaintextEditorStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Fixture: Story = {};
+

--- a/packages/editor/src/lib/PlaintextEditor.svelte
+++ b/packages/editor/src/lib/PlaintextEditor.svelte
@@ -1518,19 +1518,7 @@
     color: var(--rd-ink-4, rgba(0, 0, 0, 0.4));
   }
 
-  /* --- Pending-upload spinner (Slice 2 Apple lane) ---------------- *
-   * Inline spinner shown while a paste/drop image upload is in flight.
-   * The image widget renders `<span class="cm-md-image-spinner">…</span>`
-   * for any URL that starts with `pending-upload://` (sentinel scheme
-   * minted by plaintext-image-upload.ts). Once the upload resolves the
-   * URL is Y.Text-swapped to the real path and the widget rebuilds as
-   * a regular <img>.
-   *
-   * Minimal visual: a Phosphor CircleNotch arc, rotated via CSS
-   * keyframes. Sits in the same muted ink tone as the broken-image
-   * fallback so the optimistic / failed states share a visual register.
-   * Same vertical-align rule as the broken-image widget so the spinner
-   * tracks the surrounding text baseline. */
+  /* Documents may contain pending-upload:// sentinel URLs from KB-1 data or future upload support. */
   .plaintext-editor :global(.cm-md-image-widget[data-state='pending']) {
     display: inline-flex;
     align-items: center;

--- a/packages/editor/src/lib/PlaintextEditor.svelte
+++ b/packages/editor/src/lib/PlaintextEditor.svelte
@@ -1,0 +1,1555 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { Doc } from 'yjs';
+  import * as Y from 'yjs';
+  import {
+    EditorState,
+    Annotation,
+    type Extension,
+  } from '@codemirror/state';
+  import {
+    EditorView,
+    keymap,
+    highlightActiveLine,
+    ViewPlugin,
+    type PluginValue,
+    type ViewUpdate,
+  } from '@codemirror/view';
+  import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+  import { insertNewlineContinueMarkup } from '@codemirror/lang-markdown';
+  import { PLAINTEXT_USER_ORIGIN } from './content-format';
+  import type { LivePath, OrgPerson } from './markdown-core';
+  import {
+    plaintextDecorations,
+    livePathsChangedEffect,
+    mentionDirectoryChangedEffect,
+  } from './plaintext-decorations';
+  import {
+    plaintextLinkClickHandler,
+    plaintextLinkHover,
+  } from './plaintext-link-affordance';
+  import { plaintextMentionKeymap } from './plaintext-mention-keymap';
+  import { plaintextListKeymap } from './plaintext-list-keymap';
+  import { plaintextLinkPaste } from './plaintext-link-paste';
+
+  interface Props {
+    /** Shared Y.Doc supplied by the host app/provider. */
+    ydoc: Doc;
+    /** Bound Y.Text supplied by the host app/provider. */
+    ytext: Y.Text;
+    /** Disables typing. Mirror of MarkdownEditor's prop. */
+    readOnly?: boolean;
+    /** Accessibility label for the editor host. */
+    ariaLabel?: string;
+    /** Wrapper class — same convention as MarkdownEditor. */
+    class?: string;
+    /** Scroll ownership — 'self' for standalone, 'external' when the
+     *  parent owns the scroll container. Defaults to 'self'. */
+    scroll?: 'self' | 'external';
+    /** Optional attachment URL resolver. When provided, image source
+     *  paths in the markdown (`![](some/path.png)`) that don't look
+     *  like absolute URLs are routed through this function to produce
+     *  the actual `<img src>`. Mirrors MarkdownEditor's prop of the
+     *  same name. Omit to disable attachment-path remapping (Storybook
+     *  / no-vault contexts) — bare paths pass through and the browser
+     *  renders a broken-image icon. */
+    attachmentSrc?: (path: string) => string;
+    /** Vault live-path snapshot for wikilink resolution (Slice 5).
+     *  Mirrors MarkdownEditor's prop of the same name. The decoration
+     *  builder runs each `[[target]]` through `resolveLinkTarget`
+     *  against this list to decide between the resolved
+     *  (`cm-md-wikilink-label`) and broken
+     *  (`cm-md-wikilink-broken`) styles. Pass an empty array (or omit)
+     *  when no resolution context is available — every wikilink will
+     *  render as broken in that case, which matches reality.
+     *
+     *  Reactive: when the reference changes (vault tree update, vault
+     *  switch), the editor dispatches a `livePathsChangedEffect` so the
+     *  decoration field re-resolves without needing a doc edit. */
+    livePaths?: readonly LivePath[];
+    /** Org directory snapshot for mention chip resolution. Mirrors
+     *  MarkdownEditor's prop of the same name. The decoration builder
+     *  runs each `[Name](mention:email)` through `resolvePerson`
+     *  against this list to decide between the resolved and stale
+     *  variants of the `MentionChipWidget` (see
+     *  `plaintext-mention-widget.ts` — the resolved variant uses the
+     *  user's accent + image, the stale variant falls back to slate +
+     *  a muted line-through label). Pass an empty array (or omit) when
+     *  no resolution context is available — every mention will render
+     *  as stale, which matches reality.
+     *
+     *  Reactive: when the reference changes (org switch, member added/
+     *  removed), the editor dispatches a `mentionDirectoryChangedEffect`
+     *  so the decoration field re-resolves without needing a doc edit. */
+    orgPeople?: readonly OrgPerson[];
+    /** Wikilink click handler (Slice 6). Fires with the URL-encoded
+     *  target so the host can decode + resolve + navigate. Mirrors
+     *  MarkdownEditor's prop of the same name — both editors feed the
+     *  same `DocumentCanvas.handleWikilinkClick` upstream so resolution
+     *  and routing stay unified. Omit when there's no navigation context
+     *  (Storybook, no-vault tests) — clicks on wikilinks no-op then. */
+    onWikilinkClick?: (encodedTarget: string, event: MouseEvent) => void;
+  }
+
+  let {
+    ydoc,
+    ytext,
+    readOnly = false,
+    ariaLabel = 'Markdown editor',
+    class: className,
+    scroll = 'self',
+    attachmentSrc,
+    livePaths = [],
+    orgPeople = [],
+    onWikilinkClick,
+  }: Props = $props();
+
+  let host = $state<HTMLDivElement | null>(null);
+  // EditorView ref kept module-scoped so the `livePaths` effect below
+  // can dispatch the `livePathsChangedEffect` whenever the parent's
+  // reactive snapshot reference shifts. Initialized to null and
+  // populated in `onMount`.
+  let editorView = $state<EditorView | null>(null);
+
+  // Note: the user-driven view↔edit toggle that originally shipped with
+  // Slice 3 (floating button + Cmd-E keymap + Compartment-wrapped
+  // editable facet) was decommissioned once Slices F (focus-aware
+  // syntax reveal) and S (H-level gutter chip) landed. The combination
+  // of those two slices makes the toggle redundant: clicking outside
+  // the editor blurs focus, which hides syntax characters and reveals
+  // the H-chips for a clean reading view; clicking back into the
+  // editor focuses it and reveals the source `#`/`##`/`###` on the
+  // active line for editing. The `readOnly` prop below remains the
+  // parent's hook for soft-revoked-grant enforcement; it gates
+  // EditorState.readOnly + EditorView.editable at mount.
+
+  onMount(() => {
+    if (!host) return;
+
+    // Capture stable refs — same reasoning as MarkdownEditor.svelte:469:
+    // Svelte 5 `$props` getters re-read on every access including
+    // during cleanup. If the parent flips `binding` to null mid-tear-
+    // down, lazy reads would throw on the cleanup path.
+    const stableDoc = ydoc;
+    const stableAttachmentSrc = attachmentSrc;
+    // livePaths is captured via getter, not snapshot, so the wikilink
+    // decoration re-resolves on every rebuild against the parent's
+    // latest reactive value. Same pattern as the Crepe-side wikilink
+    // plugin in `wikilink-decoration-plugin.ts`.
+    const stableGetLivePaths = (): readonly LivePath[] => livePaths;
+    // orgPeople gets the same getter treatment for the same reason —
+    // mention chip resolution needs the latest directory each rebuild.
+    const stableGetOrgPeople = (): readonly OrgPerson[] => orgPeople;
+    // onWikilinkClick is also a $props getter — capture via a closure
+    // so the click handler reads the latest reactive callback without
+    // re-instantiating the extension. Returning `null` when the prop is
+    // undefined lets the affordance treat "no handler" as a no-op
+    // (mirrors MarkdownEditor's `if (!onWikilinkClick) return` guard).
+    const stableWikilinkClick = (
+      encoded: string,
+      event: MouseEvent,
+    ): void => {
+      const handler = onWikilinkClick;
+      if (handler === undefined) return;
+      handler(encoded, event);
+    };
+    const stableText = ytext;
+
+    // --- Sync plugin (replaces y-codemirror.next's `ySync`) ---------
+    //
+    // Mirrors upstream `y-sync.js`. The only meaningful differences:
+    //   - Local CM dispatches transact onto Y.Text with origin =
+    //     PLAINTEXT_USER_ORIGIN (a string) rather than the per-editor
+    //     YSyncConfig instance, so the spec contract holds verbatim.
+    //   - Inbound Y.Text events (origin !== PLAINTEXT_USER_ORIGIN) are
+    //     dispatched into CM as edits annotated `syncAnnotation` so
+    //     the update() loop can skip its own echo.
+    const syncAnnotation = Annotation.define<symbol>();
+    const SYNC_MARK = Symbol('plaintext-sync');
+
+    class PlaintextSyncPlugin implements PluginValue {
+      private view: EditorView;
+      private observer: (
+        event: Y.YTextEvent,
+        transaction: Y.Transaction,
+      ) => void;
+
+      constructor(view: EditorView) {
+        this.view = view;
+        this.observer = (event, _tr) => {
+          // Skip echo of our own local writes.
+          if (event.transaction.origin === PLAINTEXT_USER_ORIGIN) return;
+          const delta = event.delta;
+          const changes: { from: number; to: number; insert: string }[] = [];
+          let pos = 0;
+          for (const d of delta) {
+            if (d.insert != null) {
+              const text = typeof d.insert === 'string' ? d.insert : '';
+              if (text.length > 0) {
+                changes.push({ from: pos, to: pos, insert: text });
+              }
+            } else if (d.delete != null) {
+              changes.push({ from: pos, to: pos + d.delete, insert: '' });
+              pos += d.delete;
+            } else if (d.retain != null) {
+              pos += d.retain;
+            }
+          }
+          if (changes.length === 0) return;
+          view.dispatch({
+            changes,
+            annotations: [syncAnnotation.of(SYNC_MARK)],
+          });
+        };
+        stableText.observe(this.observer);
+      }
+
+      update(update: ViewUpdate): void {
+        if (!update.docChanged) return;
+        // Skip CM dispatches that came from the inbound Y.Text observer.
+        for (const tr of update.transactions) {
+          if (tr.annotation(syncAnnotation) === SYNC_MARK) return;
+        }
+        // Local user edits — write them back to Y.Text with our origin.
+        stableDoc.transact(() => {
+          let adj = 0;
+          update.changes.iterChanges(
+            (fromA, toA, _fromB, _toB, insert) => {
+              const insertText = insert.sliceString(0, insert.length, '\n');
+              if (fromA !== toA) {
+                stableText.delete(fromA + adj, toA - fromA);
+              }
+              if (insertText.length > 0) {
+                stableText.insert(fromA + adj, insertText);
+              }
+              adj += insertText.length - (toA - fromA);
+            },
+          );
+        }, PLAINTEXT_USER_ORIGIN);
+      }
+
+      destroy(): void {
+        stableText.unobserve(this.observer);
+      }
+    }
+    const plaintextSync = ViewPlugin.fromClass(PlaintextSyncPlugin);
+
+    // --- Undo manager ----------------------------------------------
+    //
+    // Scoped to local user edits only. Agent splices ('plaintext-agent'),
+    // peer typing (vault channel wireOrigin), and system updates
+    // (hydrate with null origin) are NOT tracked — so Ctrl-Z never
+    // reaches them. This is the spec's "Undo and origin tagging"
+    // contract: pressing undo undoes your own typing; it does not
+    // undo agent edits or remote collaborators' typing.
+    const undoManager = new Y.UndoManager(stableText, {
+      trackedOrigins: new Set([PLAINTEXT_USER_ORIGIN]),
+    });
+    const undoCmd = (): boolean => {
+      undoManager.undo();
+      return true;
+    };
+    const redoCmd = (): boolean => {
+      undoManager.redo();
+      return true;
+    };
+
+    // --- Theme -----------------------------------------------------
+    //
+    // Document-surface theme. Distinct from kb-1's app chrome (Inter
+    // Tight UI, system mono) — `.txt` content uses the prose-body face
+    // so the editor *feels* like a thoughtful reading surface, not
+    // another panel of UI. Today that face is Geist (Vercel's OFL sans)
+    // under preview evaluation, resolved via `--rd-sans-prose` and
+    // self-hosted via `@fontsource-variable/geist` from `src/app.css`.
+    // The previous Source Serif 4 stack remains defined as `--rd-serif`
+    // in `tokens.css` so reverting is a one-line edit. Swap the body
+    // face by re-pointing `font-family` below at a different token.
+    //
+    // Reading width is owned by the outer `.doc-column` wrapper (in
+    // DocumentCanvas.svelte), not this theme — the column geometry is
+    // shared with `DocumentByline` so byline + editor align
+    // structurally. Color is a muted near-black (--rd-ink-2) rather
+    // than pure black so heavy text doesn't burn.
+    //
+    // Font-smoothing — mirror Vercel docs body declarations so Geist
+    // renders with the slightly thinner, crisper feel they ship with.
+    // Harmless on the previous serif stack and on other surfaces that
+    // don't read this theme, since it only applies inside CM6's root.
+    //
+    // No line-number gutter: `lineNumbers` is NOT in the extension list
+    // and the empty CM gutter element is hidden via `.cm-gutters { display:
+    // none }` below. The intent is "this is a document, not code".
+    const documentTheme = EditorView.theme({
+      '&': {
+        height: scroll === 'self' ? '100%' : 'auto',
+        fontFamily:
+          "var(--rd-sans-prose, 'Geist Variable', system-ui, -apple-system, 'Segoe UI', sans-serif)",
+        fontSize: '16px',
+        color: 'var(--rd-ink-2, #2a2a2a)',
+        background: 'transparent',
+        textRendering: 'optimizeLegibility',
+        WebkitFontSmoothing: 'antialiased',
+        MozOsxFontSmoothing: 'grayscale',
+      },
+      '.cm-scroller': {
+        fontFamily: 'inherit',
+        overflow: scroll === 'self' ? 'auto' : 'visible',
+        lineHeight: '1.65',
+      },
+      '.cm-content': {
+        // Tight top padding — the byline sits immediately above with
+        // its own 6px bottom-pad, and the `:first-child` rule below
+        // collapses the heading's intrinsic top-padding. 8px here
+        // gives a small intentional gap between byline bottom edge
+        // and the heading's first glyph without re-introducing the
+        // pre-fix slack. 64px bottom keeps the scroll runway.
+        padding: '8px 0 64px 0',
+        caretColor: 'var(--rd-ink-1, #1a1d22)',
+      },
+      // Kill the gutter entirely — no line numbers, no fold gutter, no
+      // empty rail. The extension `lineNumbers()` is also dropped from
+      // the extension list above; this rule covers any residual gutter
+      // element CM6 renders by default.
+      '.cm-gutters': {
+        display: 'none',
+      },
+      // Soften the active-line highlight so it doesn't read as a code
+      // editor's full-bleed line band. Near-invisible warm tint.
+      '.cm-activeLine': {
+        backgroundColor: 'transparent',
+      },
+      '.cm-selectionBackground, &.cm-focused .cm-selectionBackground': {
+        backgroundColor: 'rgba(80, 120, 180, 0.18)',
+      },
+    });
+
+    // Seed the editor's initial doc from the live Y.Text. Subsequent
+    // remote/agent updates land via the observer; subsequent local
+    // edits land via update().
+    const extensions: Extension[] = [
+      history(),
+      // `lineNumbers()` deliberately omitted — see `documentTheme`
+      // comment above for the "document not code" rationale.
+      highlightActiveLine(),
+      EditorView.lineWrapping,
+      // Static editable / readOnly. The `readOnly` prop is the
+      // parent's enforcement point (e.g. soft-revoked grants); no
+      // runtime swap is needed here. The user-driven view↔edit toggle
+      // was decommissioned in favor of focus-aware reveal (Slice F) +
+      // H-chip (Slice S).
+      EditorState.readOnly.of(readOnly),
+      EditorView.editable.of(!readOnly),
+      documentTheme,
+      plaintextSync,
+      // Live-preview-style markdown decorations. They are document +
+      // selection driven and compose through EditorView.decorations:
+      // line decos wrap the line element, mark decos wrap their range,
+      // and widgets replace rendered markdown constructs.
+      plaintextDecorations({
+        attachmentSrc: stableAttachmentSrc,
+        getLivePaths: stableGetLivePaths,
+        getOrgPeople: stableGetOrgPeople,
+        onWikilinkClick: stableWikilinkClick,
+      }),
+      // Slice 6 — link click + wikilink hover preview. Two separate
+      // extensions because they hook different CM6 surfaces (DOM
+      // events vs hoverTooltip); kept in a sibling file so the
+      // decoration pipeline stays focused on painting. The click
+      // handler routes URL links to a new tab and wikilinks back to
+      // the host via the same encoded-target contract MarkdownEditor
+      // uses. The hover tooltip surfaces the resolved path / "Note
+      // not found" for wikilinks — markdown editor doesn't have this
+      // yet; parity follow-up.
+      plaintextLinkClickHandler(stableWikilinkClick),
+      plaintextLinkHover(stableGetLivePaths),
+      // Atomic-edge delete for mention chips (Apple lane Slice 1).
+      // MUST sit BEFORE the `keymap.of([...defaultKeymap])` below so
+      // Backspace / Delete reach this handler first when the caret is
+      // at a mention's edge — defaultKeymap's per-char delete would
+      // otherwise consume the closing `)` before the chip-deletion
+      // handler ran. Caret INSIDE the mention falls through to default
+      // delete (typo-fix carve-out for the display name).
+      plaintextMentionKeymap(),
+      // Tab / Shift-Tab indent / outdent for list items (Apple lane
+      // Feature 3). Gates on lezer `ListItem` ancestry; Tab outside
+      // any list falls through (returns false) so browser focus
+      // traversal stays intact for keyboard-only users. Single-line
+      // v1 — multi-line block indent is a deferred follow-up.
+      plaintextListKeymap(),
+      // Paste-a-URL-as-markdown-link: any URL over a selection wraps
+      // it as `[selection](url)`; a kb-1 note URL with no selection
+      // inserts `[note name](url)`. Non-URL pastes (and URL pastes
+      // that match neither rule) fall through to default CM6 paste.
+      // See `plaintext-link-paste.ts` for the decision rules.
+      ...(!readOnly ? [plaintextLinkPaste()] : []),
+      keymap.of([
+        { key: 'Mod-z', run: undoCmd, preventDefault: true },
+        { key: 'Mod-y', mac: 'Mod-Shift-z', run: redoCmd, preventDefault: true },
+        { key: 'Mod-Shift-z', run: redoCmd, preventDefault: true },
+        // Enter on a list line continues the list (new bullet at same
+        // indent); Enter on an empty list line exits the list. From
+        // @codemirror/lang-markdown's markdownKeymap bundle — we pull
+        // only this one command (not the bundle, which would override
+        // Backspace and conflict with plaintextMentionKeymap's atomic
+        // edge delete). Must sit BEFORE defaultKeymap's Enter (which
+        // would just insert a plain newline).
+        { key: 'Enter', run: insertNewlineContinueMarkup },
+        ...defaultKeymap,
+        ...historyKeymap,
+      ]),
+    ];
+
+    const view = new EditorView({
+      parent: host,
+      state: EditorState.create({
+        // `toJSON()` returns the unformatted string body — same value
+        // `toString()` would, but the typed entry-point per `yjs.d.ts`.
+        doc: stableText.toString(),
+        extensions,
+      }),
+    });
+    editorView = view;
+
+    return () => {
+      editorView = null;
+      view.destroy();
+      undoManager.destroy();
+    };
+  });
+
+  /**
+   * livePaths-changed effect (Slice 5). Sibling of MarkdownEditor's
+   * livePaths effect at MarkdownEditor.svelte:1441-1462. When the
+   * parent's `livePaths` reference flips (vault tree update, vault
+   * switch) we dispatch a `livePathsChangedEffect` so the decoration
+   * field's `update` callback re-resolves every wikilink against the
+   * fresh snapshot — without this the resolved/broken state would
+   * remain stale until the next user keystroke.
+   */
+  $effect(() => {
+    void livePaths;
+    const view = editorView;
+    if (view === null) return;
+    view.dispatch({ effects: livePathsChangedEffect.of(null) });
+  });
+
+  /**
+   * orgPeople-changed effect (sibling of livePaths). When the parent's
+   * `orgPeople` reference flips (org switch, member added/removed) we
+   * dispatch a `mentionDirectoryChangedEffect` so the decoration field's
+   * `update` callback re-resolves every mention chip against the fresh
+   * directory — without this the resolved/stale state would remain stale
+   * until the next user keystroke.
+   */
+  $effect(() => {
+    void orgPeople;
+    const view = editorView;
+    if (view === null) return;
+    view.dispatch({ effects: mentionDirectoryChangedEffect.of(null) });
+  });
+</script>
+
+<div
+  class={[
+    'kb2-editor-shell',
+    scroll === 'self' ? 'scroll-self' : 'scroll-external',
+    className,
+  ].filter(Boolean).join(' ')}
+  data-readonly={readOnly}
+>
+  <div
+    bind:this={host}
+    class={[
+      'plaintext-editor',
+      scroll === 'self' ? 'editor-scroll-self' : 'editor-scroll-external',
+    ].join(' ')}
+    role={readOnly ? 'document' : 'textbox'}
+    aria-label={ariaLabel}
+  ></div>
+</div>
+
+<style>
+  .kb2-editor-shell {
+    position: relative;
+    display: flex;
+    width: 100%;
+    min-height: 0;
+    flex-direction: column;
+    background: var(--rd-panel, #ffffff);
+  }
+
+  .kb2-editor-shell.scroll-self {
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .plaintext-editor {
+    width: 100%;
+  }
+
+  .plaintext-editor.editor-scroll-self {
+    height: 100%;
+    overflow: auto;
+  }
+
+  .plaintext-editor.editor-scroll-external {
+    overflow: visible;
+  }
+
+  /* CodeMirror manages its own DOM and styling; the host div above is
+     a thin wrapper providing layout + scroll-container ownership. The
+     theme extension in the script handles font/padding/gutter cosmetics;
+     the markdown decoration classes below style ranges emitted by
+     `plaintextDecorations()` (see plaintext-decorations.ts).
+
+     CM6 emits decoration classes on its own DOM nodes (`.cm-line` for
+     line decos, raw `<span>` for mark decos), so all the rules below
+     are wrapped in `:global()` to escape Svelte's CSS scoping. */
+  .plaintext-editor :global(.cm-editor) {
+    outline: none;
+    height: 100%;
+  }
+  .plaintext-editor :global(.cm-editor.cm-focused) {
+    outline: none;
+  }
+
+  /* --- First-line top-space collapse ------------------------------
+   * Mirrors the Crepe `.ProseMirror > :first-child { margin-top: 0 }`
+   * rule in DocumentCanvas.svelte. A note typically opens with a
+   * heading, and the heading-line decos below carry `padding-top:
+   * 1.5em` for mid-doc breathing. When the heading IS the first line,
+   * the byline already provides the top whitespace — collapse the
+   * heading's intrinsic top-padding so the title sits flush under
+   * "Saved · Metadata · History" instead of opening a second gap. */
+  .plaintext-editor :global(.cm-content > .cm-line:first-child) {
+    padding-top: 0;
+  }
+
+  /* --- Heading line decorations -----------------------------------
+   * Restrained sizes — the body face is already a serif at 17px, so
+   * headings only need a small lift to read as section breaks rather
+   * than a typographic crescendo. Top padding opens whitespace above
+   * the heading so the eye groups content into sections. Weight tops
+   * out at 650 — heavy enough to anchor, not heavy enough to shout.
+   *
+   * Padding, not margin: CM6's heightmap measures `.cm-line` via
+   * `getBoundingClientRect().height`, which is the border-box and
+   * does NOT include margin. Using `margin-top` here would make
+   * CM6 under-count heading line heights and place the cursor
+   * ~50px below where the user clicks (cumulative across all
+   * headings above the click). Padding lives inside the border
+   * box, so CM6 reads the height correctly and click-to-position
+   * stays aligned. */
+  /* Headings — slight negative letter-spacing mirrors the Vercel docs
+     typographic feel for Geist (their reference uses ~-0.06em at 40px,
+     which is quite aggressive; we start moderate at -0.02em on H1 and
+     fade out per level). Weight stays at 650 (between regular and bold)
+     — the variable axis carries arbitrary values cleanly. If we
+     revert `--rd-sans-prose` back to the serif stack the negative
+     letter-spacing is still fine on Source Serif 4 at heading sizes. */
+  .plaintext-editor :global(.cm-line.cm-md-h1) {
+    position: relative;
+    font-size: 1.6em;
+    font-weight: 650;
+    line-height: 1.25;
+    letter-spacing: -0.02em;
+    padding-top: 1.5em;
+    padding-bottom: 0.4em;
+    color: var(--rd-ink-1, #1a1d22);
+  }
+  .plaintext-editor :global(.cm-line.cm-md-h2) {
+    position: relative;
+    font-size: 1.35em;
+    font-weight: 650;
+    line-height: 1.3;
+    letter-spacing: -0.015em;
+    padding-top: 1.5em;
+    padding-bottom: 0.4em;
+    color: var(--rd-ink-1, #1a1d22);
+  }
+  .plaintext-editor :global(.cm-line.cm-md-h3) {
+    position: relative;
+    font-size: 1.15em;
+    font-weight: 650;
+    line-height: 1.35;
+    letter-spacing: -0.01em;
+    padding-top: 1.5em;
+    padding-bottom: 0.4em;
+    color: var(--rd-ink-1, #1a1d22);
+  }
+
+  /* --- H-level gutter chip (Slice S, refined) --------------------- *
+   * Tiny `H1` / `H2` / `H3` label sitting in the left gutter, always
+   * visible (does NOT hide when the user clicks into the heading line —
+   * the source `#` reveals as well; chip stays as the structural
+   * marker). Right edges of all chips align at a fixed x just outside
+   * column-left, so H1/H2/H3 chips stack as a clean vertical column.
+   *
+   * Vertical centering on the heading text (not the line box). The
+   * line box includes padding-top (1.5em on mid-doc headings, 0 on
+   * the first-child H1 after Slice P's first-child collapse), so the
+   * text center varies. Formula: `top: calc(<padding-top> + <half
+   * line-height>); transform: translateY(-50%)`. First-child override
+   * sets padding-top to 0 in the calc.
+   *
+   * Why absolute / right-aligned-in-fixed-box: chip must NOT consume
+   * column width (Slice P alignment invariant). Each chip is a 32px-
+   * wide right-aligned box at `left: -40px` (so the box's right edge
+   * sits 8px left of column-edge). Text inside is right-aligned, so
+   * H1/H2/H3 glyphs all end at the same x position regardless of font
+   * size.
+   *
+   * Size: H1 11px, H2 10px, H3 9px — slight tapering matches the
+   * heading hierarchy without crescendoing. */
+  .plaintext-editor :global(.cm-line.cm-md-h1)::before,
+  .plaintext-editor :global(.cm-line.cm-md-h2)::before,
+  .plaintext-editor :global(.cm-line.cm-md-h3)::before {
+    position: absolute;
+    left: -40px;
+    width: 32px;
+    text-align: right;
+    transform: translateY(-50%);
+    font-family: var(
+      --rd-mono,
+      ui-monospace,
+      SFMono-Regular,
+      'SF Mono',
+      Menlo,
+      Consolas,
+      monospace
+    );
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    color: var(--rd-ink-4, rgba(0, 0, 0, 0.4));
+    pointer-events: none;
+    user-select: none;
+  }
+  /* Per-level: size + vertical-center in ABSOLUTE px.
+     `em` inside `::before` resolves to ::before's own font-size (the chip's
+     11/10/9px), NOT the heading's — so the top:calc(...) values can't be
+     written in em terms here. Computed from heading dimensions:
+       Body font = 17px (set in documentTheme).
+       H1: font 1.6em = 27.2px, line-height 1.25 = 34px, padding-top 1.5em = 40.8px.
+       H2: font 1.35em = 22.95px, line-height 1.3 = 29.84px, padding-top 1.5em = 34.43px.
+       H3: font 1.15em = 19.55px, line-height 1.35 = 26.39px, padding-top 1.5em = 29.33px.
+     Text center = padding-top + line-height/2. */
+  .plaintext-editor :global(.cm-line.cm-md-h1)::before {
+    content: 'H1';
+    font-size: 11px;
+    top: 57.8px; /* 40.8 + 17 */
+  }
+  .plaintext-editor :global(.cm-line.cm-md-h2)::before {
+    content: 'H2';
+    font-size: 10px;
+    top: 49.35px; /* 34.43 + 14.92 */
+  }
+  .plaintext-editor :global(.cm-line.cm-md-h3)::before {
+    content: 'H3';
+    font-size: 9px;
+    top: 42.52px; /* 29.33 + 13.20 */
+  }
+  /* First-child override: Slice P's collapse zeroes padding-top, so
+     text center is just line-height/2. */
+  .plaintext-editor :global(.cm-content > .cm-line:first-child.cm-md-h1)::before {
+    top: 17px;
+  }
+  .plaintext-editor :global(.cm-content > .cm-line:first-child.cm-md-h2)::before {
+    top: 14.92px;
+  }
+  .plaintext-editor :global(.cm-content > .cm-line:first-child.cm-md-h3)::before {
+    top: 13.2px;
+  }
+  .plaintext-editor :global(.cm-line.cm-md-h4),
+  .plaintext-editor :global(.cm-line.cm-md-h5),
+  .plaintext-editor :global(.cm-line.cm-md-h6) {
+    font-size: 1em;
+    font-weight: 650;
+    padding-top: 1.2em;
+    padding-bottom: 0.3em;
+    color: var(--rd-ink-1, #1a1d22);
+  }
+  /* Adjacent-heading collapse: nested heading reads as subdivision, not section break. */
+  .plaintext-editor
+    :global(
+      :is(.cm-md-h1, .cm-md-h2, .cm-md-h3, .cm-md-h4, .cm-md-h5, .cm-md-h6)
+        + :is(.cm-md-h1, .cm-md-h2, .cm-md-h3, .cm-md-h4, .cm-md-h5, .cm-md-h6)
+    ) {
+    padding-top: 0.5em;
+  }
+  /* Chip re-center when adjacent-heading collapse fires. New padding-top
+     in px: H1 0.5em=13.6, H2 11.48, H3 9.78. top = padding-top + line-height/2. */
+  .plaintext-editor
+    :global(
+      :is(.cm-md-h1, .cm-md-h2, .cm-md-h3, .cm-md-h4, .cm-md-h5, .cm-md-h6)
+        + .cm-md-h1::before
+    ) {
+    top: 30.6px;
+  }
+  .plaintext-editor
+    :global(
+      :is(.cm-md-h1, .cm-md-h2, .cm-md-h3, .cm-md-h4, .cm-md-h5, .cm-md-h6)
+        + .cm-md-h2::before
+    ) {
+    top: 26.4px;
+  }
+  .plaintext-editor
+    :global(
+      :is(.cm-md-h1, .cm-md-h2, .cm-md-h3, .cm-md-h4, .cm-md-h5, .cm-md-h6)
+        + .cm-md-h3::before
+    ) {
+    top: 22.97px;
+  }
+  /* Kill the default-highlight-style underline on lezer-markdown's
+     heading tag emissions. `syntaxHighlighting(defaultHighlightStyle)`
+     is mounted by plaintextDecorations() for fenced-code-block
+     coloring; it also paints `tag.heading` as underlined which lands
+     on every inline span inside a heading line (the `ͼN ͼM` classes).
+     Bear has no heading underline; strip it on the line scope so the
+     fenced-code highlight survives elsewhere. */
+  .plaintext-editor :global(.cm-line.cm-md-h1 *),
+  .plaintext-editor :global(.cm-line.cm-md-h2 *),
+  .plaintext-editor :global(.cm-line.cm-md-h3 *),
+  .plaintext-editor :global(.cm-line.cm-md-h4 *),
+  .plaintext-editor :global(.cm-line.cm-md-h5 *),
+  .plaintext-editor :global(.cm-line.cm-md-h6 *) {
+    text-decoration: none;
+  }
+
+  /* --- Inline emphasis / code -------------------------------------
+   * Bold capped at 650 so it doesn't punch above the heading weight.
+   * Inline code drops a touch below body x-height (0.88em) and gets a
+   * theme-tinted background — distinct from a fenced code block but
+   * sitting in the same monospace family. */
+  .plaintext-editor :global(.cm-md-bold) {
+    font-weight: 650;
+  }
+  .plaintext-editor :global(.cm-md-italic) {
+    font-style: italic;
+  }
+  .plaintext-editor :global(.cm-md-strike) {
+    text-decoration: line-through;
+  }
+  .plaintext-editor :global(.cm-md-code) {
+    font-family: var(
+      --rd-mono,
+      ui-monospace,
+      SFMono-Regular,
+      'SF Mono',
+      Menlo,
+      Consolas,
+      monospace
+    );
+    font-size: 0.88em;
+    background-color: var(--rd-hover, rgba(0, 0, 0, 0.05));
+    padding: 0.05em 0.35em;
+    border-radius: 0.25em;
+  }
+  /* Link label tint (Slice Q polish). `[label](url)` — the label
+     between `[` and `]` carries `.cm-md-link-label`; bracket/paren/URL
+     are hidden by the cursor-reveal pattern when the cursor is
+     outside the link, so off-cursor the user sees just the tinted
+     label as a clean link. No click handler here — that's a later
+     slice. Subtle blue tint; the body color is the default. The `*`
+     descendant rule kills the default-highlight-style underline on
+     `tag.link` (lezer-markdown's emission), keeping the look Bear-soft
+     rather than classic-blue-web. */
+  .plaintext-editor :global(.cm-md-link-label),
+  .plaintext-editor :global(.cm-md-link-label *) {
+    color: var(--rd-sky, #4a90e2);
+    text-decoration: none;
+  }
+
+  /* --- Link + wikilink click affordance (Slice 6) ---------------- *
+   * Pointer cursor on tinted labels so the click is signaled at
+   * hover. We always show the pointer (not gated on focus / mod
+   * keys) — matches the markdown editor's behavior where the
+   * tinted span is unambiguously interactive. Click-and-drag for
+   * text selection still works because CM6's selection handling
+   * runs on mousedown; pointer is purely a hover-time hint.
+   *
+   * The bracket / paren syntax chars carry `.cm-md-syntax` and are
+   * NOT in this rule, so when they're revealed (cursor inside the
+   * link) clicking them still positions the caret normally — the
+   * click handler only fires on the LABEL element. */
+  .plaintext-editor :global(.cm-md-link-label),
+  .plaintext-editor :global(.cm-md-wikilink-label) {
+    cursor: pointer;
+  }
+
+  /* --- Wikilink + footnote hover preview (Slice 6 + footnote slice) *
+   * `hoverTooltip` from @codemirror/view emits a positioned
+   * `.cm-tooltip` shell; we paint the inner `.cm-md-wikilink-preview`
+   * div with Bear-soft surface tones — translucent panel, hairline
+   * border, faint shadow, small body type. The data-state attribute
+   * distinguishes resolved (path text in default ink-2) from broken
+   * (muted ink-4 + italic "Note not found:") so the reader can
+   * disambiguate at a glance without color shouting.
+   *
+   * The footnote hover (`.cm-md-footnote-preview`) shares this exact
+   * visual register — it's the same kind of "small floating reference
+   * panel" affordance, just with definition-body text inside instead
+   * of a resolved-path string.
+   *
+   * Sizing: max-width caps the tooltip at a reading width so very
+   * deep paths wrap rather than running off-screen. `word-break:
+   * break-word` keeps long basenames from overflowing the cap.
+   *
+   * `pointer-events: none` is critical — the tooltip is purely
+   * informational, and without it the panel intercepts the click the
+   * user aimed at the link beneath, sending `event.target` to the
+   * tooltip and breaking the affordance handler's label-class match.
+   * (Symptom: cursor lands on the link's line, Shape A reveals raw
+   * markdown, click never follows.) */
+  :global(
+      .cm-tooltip:has(.cm-md-wikilink-preview),
+      .cm-tooltip:has(.cm-md-footnote-preview)
+    ) {
+    background: var(--rd-panel, #fdfdfd);
+    color: var(--rd-ink-2, rgba(0, 0, 0, 0.75));
+    border: 1px solid var(--rd-rule, rgba(0, 0, 0, 0.1));
+    border-radius: 6px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+    overflow: hidden;
+    pointer-events: none;
+  }
+  :global(.cm-md-wikilink-preview),
+  :global(.cm-md-footnote-preview) {
+    padding: 6px 10px;
+    font-family: var(
+      --rd-sans,
+      -apple-system,
+      'Inter Tight',
+      system-ui,
+      sans-serif
+    );
+    font-size: 13px;
+    line-height: 1.4;
+    max-width: 360px;
+    word-break: break-word;
+  }
+  :global(.cm-md-wikilink-preview[data-state='broken']) {
+    color: var(--rd-ink-4, rgba(0, 0, 0, 0.4));
+    font-style: italic;
+  }
+
+  /* --- Wikilink tints (Slice 5) ---------------------------------- *
+   * `[[note]]` and `[[note|alias]]` — the resolved-target label is
+   * tinted in the same Bear-soft sky tone as the `[label](url)` link
+   * (sibling kind of cross-reference; same prose-link affordance). The
+   * `[[` / `]]` bracket characters and the `|` (when an alias is
+   * present) follow the cursor-reveal pattern via the existing
+   * `.cm-md-syntax.cm-hidden` rules — off-cursor the reader sees just
+   * the tinted label, on-cursor the brackets reveal for editing.
+   *
+   * Resolved (`.cm-md-wikilink-label`): sky-tone color, no underline —
+   * matches the inline-link label so wikilinks read as cross-references
+   * in the same visual register, not as classic-blue-web hyperlinks.
+   *
+   * Broken (`.cm-md-wikilink-label.cm-md-wikilink-broken`): the
+   * resolved class always lands first, so we additionally override
+   * `color` with the muted ink tone and add a dotted-underline hint.
+   * The dotted underline is a "soft warning" signal — the link is
+   * still legible as a reference, but the reader sees at-a-glance
+   * that the target doesn't currently resolve. No bright red /
+   * strikethrough — that would conflict with Bear's calm-prose
+   * aesthetic and over-rotate on what's often a transient state
+   * (you're about to create the target note next).
+   *
+   * No click handler this slice (Slice 5 is parse + paint only). The
+   * click affordance + hover preview land in Slice 6. */
+  .plaintext-editor :global(.cm-md-wikilink-label),
+  .plaintext-editor :global(.cm-md-wikilink-label *) {
+    color: var(--rd-sky, #4a90e2);
+    text-decoration: none;
+  }
+  .plaintext-editor :global(.cm-md-wikilink-label.cm-md-wikilink-broken),
+  .plaintext-editor :global(.cm-md-wikilink-label.cm-md-wikilink-broken *) {
+    color: var(--rd-ink-4, rgba(0, 0, 0, 0.4));
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+    text-decoration-thickness: 1px;
+  }
+
+  /* --- Footnote reference (Slice 4 of plaintext Apple lane) ------- *
+   * Inline `[^id]` reference. Off-line the `[^` / `]` brackets hide
+   * via the standard cm-md-syntax.cm-hidden rule, leaving just the id
+   * text — which we style as a small superscript clickable span in
+   * the same Bear-soft sky tone the wikilink labels use (sibling
+   * cross-reference; same prose-link visual register). On-line the
+   * brackets reveal as raw markdown for editing.
+   *
+   * Broken (`.cm-md-footnote-ref-broken`): no matching FootnoteDef in
+   * the doc. Muted ink + dotted underline — same soft-warning pattern
+   * as broken wikilinks. */
+  .plaintext-editor :global(.cm-md-footnote-ref) {
+    vertical-align: super;
+    font-size: 0.75em;
+    line-height: 1;
+    color: var(--rd-sky, #4a90e2);
+    cursor: pointer;
+    text-decoration: none;
+  }
+  .plaintext-editor :global(.cm-md-footnote-ref.cm-md-footnote-ref-broken) {
+    color: var(--rd-ink-4, rgba(0, 0, 0, 0.4));
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+    text-decoration-thickness: 1px;
+  }
+
+  /* --- Footnote definition label (Bear Notes inline render) -------- *
+   * Block definition `[^id]: body text` renders in Bear style: the
+   * line flows as ordinary prose, with the id painted inline in link
+   * color and the `:` flowing as plain punctuation. No gutter chip,
+   * no card chrome — `[^` and `]` are hidden via the standard
+   * `cm-md-syntax.cm-hidden` rule (emitted from plaintext-decorations
+   * .ts), so off-cursor the user sees `name: body…`, with `name`
+   * tinted like a wikilink/link label.
+   *
+   * Cursor-on-line drops the label paint and reveals the raw `[^id]:`
+   * source — same reveal pattern as wikilinks and other inline marks. */
+  .plaintext-editor :global(.cm-md-footnote-label) {
+    color: var(--rd-sky, #4a90e2);
+    text-decoration: none;
+  }
+
+  /* --- Lists -------------------------------------------------------- *
+   * `.cm-md-listitem` lands on the FIRST source line of every
+   * ListItem (bullet or ordered). `.cm-md-listitem-depth-N` carries
+   * the nesting depth (0..5, clamped in the builder). Padding-left
+   * scales with depth so nested items visibly step rightward. Marker
+   * (`-` / `*` / `1.`) is always visible (Bear-style "bullet always
+   * present").
+   *
+   * Rhythm (Bear-tightened):
+   *   - depth-0 sits at 0.5em from the column-left — the bullet hugs
+   *     the margin so list-prose doesn't read as deeply inset against
+   *     surrounding paragraphs (matches Bear Notes' reference render).
+   *   - Each subsequent depth steps +1.25em — enough nesting signal
+   *     without ballooning the indent at deep levels.
+   *   - Marker has `margin-right: 0.5em` so there's a clear, body-em
+   *     gap between marker glyph and item text (Bear's bullet→text
+   *     gap reads at ~half a body em).
+   *   - Marker source-syntax font-size is bumped (was 0.7em → see the
+   *     `:first-child` rule below) so raw `- ` / `1.` is readable when
+   *     the cursor enters the line and source reveals.
+   *   - Color: bullets/numbers tint `--rd-sky` to share the link blue;
+   *     source-syntax stays in muted ink. */
+  .plaintext-editor :global(.cm-line.cm-md-listitem) {
+    padding-left: 0.5em;
+  }
+  .plaintext-editor :global(.cm-line.cm-md-listitem-depth-0) {
+    padding-left: 0.2em;
+  }
+  .plaintext-editor :global(.cm-line.cm-md-listitem-depth-1) {
+    padding-left: 1.75em;
+  }
+  .plaintext-editor :global(.cm-line.cm-md-listitem-depth-2) {
+    padding-left: 3em;
+  }
+  .plaintext-editor :global(.cm-line.cm-md-listitem-depth-3) {
+    padding-left: 4.25em;
+  }
+  .plaintext-editor :global(.cm-line.cm-md-listitem-depth-4) {
+    padding-left: 5.5em;
+  }
+  .plaintext-editor :global(.cm-line.cm-md-listitem-depth-5) {
+    padding-left: 6.75em;
+  }
+  /* Only the FIRST .cm-md-syntax span (the ListMark) gets the
+     quiet-marker + gap styling — other `.cm-md-syntax` spans in the
+     same line (wikilink brackets, emphasis marks, etc.) are sibling
+     direct children and would otherwise inherit the margin-right,
+     leaving visible whitespace next to hidden brackets.
+
+     Font-size kept at the body em (no shrink) so that when the cursor
+     enters a list line and the raw `- ` / `1.` source reveals, the
+     marker is legible. The off-cursor bullet/number is a WIDGET
+     (cm-md-bullet-glyph / cm-md-ordered-number) with its own size
+     register, so widget quietness is unaffected.
+
+     Column-width-match (Slice apple-list-alignment): the raw `- ` /
+     `1.` source occupies the SAME fixed-width column the off-cursor
+     BulletGlyphWidget / OrderedNumberWidget uses (font-size 0.8em,
+     width 1.6em, margin-right 0.5em, inline-block, text-align right).
+     Without this, body text shifted left ~1.1em when the cursor
+     entered a list line — the on-cursor reveal pushed the bullet
+     against the body. Now the column is stable; only the marker
+     swaps from glyph to source.
+
+     Task lines excluded via :not(.cm-md-listitem-task): task-bearing
+     items have their own visual column (the checkbox widget off-
+     cursor, raw `- [ ]` source on-cursor). Giving them the bullet
+     column would either push the off-cursor checkbox right by 1.6em
+     OR create a phantom column before the hidden ListMark. */
+  .plaintext-editor
+    :global(.cm-line.cm-md-listitem:not(.cm-md-listitem-task) > .cm-md-syntax:first-child),
+  .plaintext-editor
+    :global(.cm-line.cm-md-listitem:not(.cm-md-listitem-task) > .cm-md-syntax:first-child > *) {
+    color: var(--rd-ink-4, rgba(0, 0, 0, 0.4));
+    font-size: 0.8em;
+    display: inline-block;
+    width: 1.6em;
+    margin-right: 0.5em;
+    text-align: right;
+    vertical-align: baseline;
+  }
+
+  /* --- Task-list checkbox (Slice 3 → Slice L redesign) ------------- *
+   * Inline widget replacing the 3-char TaskMarker (`[ ]` / `[x]`) in a
+   * GFM task-list item. Slice L drops the bullet entirely on task-list
+   * lines (suppressed in the ListMark branch of plaintext-decorations.ts)
+   * so the row reads: checkbox · text. The leading affordance IS the
+   * checkbox; a redundant `-` next to it was loud + ugly.
+   *
+   * Visual register: NOT the browser-native `<input type="checkbox">`
+   * (the blue accent fought the editor's quiet palette). Instead a
+   * custom inline SVG widget in `currentColor`:
+   *   - Unchecked → an outlined rounded-corner square, faded to ~0.5
+   *     opacity. The border IS the glyph.
+   *   - Checked   → the Phosphor `Check` icon path, currentColor, no
+   *     tint. Reads as a typographic check mark, not a UI control.
+   *
+   * Both states track the body em — the box is 0.95em on a side so it
+   * scales with reading size. `vertical-align: -0.1em` nudges the box
+   * down a hair so the centre of the box aligns with text x-height
+   * (raw baseline-align reads as floating above the line).
+   *
+   * Dark-mode parity: every color reference uses `currentColor` or an
+   * `--rd-*` variable, so the same rules read clean against `--rd-bg`
+   * in both themes — no hardcoded hex for the glyph itself.
+   *
+   * Click behaviour unchanged from Slice 3 — mousedown on the wrap
+   * dispatches the source-text flip; see TaskCheckboxWidget.toDOM. */
+  .plaintext-editor :global(.cm-md-task-checkbox) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* Baseline-align so the box sits on the text baseline; the
+       -0.1em nudge counteracts the SVG's centre-relative-to-baseline
+       offset so the glyph optically aligns with x-height. */
+    vertical-align: -0.1em;
+    cursor: pointer;
+    /* Track the body em — 0.95em-square so the glyph reads at the
+       same visual weight as a list bullet / em-dash. */
+    width: 0.95em;
+    height: 0.95em;
+    /* Tiny gap before the body text so the row breathes. */
+    margin-right: 0.4em;
+    /* Quiet by default — both checked + unchecked states sit at low
+       opacity. Same ~0.5 register as cm-md-ink-4 muted ink. The
+       checked state's text gets a separate dim via the
+       .cm-md-listitem-task-checked rule below; the box itself stays
+       quiet so the line reads as a single, dimmed unit. */
+    color: currentColor;
+    opacity: 0.55;
+  }
+  .plaintext-editor :global(.cm-md-task-checkbox-unchecked) {
+    /* Rounded-corner outline square — the box IS the glyph. Use
+       `currentColor` so light/dark mode flips with the body ink.
+       The 1.25px border weight tracks the editor's hairline tokens
+       (cm-md-rule width). */
+    border: 1.25px solid currentColor;
+    border-radius: 3px;
+  }
+  .plaintext-editor :global(.cm-md-task-checkbox-checked) {
+    /* No border on the checked state — the check glyph is the
+       affordance. Box dimensions persist so the row's horizontal
+       rhythm doesn't shift on toggle (preventing layout jitter when
+       the user clicks).
+       Bump the opacity slightly higher than unchecked so the check
+       glyph reads cleanly; the text strike-through carries the
+       "completed" register, so the check itself can be a touch
+       firmer without competing. */
+    opacity: 0.75;
+  }
+  .plaintext-editor :global(.cm-md-task-checkbox-glyph) {
+    /* The SVG fills the wrap's content box; `display: block` removes
+       inline-baseline whitespace below the SVG. */
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+
+  /* Slice L: strike-through + dim the BODY text of a checked task
+     line. Scoped tightly — the checkbox widget is excluded via
+     direct-descendant `:not()` so the box itself stays unstyled
+     (a struck-through checkbox would compound visual noise).
+     The line's `.cm-md-listitem` line deco gives us the cm-line
+     class; this rule layers on top.
+     Both `text-decoration` AND opacity for a soft, Bear-clean
+     completed register — strikethrough alone reads as a hard edit,
+     dim alone reads as a draft. Combined they say "done & quiet". */
+  .plaintext-editor :global(.cm-line.cm-md-listitem-task-checked) {
+    opacity: 0.5;
+  }
+  /* Strikethrough is applied as a Decoration.mark over just the body
+     range (after the TaskMarker), not on the line as a whole. CSS
+     parent text-decoration draws across every in-flow descendant
+     including zero-width .cm-hidden chars, so a line-scope line-
+     through would read as a short leading dash before the checkbox.
+     Scoping to the body mark avoids that bleed entirely. */
+  .plaintext-editor :global(.cm-md-listitem-task-checked-body) {
+    text-decoration: line-through;
+    text-decoration-color: currentColor;
+  }
+
+  /* --- Bullet glyphs + ordered numbers (Slice L) ----------------- *
+   * Inline widgets replacing the `ListMark` source range when the
+   * cursor is OFF the enclosing ListItem. Cursor INSIDE reveals raw
+   * source (handled in plaintext-decorations.ts via the visible
+   * cm-md-syntax mark — styled small + muted by the first-child rule
+   * above, same as before).
+   *
+   * Visual register: same family as the existing quiet-marker rule
+   * (small, muted). currentColor + opacity so dark/light mode flips
+   * cleanly without hardcoded hex.
+   *
+   * The two widget classes share styling so the visual family
+   * (bullet glyph + ordered number) reads as one register — both
+   * are typographic ornaments, not UI chrome. */
+  /* Both widget classes share a fixed-width marker column so the body
+     text starts at the same x position regardless of glyph kind or
+     number length. Single-digit `1.` and double-digit `10.` and a bullet
+     `●` all occupy the same 1.6em right-aligned column.
+
+     Color: `--rd-sky` so bullets / numbers share the link-blue family
+     with `[link]` / `[[wikilink]]` / `[^footnote]` labels — every
+     inline accent in the editor reads in one voice. Opacity stays a
+     touch under 1.0 so the marker is present but doesn't shout. */
+  .plaintext-editor :global(.cm-md-bullet-glyph),
+  .plaintext-editor :global(.cm-md-ordered-number) {
+    display: inline-block;
+    color: var(--rd-sky, #4a90e2);
+    opacity: 0.85;
+    font-size: 0.8em;
+    width: 1.6em;
+    margin-right: 0.5em;
+    text-align: right;
+    vertical-align: baseline;
+  }
+  /* SVG bullet glyph: 0.75em square so it visually matches the cap-
+     height of a number / lowercase letter at the same font-size; sits
+     on the baseline (small translateY nudge to land it on the text
+     baseline cleanly). currentColor on the SVG fill so dark/light flip
+     just works (the parent `.cm-md-bullet-glyph` now sets color to
+     `--rd-sky` so the SVG inherits the link-blue tint). */
+  .plaintext-editor :global(.cm-md-bullet-glyph svg) {
+    width: 0.6em;
+    height: 0.6em;
+    vertical-align: -0.05em;
+    display: inline-block;
+  }
+  .plaintext-editor :global(.cm-md-ordered-number) {
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* --- Blockquote as callout (Slice p polish) --------------------- *
+   * Callout shape: thick accent bar + subtle tinted background. Each
+   * blockquote line gets the line deco, so the bar + tint paints
+   * continuously down a multi-line quote. The first / last lines
+   * round the corners so the run reads as a single unit.
+   *
+   * Accent: `--rd-sky` (cool blue, available in the redesign tokens).
+   * Distinct from selection highlights so callouts read as content. */
+  .plaintext-editor :global(.cm-line.cm-md-blockquote) {
+    border-left: 4px solid var(--rd-sky, #7fb9e5);
+    background-color: color-mix(
+      in oklch,
+      var(--rd-sky, #7fb9e5) 8%,
+      transparent
+    );
+    padding-left: 1em;
+    /* Slice Q polish: open the text from the top/bottom borders.
+       Blockquotes are line decos (not widgets), so per-line padding
+       is the only knob — first/last/middle can't differ structurally.
+       0.45em each opens single-line quotes without bloating them and
+       gives multi-line quotes airy interior rhythm. */
+    padding-top: 0.45em;
+    padding-bottom: 0.45em;
+    /* External top margin pushes the blockquote away from the
+       preceding heading/paragraph so the tinted card doesn't crowd
+       it. ONLY the first line of a blockquote should carry this —
+       the adjacent-sibling rule below zeros it for consecutive
+       blockquote lines so a multi-line quote reads as one block,
+       not a stack of separately-spaced lines. No `margin-bottom`;
+       the next content's own `margin-top` handles separation. */
+    margin-top: 0.6em;
+    color: var(--rd-ink-2, rgba(0, 0, 0, 0.75));
+    font-style: italic;
+  }
+  .plaintext-editor
+    :global(.cm-line.cm-md-blockquote + .cm-line.cm-md-blockquote) {
+    margin-top: 0;
+  }
+
+  /* --- Fenced code block (Slice 2, Slice T polish + decompose) --- *
+   * Two-layer decoration so the monospace font survives the cursor-
+   * enter "reveal" transition without the body reflowing into the
+   * editor's serif face:
+   *
+   *   - `.cm-md-code-block-text`  → TYPOGRAPHY layer. Monospace family
+   *     + tightened font-size + line-height. ALWAYS applied to fence
+   *     content lines, regardless of cursor position. This is the
+   *     "this is code, not prose" signal — it must NOT toggle as the
+   *     user clicks in / out of the fence.
+   *
+   *   - `.cm-md-code-block-card`  → CARD-CHROME layer. Background tint
+   *     + side padding. ONLY applied off-fence. Paired with the
+   *     positional `.cm-md-code-fence-{top,middle,bottom,only}`
+   *     classes that add the border + radius so the run reads as a
+   *     single rounded slab. Off-fence the user sees a card; on-fence
+   *     the card vanishes (the user is editing raw markdown), but the
+   *     code text stays monospace at the same size and line-height,
+   *     so only the chrome moves — the text doesn't shift horizontally
+   *     or reflow.
+   *
+   * Inner syntax highlighting lights up automatically via
+   * syntaxHighlighting(defaultHighlightStyle) wired in
+   * plaintextDecorations() — CM6 emits `.tok-keyword`, `.tok-string`,
+   * etc. on inline spans inside the fence body. Those tok-* spans are
+   * scoped under the code-block-text rule's monospace family via
+   * font-family inheritance.
+   *
+   * Font-size tightened from 0.88em to 0.82em (matches a request from
+   * the design pass — monospace reads larger than proportional at
+   * equal pixel height, so the inline-code rule's 0.88em is too big
+   * for a multi-line fence block). Line-height tightened from the
+   * inherited 1.65 (set on .cm-scroller) down to 1.4 for the same
+   * reason — code wants tighter vertical rhythm. */
+  .plaintext-editor :global(.cm-line.cm-md-code-block-text) {
+    font-family:
+      ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas,
+      'Liberation Mono', monospace;
+    font-size: 0.82em;
+    line-height: 1.4;
+  }
+  .plaintext-editor :global(.cm-line.cm-md-code-block-card) {
+    background-color: var(--rd-code-bg, rgba(0, 0, 0, 0.045));
+    padding: 0 1em;
+  }
+  /* --- Fence delimiter line collapse (off-fence) ------------------ *
+   * `.cm-md-code-fence-delim` only lands on opening / closing fence
+   * lines when the cursor is OFF the fence. Collapsing to zero height
+   * via font-size + line-height + padding makes the visual code box
+   * snap up against the surrounding prose. On-fence, the decoration
+   * builder emits NO line decoration on delimiter lines so they
+   * render at full size as plain prose (raw ` ```ts ` / ` ``` ` for
+   * editing); content lines keep `cm-md-code-block-text` so the body
+   * stays monospace at the same size across the toggle. */
+  .plaintext-editor :global(.cm-line.cm-md-code-fence-delim) {
+    font-size: 0;
+    line-height: 0;
+    padding: 0;
+    background-color: transparent;
+    /* Smooth the collapse so cursor enter/exit doesn't snap. */
+    transition:
+      font-size 120ms ease,
+      line-height 120ms ease,
+      padding 120ms ease;
+  }
+  /* --- Fence content-line frame (border + radius) ----------------- *
+   * Top / middle / bottom classes paint a single rounded box across
+   * all content lines of the fence. Top line rounds top-{left,right};
+   * bottom line rounds bottom-{left,right}; middle keeps straight
+   * sides. Border-top on top, border-bottom on bottom, side borders
+   * on every content line so the run reads as one slab.
+   *
+   * `*-only` covers the single-content-line case (rounds all four
+   * corners + full border). All four classes share the side borders +
+   * padding-block via the multi-selector below. */
+  .plaintext-editor :global(.cm-line.cm-md-code-fence-top),
+  .plaintext-editor :global(.cm-line.cm-md-code-fence-middle),
+  .plaintext-editor :global(.cm-line.cm-md-code-fence-bottom),
+  .plaintext-editor :global(.cm-line.cm-md-code-fence-only) {
+    position: relative;
+    border-left: 1px solid var(--rd-rule, rgba(0, 0, 0, 0.08));
+    border-right: 1px solid var(--rd-rule, rgba(0, 0, 0, 0.08));
+  }
+  .plaintext-editor :global(.cm-line.cm-md-code-fence-top) {
+    border-top: 1px solid var(--rd-rule, rgba(0, 0, 0, 0.08));
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+    padding-top: 0.75em;
+  }
+  .plaintext-editor :global(.cm-line.cm-md-code-fence-bottom) {
+    border-bottom: 1px solid var(--rd-rule, rgba(0, 0, 0, 0.08));
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
+    padding-bottom: 0.75em;
+  }
+  .plaintext-editor :global(.cm-line.cm-md-code-fence-only) {
+    border-top: 1px solid var(--rd-rule, rgba(0, 0, 0, 0.08));
+    border-bottom: 1px solid var(--rd-rule, rgba(0, 0, 0, 0.08));
+    border-radius: 6px;
+    padding-top: 0.75em;
+    padding-bottom: 0.75em;
+  }
+  /* --- Language label (top-right corner) -------------------------- *
+   * `data-fence-lang` lands on the first content line (Top or Only)
+   * carrying the trimmed info-string from the opening ` ``` `. CSS
+   * paints it as a small muted label in the top-right corner of the
+   * rendered box. `pointer-events: none` so it doesn't intercept
+   * clicks that should land in the code text. */
+  .plaintext-editor :global(.cm-line.cm-md-code-fence-top[data-fence-lang]),
+  .plaintext-editor :global(.cm-line.cm-md-code-fence-only[data-fence-lang]) {
+    /* `position: relative` is already set by the side-border rule
+       above; restate for clarity — `::after` is positioned within. */
+    position: relative;
+  }
+  .plaintext-editor
+    :global(.cm-line.cm-md-code-fence-top[data-fence-lang]::after),
+  .plaintext-editor
+    :global(.cm-line.cm-md-code-fence-only[data-fence-lang]::after) {
+    content: attr(data-fence-lang);
+    position: absolute;
+    top: 0.35em;
+    right: 0.7em;
+    font-family: var(
+      --rd-mono,
+      ui-monospace,
+      SFMono-Regular,
+      'SF Mono',
+      Menlo,
+      Consolas,
+      monospace
+    );
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--rd-ink-4, rgba(0, 0, 0, 0.4));
+    pointer-events: none;
+    user-select: none;
+  }
+
+  /* --- Horizontal rule (Slice R) ---------------------------------- *
+   * `---` / `***` / `___` on its own line → thin hairline rule, Bear-
+   * style. The decoration builder emits a `.cm-md-hr` line deco plus
+   * a `cm-md-syntax` mark on the source chars (hidden off-cursor via
+   * the cm-md-syntax.cm-hidden rule below, revealed on-cursor).
+   *
+   * Off-cursor (`:not(.cm-activeLine)`): the source chars collapse to
+   * zero width via `font-size: 0` so the line's content height is ~0.
+   * A `::before` pseudo paints the actual hairline, sitting in roomy
+   * vertical padding so the rule reads as a quiet break in the flow.
+   *
+   * On-cursor (.cm-activeLine): no border, no pseudo. The chars
+   * reveal at full size and the user sees raw `---` for editing.
+   * `highlightActiveLine()` is mounted in the editor's extension list,
+   * which adds `.cm-activeLine` to the line currently containing the
+   * caret.
+   *
+   * Thin (1px) + low-alpha rule via `--rd-rule` so it doesn't compete
+   * with body text / headings. Padding (not margin) for CM6 heightmap
+   * correctness — same border-box reasoning as the heading and table
+   * fixes. */
+  .plaintext-editor :global(.cm-line.cm-md-hr) {
+    position: relative;
+    padding-top: 0.8em;
+    padding-bottom: 0.8em;
+  }
+  .plaintext-editor :global(.cm-line.cm-md-hr:not(.cm-activeLine))::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 50%;
+    border-top: 1px solid var(--rd-rule, rgba(0, 0, 0, 0.1));
+  }
+
+  /* --- Syntax-character hide/reveal (Slice p polish) -------------- *
+   * `cm-md-syntax` is emitted on EVERY syntax-char span; `cm-hidden`
+   * is added on top when the cursor sits OUTSIDE the enclosing
+   * decorated range. So:
+   *   - cursor outside  →  span has both classes  →  collapsed + faded
+   *   - cursor inside   →  span has only cm-md-syntax  →  full size
+   *
+   * Smooth transitions: we can't animate `display: none`, so the hidden
+   * state uses `font-size: 0` + `opacity: 0` instead. That zeros the
+   * span's rendered width (no residual character cell) while still
+   * letting both sides animate. The 120ms ease is fast enough to feel
+   * snappy on cursor-enter / cursor-exit, slow enough to read as a
+   * fade rather than a flash.
+   *
+   * Important: `font-size: 0` collapses the span's inline width but
+   * leaves it in the flow as a 0-width box; CM6's selection painter
+   * still positions the caret at the underlying source position
+   * correctly because the source offset hasn't changed — only the
+   * visual width has.
+   *
+   * The build pass in plaintext-decorations.ts toggles which mark
+   * (hiddenSyntaxMark vs visibleSyntaxMark) lands on each syntax
+   * range per-update; the CSS just reads the resulting class set. */
+  .plaintext-editor :global(.cm-md-syntax) {
+    transition:
+      font-size 120ms ease,
+      opacity 120ms ease;
+  }
+  .plaintext-editor :global(.cm-md-syntax.cm-hidden) {
+    font-size: 0;
+    opacity: 0;
+  }
+
+  /* --- Tables (Slice p polish) ------------------------------------ *
+   * Rounded corners + soft shadow + tinted header row. `border-collapse:
+   * separate` is required so border-radius on the outer table actually
+   * clips the corner cells; `overflow: hidden` on the wrapper would
+   * normally do it but tables can't crop their own children via
+   * overflow. Inner cell borders use a hairline rule so the grid still
+   * reads without competing with the outer shadow.
+   *
+   * Per-cell `text-align` is applied inline by TableWidget.toDOM —
+   * keep that wins-the-cascade pattern intact (no default text-align
+   * here).
+   *
+   * Padding lives on the `.cm-md-table-wrap` div, not as `margin` on
+   * the table itself: CM6's heightmap measures the widget's outer DOM
+   * element via `getBoundingClientRect().height`, which is the
+   * border-box and excludes margin. A bare `<table>` with `margin: 1em
+   * 0` would make CM6 under-count the widget's visual height by ~32px
+   * and clicks below the table would drift below the visual target
+   * (same bug class as the heading margin→padding fix in commit
+   * e8875767). The wrap div's padding stays inside the border-box so
+   * CM6 reads the full visual height and click-to-position stays
+   * aligned. */
+  .plaintext-editor :global(.cm-md-table-wrap) {
+    padding-top: 1em;
+    padding-bottom: 1em;
+  }
+  .plaintext-editor :global(table.cm-md-table) {
+    border-collapse: separate;
+    border-spacing: 0;
+    font-size: 0.95em;
+    line-height: 1.5;
+    max-width: 100%;
+    overflow: hidden;
+    display: table;
+    border-radius: 6px;
+    /* Outer frame so the table reads as a "table in a margin" rather
+       than fading into the document. The same hairline weight as code
+       fences (Slice T) — both block constructs sit in the same visual
+       register. Interior cell rules are stripped at last-child to
+       avoid double-strokes against this outer border (see the
+       `:last-child` rules below). */
+    border: 1px solid var(--rd-rule, rgba(0, 0, 0, 0.08));
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.06),
+      0 1px 2px rgba(0, 0, 0, 0.04);
+  }
+  .plaintext-editor :global(table.cm-md-table th),
+  .plaintext-editor :global(table.cm-md-table td) {
+    border-right: 1px solid var(--rd-rule, rgba(0, 0, 0, 0.07));
+    border-bottom: 1px solid var(--rd-rule, rgba(0, 0, 0, 0.07));
+    padding: 0.5em 0.75em;
+    vertical-align: top;
+  }
+  /* Strip the right border on the last column and the bottom border
+     on the last row so the rounded outer frame doesn't fight an inner
+     line one pixel inside it. */
+  .plaintext-editor :global(table.cm-md-table th:last-child),
+  .plaintext-editor :global(table.cm-md-table td:last-child) {
+    border-right: none;
+  }
+  .plaintext-editor :global(table.cm-md-table tbody tr:last-child td) {
+    border-bottom: none;
+  }
+  .plaintext-editor :global(table.cm-md-table thead th) {
+    background-color: color-mix(
+      in oklch,
+      var(--rd-sky, #7fb9e5) 10%,
+      transparent
+    );
+    font-weight: 600;
+    color: var(--rd-ink-1, #1a1d22);
+  }
+  /* Subtle zebra — barely perceptible, just enough to track rows. */
+  .plaintext-editor :global(table.cm-md-table tbody tr:nth-child(even) td) {
+    background-color: var(--rd-rule-soft, rgba(0, 0, 0, 0.02));
+  }
+
+  /* --- Images (Slice 4) ------------------------------------------- *
+   * Inline widget — `<span class="cm-md-image-widget"><img></span>`.
+   * The span wrapper renders inline so an image inside a paragraph
+   * sits with surrounding text; the img itself uses inline-block so
+   * the natural baseline aligns reasonably with text. `max-width:
+   * 100%` keeps wide images contained; `height: auto` preserves
+   * aspect ratio. No captions, no custom sizing in v1. */
+  .plaintext-editor :global(.cm-md-image-widget) {
+    display: inline;
+  }
+  .plaintext-editor :global(img.cm-md-image) {
+    max-width: 100%;
+    height: auto;
+    display: inline-block;
+    vertical-align: middle;
+    /* Subtle border so a transparent image is still visually
+       discernible (and matches the table border weight). */
+    border-radius: 3px;
+  }
+  /* Broken-image fallback — Phosphor ImageBroken glyph + optional alt
+     text. Replaces the browser's default broken-image icon (OS-
+     specific, jarring) with a muted in-language indicator. Tinted to
+     match the inline-code muted-state color (ink-4) so it reads as a
+     quiet "this didn't load" signal rather than an error. */
+  .plaintext-editor :global(.cm-md-image-widget[data-state='broken']) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    /* Align the flex box itself with the surrounding text baseline so the
+       glyph + alt text flow with the paragraph instead of floating above
+       the line (an inline-flex box defaults to `vertical-align: baseline`
+       on its bottom edge, which sits too high). */
+    vertical-align: middle;
+  }
+  .plaintext-editor :global(.cm-md-image-broken) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    color: var(--rd-ink-4, rgba(0, 0, 0, 0.4));
+    vertical-align: middle;
+  }
+  .plaintext-editor :global(.cm-md-image-broken svg) {
+    flex: none;
+  }
+  .plaintext-editor :global(.cm-md-image-broken-alt) {
+    font-size: 0.88em;
+    font-style: italic;
+    color: var(--rd-ink-4, rgba(0, 0, 0, 0.4));
+  }
+
+  /* --- Pending-upload spinner (Slice 2 Apple lane) ---------------- *
+   * Inline spinner shown while a paste/drop image upload is in flight.
+   * The image widget renders `<span class="cm-md-image-spinner">…</span>`
+   * for any URL that starts with `pending-upload://` (sentinel scheme
+   * minted by plaintext-image-upload.ts). Once the upload resolves the
+   * URL is Y.Text-swapped to the real path and the widget rebuilds as
+   * a regular <img>.
+   *
+   * Minimal visual: a Phosphor CircleNotch arc, rotated via CSS
+   * keyframes. Sits in the same muted ink tone as the broken-image
+   * fallback so the optimistic / failed states share a visual register.
+   * Same vertical-align rule as the broken-image widget so the spinner
+   * tracks the surrounding text baseline. */
+  .plaintext-editor :global(.cm-md-image-widget[data-state='pending']) {
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+  }
+  .plaintext-editor :global(.cm-md-image-spinner) {
+    display: inline-flex;
+    align-items: center;
+    color: var(--rd-ink-4, rgba(0, 0, 0, 0.4));
+    animation: cm-md-image-spin 0.9s linear infinite;
+    vertical-align: middle;
+  }
+  @keyframes cm-md-image-spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+</style>

--- a/packages/editor/src/lib/PlaintextEditor.undo.test.ts
+++ b/packages/editor/src/lib/PlaintextEditor.undo.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
+import {
+  PLAINTEXT_AGENT_ORIGIN,
+  PLAINTEXT_USER_ORIGIN,
+} from './content-format';
+
+/**
+ * Substrate contract tests for `<PlaintextEditor>`'s undo gate.
+ *
+ * The component mounts an actual CodeMirror 6 EditorView, which is
+ * impractical to instantiate in this repo's vitest config (no DOM
+ * environment configured — see `vitest.config.ts`; all existing tests
+ * are pure-logic). Mounting CM6 needs JSDOM/happy-dom + @testing-
+ * library/svelte, which would be a much larger addition than this
+ * slice warrants.
+ *
+ * Instead, these tests pin the *substrate contract* the component
+ * builds on: a `Y.UndoManager` configured with `trackedOrigins: new
+ * Set([PLAINTEXT_USER_ORIGIN])` against the `Y.Text` at
+ * the bound Markdown `Y.Text`. We then exercise the same transact-with-
+ * origin pattern the component uses for local edits and agent
+ * splices, and assert the undo gate behaves per the spec:
+ *
+ *   - User edits are undoable.
+ *   - Agent splices ('plaintext-agent') are NOT undoable.
+ *   - Updates with `null` origin (hydrate-like / system) are NOT
+ *     undoable.
+ *
+ * If `<PlaintextEditor>` drifts from this transaction-origin
+ * contract, these tests stay green but the editor would visibly
+ * break — that's the seam Slice 5's two-browser smoke catches. The
+ * spec layer is what we pin here.
+ *
+ * Spec: `docs/plans/2026-05-13-plaintext-shadow-track.md`
+ *   §"Undo and origin tagging"
+ */
+
+function setup(initial = '') {
+  const doc = new Y.Doc();
+  const ytext = doc.getText('markdown');
+  if (initial.length > 0) {
+    // Seed without polluting the undo stack — seed comes from hydrate,
+    // not from the user. `null` origin matches what `Y.applyUpdate`
+    // would write if hydration ever lacked an explicit origin.
+    doc.transact(() => {
+      ytext.insert(0, initial);
+    }, null);
+  }
+  const undoManager = new Y.UndoManager(ytext, {
+    trackedOrigins: new Set([PLAINTEXT_USER_ORIGIN]),
+  });
+  return { doc, ytext, undoManager };
+}
+
+describe('PlaintextEditor undo gate (substrate contract)', () => {
+  it('undoes a local user edit', () => {
+    const { doc, ytext, undoManager } = setup('hello');
+    doc.transact(() => {
+      ytext.insert(ytext.length, ' world');
+    }, PLAINTEXT_USER_ORIGIN);
+    expect(ytext.toJSON()).toBe('hello world');
+    undoManager.undo();
+    expect(ytext.toJSON()).toBe('hello');
+  });
+
+  it('does NOT undo an agent splice', () => {
+    const { doc, ytext, undoManager } = setup('hello');
+    // Agent splice — the same shape `applyEditNote` will emit on the
+    // server side for plaintext (Slice 2). Origin is the string
+    // sentinel `PLAINTEXT_AGENT_ORIGIN`.
+    doc.transact(() => {
+      ytext.insert(0, 'AGENT: ');
+    }, PLAINTEXT_AGENT_ORIGIN);
+    expect(ytext.toJSON()).toBe('AGENT: hello');
+    // Undo should be a no-op — the undo stack is empty (no tracked
+    // origins emitted anything).
+    undoManager.undo();
+    expect(ytext.toJSON()).toBe('AGENT: hello');
+  });
+
+  it('does NOT undo a null-origin (system / hydrate) update', () => {
+    const { doc, ytext, undoManager } = setup('hello');
+    doc.transact(() => {
+      ytext.insert(0, 'HYDRATED: ');
+    }, null);
+    expect(ytext.toJSON()).toBe('HYDRATED: hello');
+    undoManager.undo();
+    expect(ytext.toJSON()).toBe('HYDRATED: hello');
+  });
+
+  it('preserves the agent splice when user undo runs after both edits', () => {
+    // The realistic concurrent edit scenario: agent splice lands,
+    // user types more, user hits Ctrl-Z. Only the user's keystrokes
+    // should reverse — the agent's edit stays.
+    const { doc, ytext, undoManager } = setup('hello');
+    doc.transact(() => {
+      ytext.insert(0, 'AGENT: ');
+    }, PLAINTEXT_AGENT_ORIGIN);
+    doc.transact(() => {
+      ytext.insert(ytext.length, '!');
+    }, PLAINTEXT_USER_ORIGIN);
+    expect(ytext.toJSON()).toBe('AGENT: hello!');
+    undoManager.undo();
+    // User keystroke gone, agent prefix preserved.
+    expect(ytext.toJSON()).toBe('AGENT: hello');
+    // No further undo work — second undo is a no-op.
+    undoManager.undo();
+    expect(ytext.toJSON()).toBe('AGENT: hello');
+  });
+
+  it('redoes a previously undone user edit', () => {
+    const { doc, ytext, undoManager } = setup('hello');
+    doc.transact(() => {
+      ytext.insert(ytext.length, ' world');
+    }, PLAINTEXT_USER_ORIGIN);
+    undoManager.undo();
+    expect(ytext.toJSON()).toBe('hello');
+    undoManager.redo();
+    expect(ytext.toJSON()).toBe('hello world');
+  });
+
+  it('exposes user transactions with origin === PLAINTEXT_USER_ORIGIN', () => {
+    // Wire-side guarantee: whatever else changes about the binding,
+    // the spec contract is that local CM6 edits enter Yjs with this
+    // exact string origin so downstream observers and debug tooling
+    // can discriminate.
+    const { doc, ytext } = setup();
+    const seenOrigins: unknown[] = [];
+    doc.on('afterTransaction', (tr) => seenOrigins.push(tr.origin));
+    doc.transact(() => {
+      ytext.insert(0, 'hi');
+    }, PLAINTEXT_USER_ORIGIN);
+    expect(seenOrigins).toContain(PLAINTEXT_USER_ORIGIN);
+  });
+});

--- a/packages/editor/src/lib/content-format.ts
+++ b/packages/editor/src/lib/content-format.ts
@@ -1,0 +1,3 @@
+export const PLAINTEXT_USER_ORIGIN = 'plaintext-user';
+export const PLAINTEXT_AGENT_ORIGIN = 'plaintext-agent';
+

--- a/packages/editor/src/lib/index.ts
+++ b/packages/editor/src/lib/index.ts
@@ -1,0 +1,7 @@
+export { default as PlaintextEditor } from './PlaintextEditor.svelte';
+export {
+  PLAINTEXT_AGENT_ORIGIN,
+  PLAINTEXT_USER_ORIGIN,
+} from './content-format';
+export type { LivePath, OrgPerson } from './markdown-core';
+

--- a/packages/editor/src/lib/markdown-core.ts
+++ b/packages/editor/src/lib/markdown-core.ts
@@ -1,0 +1,158 @@
+import {
+  accentForId,
+  accentHex,
+  accentHexForId,
+  type AccentName,
+} from '@kb-2/ui';
+
+export { accentForId, accentHex, accentHexForId, type AccentName };
+
+export const MENTION_URL_SCHEME = 'mention:' as const;
+
+export interface MentionParts {
+  email: string;
+}
+
+export function parseMentionUrl(href: string): MentionParts | null {
+  if (!href.startsWith(MENTION_URL_SCHEME)) return null;
+  const payload = href.slice(MENTION_URL_SCHEME.length);
+  if (payload.length === 0) return null;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(payload);
+  } catch {
+    return null;
+  }
+  const atIdx = decoded.indexOf('@');
+  if (atIdx === -1) return null;
+  if (decoded.includes('@', atIdx + 1)) return null;
+  const local = decoded.slice(0, atIdx);
+  const domain = decoded.slice(atIdx + 1);
+  if (local.length === 0 || domain.length === 0) return null;
+  return { email: decoded };
+}
+
+export interface OrgPerson {
+  id: string;
+  email: string;
+  name: string;
+  image: string | null;
+}
+
+export function resolvePerson(
+  email: string,
+  orgPeople: readonly OrgPerson[],
+): OrgPerson | null {
+  const target = email.toLowerCase();
+  for (const person of orgPeople) {
+    if (person.email.toLowerCase() === target) return person;
+  }
+  return null;
+}
+
+export interface WikilinkParts {
+  target: string;
+  heading: string;
+  alias?: string;
+}
+
+export function parseWikilinkInner(inner: string): WikilinkParts | null {
+  const pipeIdx = inner.indexOf('|');
+  let targetAndHeading: string;
+  let alias: string | undefined;
+  if (pipeIdx === -1) {
+    targetAndHeading = inner;
+  } else {
+    targetAndHeading = inner.slice(0, pipeIdx);
+    const rawAlias = inner.slice(pipeIdx + 1).trim();
+    alias = rawAlias.length === 0 ? undefined : rawAlias;
+  }
+  const hashIdx = targetAndHeading.indexOf('#');
+  let target: string;
+  let heading: string;
+  if (hashIdx === -1) {
+    target = targetAndHeading.trim();
+    heading = '';
+  } else {
+    target = targetAndHeading.slice(0, hashIdx).trim();
+    heading = targetAndHeading.slice(hashIdx + 1).trim();
+  }
+  if (target.length === 0) return null;
+  return alias === undefined ? { target, heading } : { target, heading, alias };
+}
+
+export interface LivePath {
+  path: string;
+  noteId: string;
+}
+
+const RESOLVABLE_EXTENSIONS = ['.md', '.txt'] as const;
+
+function basenameNoExt(path: string): string {
+  const slashIdx = path.lastIndexOf('/');
+  const base = slashIdx === -1 ? path : path.slice(slashIdx + 1);
+  return stripEditorExtension(base);
+}
+
+function stripEditorExtension(s: string): string {
+  for (const ext of RESOLVABLE_EXTENSIONS) {
+    if (s.endsWith(ext)) return s.slice(0, -ext.length);
+  }
+  return s;
+}
+
+export function resolveLinkTarget(params: {
+  raw: string;
+  livePaths: readonly LivePath[];
+}): LivePath | null {
+  const { raw, livePaths } = params;
+  for (const candidate of livePaths) {
+    if (candidate.path === raw) return candidate;
+    for (const ext of RESOLVABLE_EXTENSIONS) {
+      if (candidate.path === `${raw}${ext}`) return candidate;
+    }
+  }
+
+  const rawNoExt = stripEditorExtension(raw);
+  const target = rawNoExt.toLowerCase();
+  let sole: LivePath | null = null;
+  let multiple = false;
+  for (const candidate of livePaths) {
+    if (basenameNoExt(candidate.path).toLowerCase() === target) {
+      if (sole === null) {
+        sole = candidate;
+      } else {
+        multiple = true;
+        break;
+      }
+    }
+  }
+  if (sole !== null && !multiple) return sole;
+
+  if (rawNoExt.includes('/')) {
+    sole = null;
+    multiple = false;
+    for (const candidate of livePaths) {
+      let hit = false;
+      for (const ext of RESOLVABLE_EXTENSIONS) {
+        const withExt = `${rawNoExt}${ext}`;
+        if (candidate.path === withExt || candidate.path.endsWith(`/${withExt}`)) {
+          hit = true;
+          break;
+        }
+      }
+      if (hit) {
+        if (sole === null) {
+          sole = candidate;
+        } else {
+          multiple = true;
+          break;
+        }
+      }
+    }
+    if (sole !== null && !multiple) return sole;
+  }
+
+  return null;
+}
+

--- a/packages/editor/src/lib/plaintext-decorations.test.ts
+++ b/packages/editor/src/lib/plaintext-decorations.test.ts
@@ -1,0 +1,1950 @@
+import { describe, expect, it } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { syntaxTree } from '@codemirror/language';
+import type { SyntaxNode } from '@lezer/common';
+import { accentForId } from './markdown-core';
+import {
+  plaintextDecorations,
+  buildMarkdownDecorations,
+  parseImageNode,
+  parseTableNode,
+  parseTableCellInlineMarkdown,
+  parseColumnAlignment,
+  unescapeMarkdownInline,
+} from './plaintext-decorations';
+
+/**
+ * Unit tests for Slice 4 fix-pass — table + image live-preview
+ * decorations.
+ *
+ * The vitest config has no DOM environment (see vitest.config.ts), so we
+ * exercise the pure pieces:
+ *
+ *   - `buildMarkdownDecorations(state, selection, opts)` — given an
+ *     `EditorState` it returns a `DecorationSet`. No view required.
+ *   - `parseImageNode(node, state)` — pure helper.
+ *   - `parseTableNode(node, state)` — pure helper.
+ *   - `parseColumnAlignment(cell)` and `unescapeMarkdownInline(text)`
+ *     — string-level pure helpers.
+ *   - `EditorState.create({ extensions: [plaintextDecorations()] })` —
+ *     the full extension construction path. The CRITICAL "editor mounts
+ *     at all" regression test pins this; Slice 4's original landing
+ *     threw `RangeError: Block decorations may not be specified via
+ *     plugins` from `EditorState.create` onwards because the Table
+ *     widget's `block: true` replace was emitted from a ViewPlugin's
+ *     decoration facet. The fix-pass moves all decorations into a
+ *     `StateField`, which is allowed to host block decorations.
+ *
+ * Tests deliberately do NOT touch any DOM API — no widget.toDOM, no
+ * EditorView. That space stays the browser-smoke's job.
+ */
+
+function makeState(doc: string) {
+  return EditorState.create({
+    doc,
+    extensions: [plaintextDecorations()],
+  });
+}
+
+/** Find the first lezer node with the given name in the state's tree. */
+function findNode(state: EditorState, name: string): SyntaxNode | null {
+  let found: SyntaxNode | null = null;
+  syntaxTree(state).iterate({
+    enter: (n) => {
+      if (found !== null) return false;
+      if (n.type.name === name) {
+        found = n.node;
+        return false;
+      }
+      return undefined;
+    },
+  });
+  return found;
+}
+
+/** Assertion helper that narrows `SyntaxNode | null` to `SyntaxNode`. */
+function requireNode(node: SyntaxNode | null, name: string): SyntaxNode {
+  if (node === null) {
+    throw new Error(`expected a ${name} node in the syntax tree`);
+  }
+  return node;
+}
+
+describe('plaintextDecorations — editor-mounts-at-all regression', () => {
+  it('constructs an EditorState with the plaintextDecorations extension without throwing', () => {
+    // This is the floor — Slice 4 originally threw `RangeError: Block
+    // decorations may not be specified via plugins` here, crashing
+    // every .txt note on mount. If this test ever fails again the
+    // root cause is almost certainly a block-shaped `Decoration.replace`
+    // being routed through a `ViewPlugin` instead of the StateField.
+    const doc = [
+      '# Heading',
+      '',
+      '| a | b |',
+      '| - | - |',
+      '| 1 | 2 |',
+      '',
+      '![alt](https://example.com/x.png)',
+      '',
+      'Done.',
+    ].join('\n');
+    expect(() => makeState(doc)).not.toThrow();
+  });
+
+  it('produces a non-empty DecorationSet for a doc with a table', () => {
+    // Place the cursor well past the table so the table replace
+    // decoration is emitted (this is the path that previously crashed
+    // CM6 in a ViewPlugin's decoration facet).
+    const doc = '| a | b |\n| - | - |\n| 1 | 2 |\n\n\nafter\n';
+    const state = makeState(doc);
+    const decos = buildMarkdownDecorations(state, {
+      from: doc.length,
+      to: doc.length,
+    });
+    expect(decos.size).toBeGreaterThan(0);
+  });
+
+  it('does not throw when the cursor is inside a table (raw-mode path)', () => {
+    const doc = '| a | b |\n| - | - |\n| 1 | 2 |\n';
+    const state = makeState(doc);
+    // Caret somewhere inside the body row.
+    expect(() => buildMarkdownDecorations(state, { from: 22, to: 22 })).not.toThrow();
+  });
+});
+
+describe('parseImageNode — alt + url extraction', () => {
+  function imageStateOrThrow(line: string): {
+    state: EditorState;
+    image: SyntaxNode;
+  } {
+    const state = makeState(line);
+    const image = requireNode(findNode(state, 'Image'), 'Image');
+    return { state, image };
+  }
+
+  it('extracts alt and url from `![alt](url)`', () => {
+    const { state, image } = imageStateOrThrow('![my alt](https://example.com/img.png)');
+    const parsed = parseImageNode(image, state);
+    expect(parsed).toEqual({
+      alt: 'my alt',
+      url: 'https://example.com/img.png',
+    });
+  });
+
+  it('extracts an empty alt from `![](url)`', () => {
+    const { state, image } = imageStateOrThrow('![](https://example.com/img.png)');
+    const parsed = parseImageNode(image, state);
+    expect(parsed?.alt).toBe('');
+    expect(parsed?.url).toBe('https://example.com/img.png');
+  });
+
+  it('preserves whitespace in alt text', () => {
+    const { state, image } = imageStateOrThrow('![alt with spaces](https://example.com/img.png)');
+    const parsed = parseImageNode(image, state);
+    expect(parsed?.alt).toBe('alt with spaces');
+  });
+
+  it('ignores the title and still extracts alt + url', () => {
+    const { state, image } = imageStateOrThrow('![alt](https://example.com/img.png "the title")');
+    const parsed = parseImageNode(image, state);
+    expect(parsed?.alt).toBe('alt');
+    expect(parsed?.url).toBe('https://example.com/img.png');
+  });
+
+  it('strips angle brackets around URLs containing spaces', () => {
+    const { state, image } = imageStateOrThrow(
+      '![alt](<https://example.com/path with spaces.png>)',
+    );
+    const parsed = parseImageNode(image, state);
+    expect(parsed?.url).toBe('https://example.com/path with spaces.png');
+  });
+
+  it('returns null when there is no URL', () => {
+    // Reference-style — no `(url)` part. We treat that as malformed.
+    const state = makeState('![alt][ref]');
+    const image = findNode(state, 'Image');
+    if (image === null) {
+      // Some lezer-markdown versions don't emit an Image node at all
+      // for unresolved reference shorthands — that's also "fall back to
+      // raw markdown", so this passes vacuously.
+      return;
+    }
+    const parsed = parseImageNode(image, state);
+    expect(parsed).toBeNull();
+  });
+
+  it('handles various URL schemes', () => {
+    const cases = [
+      'data:image/png;base64,iVBORw0KGgo=',
+      'blob:http://localhost:8797/abc-123',
+      '//example.com/img.png',
+      'http://example.com/img.png',
+      'assets/note-id/foo.png',
+    ];
+    for (const url of cases) {
+      const { state, image } = imageStateOrThrow(`![x](${url})`);
+      const parsed = parseImageNode(image, state);
+      expect(parsed?.url, `parsed url for ${url}`).toBe(url);
+    }
+  });
+});
+
+describe('unescapeMarkdownInline', () => {
+  it('unescapes pipes inside cell text', () => {
+    expect(unescapeMarkdownInline('a\\|b')).toBe('a|b');
+  });
+
+  it('unescapes a backslash', () => {
+    expect(unescapeMarkdownInline('\\\\')).toBe('\\');
+  });
+
+  it('unescapes emphasis markers', () => {
+    expect(unescapeMarkdownInline('\\*x')).toBe('*x');
+    expect(unescapeMarkdownInline('\\_y')).toBe('_y');
+    expect(unescapeMarkdownInline('\\`z')).toBe('`z');
+  });
+
+  it('keeps backslash for non-punctuation', () => {
+    expect(unescapeMarkdownInline('\\z')).toBe('\\z');
+  });
+
+  it('is a no-op for strings without backslashes', () => {
+    expect(unescapeMarkdownInline('abc')).toBe('abc');
+    expect(unescapeMarkdownInline('')).toBe('');
+  });
+});
+
+describe('parseColumnAlignment — delimiter cell parsing', () => {
+  it('returns "left" for `---` and `:---`', () => {
+    expect(parseColumnAlignment('---')).toBe('left');
+    expect(parseColumnAlignment(':---')).toBe('left');
+    expect(parseColumnAlignment('  ---  ')).toBe('left');
+  });
+
+  it('returns "center" for `:---:`', () => {
+    expect(parseColumnAlignment(':---:')).toBe('center');
+    expect(parseColumnAlignment('  :---:  ')).toBe('center');
+  });
+
+  it('returns "right" for `---:`', () => {
+    expect(parseColumnAlignment('---:')).toBe('right');
+  });
+});
+
+describe('parseTableNode — alignment + unescape', () => {
+  function tableStateOrThrow(doc: string): {
+    state: EditorState;
+    table: SyntaxNode;
+  } {
+    const state = makeState(doc);
+    const table = requireNode(findNode(state, 'Table'), 'Table');
+    return { state, table };
+  }
+
+  it('parses header, body, and alignments for a 3-col mixed table', () => {
+    const doc =
+      '| Name | Score | Status |\n' +
+      '| :--- | :---: | ---:   |\n' +
+      '| Alice | 42 | ok |\n' +
+      '| Bob | 7 | review |\n';
+    const { state, table } = tableStateOrThrow(doc);
+    const parsed = parseTableNode(table, state);
+    expect(parsed.header).toEqual(['Name', 'Score', 'Status']);
+    expect(parsed.alignments).toEqual(['left', 'center', 'right']);
+    expect(parsed.body).toEqual([
+      ['Alice', '42', 'ok'],
+      ['Bob', '7', 'review'],
+    ]);
+  });
+
+  it('unescapes escaped pipes inside cells (`Carol\\|special`)', () => {
+    const doc = '| Name | Status |\n' + '| --- | --- |\n' + '| Carol\\|special | ok |\n';
+    const { state, table } = tableStateOrThrow(doc);
+    const parsed = parseTableNode(table, state);
+    expect(parsed.body[0][0]).toBe('Carol|special');
+  });
+
+  it('pads alignments to header column count when delimiter row is shorter', () => {
+    // Pathological — but defensive: alignments default to 'left' for
+    // any column not explicitly delimited.
+    const doc = '| a | b | c |\n| --- |\n| 1 | 2 | 3 |\n';
+    const state = makeState(doc);
+    const table = findNode(state, 'Table');
+    if (table === null) return; // parser might reject; that's fine
+    const parsed = parseTableNode(table, state);
+    expect(parsed.alignments.length).toBeGreaterThanOrEqual(parsed.header.length);
+    for (let i = 1; i < parsed.alignments.length; i++) {
+      expect(parsed.alignments[i]).toBe('left');
+    }
+  });
+
+  it('does not crash on a 50-row table (smoke / performance)', () => {
+    const rows: string[] = ['| a | b | c |', '| --- | :---: | ---: |'];
+    for (let i = 0; i < 50; i++) {
+      rows.push(`| r${String(i)} | v${String(i)} | s${String(i)} |`);
+    }
+    const doc = rows.join('\n') + '\n';
+    const { state, table } = tableStateOrThrow(doc);
+    const t0 = performance.now();
+    const parsed = parseTableNode(table, state);
+    const t1 = performance.now();
+    expect(parsed.body.length).toBe(50);
+    // 50 rows × 3 cells should be sub-millisecond on any laptop —
+    // 50ms is a generous CI ceiling.
+    expect(t1 - t0).toBeLessThan(50);
+  });
+});
+
+describe('table cells — inline rendering contract', () => {
+  it('parses bold, mention chips, URL links, and wikilinks inside a cell', () => {
+    const parts = parseTableCellInlineMarkdown(
+      '**bold** [Alice](mention:alice@kb-1.dev) [Example](https://example.com) [[welcome]]',
+      {
+        orgPeople: [
+          {
+            id: 'user-alice',
+            email: 'alice@kb-1.dev',
+            name: 'Alice (dev)',
+            image: null,
+          },
+        ],
+        livePaths: [{ path: 'welcome.md', noteId: 'note-welcome' }],
+      },
+    );
+
+    expect(parts.some((part) => part.kind === 'strong')).toBe(true);
+    const mention = parts.find((part) => part.kind === 'mention');
+    expect(mention?.kind === 'mention' ? mention.props.displayName : null).toBe('Alice (dev)');
+    const link = parts.find((part) => part.kind === 'link');
+    expect(link?.kind === 'link' ? link.href : null).toBe('https://example.com');
+    const wikilink = parts.find((part) => part.kind === 'wikilink');
+    expect(wikilink).toMatchObject({
+      kind: 'wikilink',
+      target: 'welcome',
+      label: 'welcome',
+      resolved: true,
+    });
+  });
+
+  it('keeps table source raw while the cursor is inside the table', () => {
+    const doc =
+      '| Feature | Value |\n' +
+      '| --- | --- |\n' +
+      '| Bold | **bold cell** |\n' +
+      '| Person | [Alice](mention:alice@kb-1.dev) |\n';
+    const state = makeState(doc);
+    const cursorInsideTable = doc.indexOf('bold cell');
+    const set = buildMarkdownDecorations(
+      state,
+      { from: cursorInsideTable, to: cursorInsideTable },
+      {
+        orgPeople: [
+          {
+            id: 'user-alice',
+            email: 'alice@kb-1.dev',
+            name: 'Alice',
+            image: null,
+          },
+        ],
+      },
+    );
+
+    let tableWidgetCount = 0;
+    let boldMarkCount = 0;
+    let mentionWidgetCount = 0;
+    set.between(0, doc.length, (_from, _to, value) => {
+      const spec = value.spec as {
+        class?: string;
+        widget?: { header?: unknown; props?: unknown };
+      };
+      if (spec.widget?.header) tableWidgetCount++;
+      if (spec.class === 'cm-md-bold') boldMarkCount++;
+      if (spec.widget?.props) mentionWidgetCount++;
+    });
+    expect(tableWidgetCount).toBe(0);
+    expect(boldMarkCount).toBe(0);
+    expect(mentionWidgetCount).toBe(0);
+  });
+});
+
+describe('selection-range reveal (forward + backward)', () => {
+  // Doc: a paragraph with an image. The image source range is at a
+  // known position; we'll select across it forward and backward and
+  // confirm both produce the same decoration set (the image widget
+  // collapses to source in both cases).
+
+  const doc = 'before ![pic](https://example.com/x.png) after\n';
+  // 'before ' = 7 chars, then `![pic](...)` starts at index 7.
+  const imageStart = 7;
+  const imageEnd = 7 + '![pic](https://example.com/x.png)'.length; // 40
+
+  function buildAt(from: number, to: number) {
+    const state = makeState(doc);
+    return buildMarkdownDecorations(state, { from, to });
+  }
+
+  function widgetReplaceCount(set: ReturnType<typeof buildAt>): number {
+    let count = 0;
+    set.between(0, doc.length, (_from, _to, value) => {
+      // `value.spec.widget` is non-null when this is a widget replace.
+      // Both TableWidget and ImageWidget set widget; line/mark decos
+      // don't.
+      const spec: { widget?: unknown } = value.spec as { widget?: unknown };
+      if (spec.widget) count++;
+    });
+    return count;
+  }
+
+  it('renders the image widget when selection is fully outside the range', () => {
+    const set = buildAt(0, 0);
+    expect(widgetReplaceCount(set)).toBe(1);
+  });
+
+  it('collapses the widget when a forward selection crosses it', () => {
+    // anchor=5 (before 'before '), head=imageStart+3 (inside `![pic`)
+    const set = buildAt(5, imageStart + 3);
+    expect(widgetReplaceCount(set)).toBe(0);
+  });
+
+  it('collapses the widget when a backward selection crosses it (head < anchor)', () => {
+    // Caller normalizes to {from, to} via state.selection.main.from/.to,
+    // which is order-independent. We simulate by passing the normalized
+    // pair — the bug was the OLD path used `.head` directly, which is
+    // the moving endpoint. Here both directions yield the same
+    // `from`/`to` after normalization, so the reveal triggers the same
+    // way.
+    const a = 5;
+    const b = imageStart + 3;
+    const setFwd = buildAt(Math.min(a, b), Math.max(a, b));
+    const setBwd = buildAt(Math.min(b, a), Math.max(b, a));
+    expect(widgetReplaceCount(setFwd)).toBe(widgetReplaceCount(setBwd));
+    expect(widgetReplaceCount(setFwd)).toBe(0);
+  });
+
+  it('keeps the widget when the selection ends before the range starts', () => {
+    const set = buildAt(0, imageStart - 1);
+    expect(widgetReplaceCount(set)).toBe(1);
+  });
+
+  it('keeps the widget when the selection starts after the range ends', () => {
+    const set = buildAt(imageEnd + 1, doc.length);
+    expect(widgetReplaceCount(set)).toBe(1);
+  });
+});
+
+describe('broken-table shapes', () => {
+  it('pads body rows that have fewer cells than header', () => {
+    const doc = '| a | b | c |\n' + '| - | - | - |\n' + '| 1 | 2 |\n'; // missing third column
+    const state = makeState(doc);
+    const table = requireNode(findNode(state, 'Table'), 'Table');
+    const parsed = parseTableNode(table, state);
+    expect(parsed.header.length).toBe(3);
+    // Body row may be short — the TableWidget pads at render time.
+    // Here we just confirm we extracted whatever cells the parser saw.
+    expect(parsed.body[0].length).toBeLessThanOrEqual(3);
+  });
+
+  it('truncates body rows with more cells than header at render time', () => {
+    const doc = '| a | b |\n' + '| - | - |\n' + '| 1 | 2 | 3 |\n';
+    const state = makeState(doc);
+    const table = requireNode(findNode(state, 'Table'), 'Table');
+    const parsed = parseTableNode(table, state);
+    expect(parsed.header.length).toBe(2);
+    // Extras may appear in the parsed body — TableWidget caps the
+    // render at header.length columns, which is verified at the
+    // widget level (no DOM here).
+    expect(parsed.body[0].length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('falls through to plain text when there is no delimiter row', () => {
+    // No `| --- |` line → not a GFM table per the parser.
+    const doc = '| a | b |\n| 1 | 2 |\n';
+    const state = makeState(doc);
+    const table = findNode(state, 'Table');
+    // lezer-markdown's GFM Table extension requires the delimiter row;
+    // without it no Table node is emitted. The build path then leaves
+    // raw pipes in place.
+    expect(table).toBeNull();
+    // The decoration build should still complete cleanly.
+    expect(() => buildMarkdownDecorations(state, { from: 0, to: 0 })).not.toThrow();
+  });
+});
+
+describe('wikilinks (Slice 5) — parse + decoration', () => {
+  /**
+   * Walk a DecorationSet for marks whose `class` property contains the
+   * given substring (e.g. 'cm-md-wikilink-broken'). Returns the matching
+   * (from, to) pairs in source order.
+   */
+  function findMarksByClass(
+    set: ReturnType<typeof buildMarkdownDecorations>,
+    substr: string,
+    docLen: number,
+  ): { from: number; to: number; class: string }[] {
+    const hits: { from: number; to: number; class: string }[] = [];
+    set.between(0, docLen, (from, to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      const cls = spec.class ?? '';
+      if (cls.includes(substr)) {
+        hits.push({ from, to, class: cls });
+      }
+    });
+    return hits;
+  }
+
+  it('emits a Wikilink node for `[[target]]`', () => {
+    const state = makeState('see [[Kyoto Hotel]] today\n');
+    const wikilink = requireNode(findNode(state, 'Wikilink'), 'Wikilink');
+    // The Wikilink node spans the full `[[target]]` range.
+    expect(state.sliceDoc(wikilink.from, wikilink.to)).toBe('[[Kyoto Hotel]]');
+  });
+
+  it('does not match across newlines (`[[foo\\nbar]]` stays raw)', () => {
+    const state = makeState('[[foo\nbar]]\n');
+    const wikilink = findNode(state, 'Wikilink');
+    expect(wikilink).toBeNull();
+  });
+
+  it('does not match an unclosed `[[foo`', () => {
+    const state = makeState('[[foo and never closes\n');
+    const wikilink = findNode(state, 'Wikilink');
+    expect(wikilink).toBeNull();
+  });
+
+  it('parses `[[target|alias]]` with an alias child', () => {
+    const state = makeState('see [[home-page|Home]] today\n');
+    const wikilink = requireNode(findNode(state, 'Wikilink'), 'Wikilink');
+    // Walk children and confirm we got a target + alias-mark + alias.
+    const childNames: string[] = [];
+    let child: SyntaxNode | null = wikilink.firstChild;
+    while (child !== null) {
+      childNames.push(child.type.name);
+      child = child.nextSibling;
+    }
+    // Order: WikilinkMark, WikilinkTarget, WikilinkAliasMark,
+    // WikilinkAlias, WikilinkMark.
+    expect(childNames).toEqual([
+      'WikilinkMark',
+      'WikilinkTarget',
+      'WikilinkAliasMark',
+      'WikilinkAlias',
+      'WikilinkMark',
+    ]);
+  });
+
+  it('paints a resolved wikilink with the cm-md-wikilink-label class', () => {
+    // Doc has the wikilink on line 1 and a body line below. Caret on
+    // line 2 → wikilink is OFF the cursor's line, so the Shape A
+    // line-based reveal hides the brackets and tints the label.
+    const doc = 'see [[Kyoto Hotel]] today\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(
+      state,
+      { from: offLine, to: offLine },
+      {
+        livePaths: [{ path: 'notes/Kyoto Hotel.md', noteId: 'n-kyoto' }],
+      },
+    );
+    const labels = findMarksByClass(set, 'cm-md-wikilink-label', doc.length);
+    expect(labels.length).toBe(1);
+    // Resolved label MUST NOT carry the broken modifier.
+    expect(labels[0].class).not.toContain('cm-md-wikilink-broken');
+    // Range covers the target text exactly (`Kyoto Hotel`, between
+    // the opening `[[` at index 4 and the closing `]]` at index 17).
+    expect(doc.slice(labels[0].from, labels[0].to)).toBe('Kyoto Hotel');
+  });
+
+  it('paints a broken wikilink with the cm-md-wikilink-broken class', () => {
+    const doc = 'see [[ghost-target]] today\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(state, { from: offLine, to: offLine }, { livePaths: [] });
+    const brokens = findMarksByClass(set, 'cm-md-wikilink-broken', doc.length);
+    expect(brokens.length).toBe(1);
+    expect(doc.slice(brokens[0].from, brokens[0].to)).toBe('ghost-target');
+  });
+
+  it('emits cm-md-syntax marks on the `[[` and `]]` brackets when caret is on a different line', () => {
+    // Shape A: brackets hide off-line, reveal on-line. Caret on line 2.
+    const doc = '[[Note]]\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(state, {
+      from: offLine,
+      to: offLine,
+    });
+    const hidden: { from: number; to: number }[] = [];
+    set.between(0, doc.length, (from, to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      if (spec.class?.includes('cm-md-syntax') && spec.class?.includes('cm-hidden')) {
+        hidden.push({ from, to });
+      }
+    });
+    // Two syntax-mark ranges: `[[` (0..2) and `]]` (6..8).
+    const ranges = hidden.map((h) => `${String(h.from)}..${String(h.to)}`).sort();
+    expect(ranges).toContain('0..2');
+    expect(ranges).toContain('6..8');
+  });
+
+  it('reveals `[[` / `]]` when the caret is on the same line as the wikilink', () => {
+    // Shape A: same-line cursor reveals the raw markdown. The test
+    // previously asserted "caret inside the link span"; now any caret
+    // on the link's line counts.
+    const doc = '[[Note]]\n';
+    const state = makeState(doc);
+    // Caret inside the target text — same line.
+    const set = buildMarkdownDecorations(state, { from: 3, to: 3 }, { livePaths: [] });
+    // Confirm the hidden-syntax marks are NOT present on the bracket
+    // ranges anymore (they should be visible-syntax instead).
+    let hiddenCount = 0;
+    set.between(0, doc.length, (_from, _to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      if (spec.class?.includes('cm-md-syntax') && spec.class?.includes('cm-hidden')) {
+        hiddenCount++;
+      }
+    });
+    expect(hiddenCount).toBe(0);
+  });
+
+  it('paints the alias (not the target) as the label when an alias is present', () => {
+    const doc = '[[hidden-target|Visible Label]]\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(
+      state,
+      { from: offLine, to: offLine },
+      { livePaths: [{ path: 'hidden-target.md', noteId: 'n-1' }] },
+    );
+    const labels = findMarksByClass(set, 'cm-md-wikilink-label', doc.length);
+    expect(labels.length).toBe(1);
+    expect(doc.slice(labels[0].from, labels[0].to)).toBe('Visible Label');
+  });
+
+  it('resolves a wikilink target that includes a `#heading` to the page', () => {
+    // The `#heading` is part of the wikilink syntax; resolution targets
+    // the bare page name. The label range still spans `target#heading`
+    // (the full target text the user typed).
+    const doc = '[[my-note#section-2]]\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(
+      state,
+      { from: offLine, to: offLine },
+      { livePaths: [{ path: 'my-note.md', noteId: 'n-mn' }] },
+    );
+    const labels = findMarksByClass(set, 'cm-md-wikilink-label', doc.length);
+    expect(labels.length).toBe(1);
+    // Resolved (not broken) — the page resolves regardless of heading.
+    expect(labels[0].class).not.toContain('cm-md-wikilink-broken');
+  });
+
+  it('does not throw when a wikilink has an empty inner (`[[]]`)', () => {
+    const doc = 'see [[]] today\n';
+    const state = makeState(doc);
+    expect(() => buildMarkdownDecorations(state, { from: 0, to: 0 })).not.toThrow();
+  });
+
+  // -- Shape A: line-based reveal for links --------------------------------
+  // The cursor's line is the "edit zone"; links on that line render as
+  // raw markdown so a click lands as text-position (CM6 default) rather
+  // than following the link. Links on other lines stay decorated.
+
+  it('skips the wikilink label paint when the caret is on the same line (Shape A)', () => {
+    const doc = 'see [[Kyoto Hotel]] today\nelsewhere\n';
+    const state = makeState(doc);
+    // Caret in the body text of line 1 — outside the wikilink span but
+    // on the same line. Shape A says the label should NOT paint, so a
+    // click lands as text-position via CM6's default handling.
+    const sameLine = doc.indexOf('today');
+    const set = buildMarkdownDecorations(
+      state,
+      { from: sameLine, to: sameLine },
+      {
+        livePaths: [{ path: 'notes/Kyoto Hotel.md', noteId: 'n-kyoto' }],
+      },
+    );
+    const labels = findMarksByClass(set, 'cm-md-wikilink-label', doc.length);
+    expect(labels.length).toBe(0);
+    // And the brackets/target should be visible (revealed), not hidden.
+    let hiddenCount = 0;
+    set.between(0, doc.length, (_from, _to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      if (spec.class?.includes('cm-md-syntax') && spec.class?.includes('cm-hidden')) {
+        hiddenCount++;
+      }
+    });
+    expect(hiddenCount).toBe(0);
+  });
+
+  it('skips the URL-link label paint when the caret is on the same line (Shape A)', () => {
+    const doc = 'see [Anthropic](https://anthropic.com) today\nelsewhere\n';
+    const state = makeState(doc);
+    const sameLine = doc.indexOf('today');
+    const set = buildMarkdownDecorations(state, {
+      from: sameLine,
+      to: sameLine,
+    });
+    const labels = findMarksByClass(set, 'cm-md-link-label', doc.length);
+    expect(labels.length).toBe(0);
+    // Off-line: caret on line 2 → label IS painted.
+    const offLine = doc.indexOf('elsewhere');
+    const setOff = buildMarkdownDecorations(state, {
+      from: offLine,
+      to: offLine,
+    });
+    const labelsOff = findMarksByClass(setOff, 'cm-md-link-label', doc.length);
+    expect(labelsOff.length).toBe(1);
+    expect(doc.slice(labelsOff[0].from, labelsOff[0].to)).toBe('Anthropic');
+  });
+});
+
+describe('autolinks (GFM) — parse + decoration', () => {
+  /**
+   * Same shape as the wikilink `findMarksByClass` helper. Kept local
+   * to this block to avoid cross-block coupling — the wikilink block
+   * already declares it as a private helper.
+   */
+  function findMarksByClass(
+    set: ReturnType<typeof buildMarkdownDecorations>,
+    substr: string,
+    docLen: number,
+  ): { from: number; to: number; class: string }[] {
+    const hits: { from: number; to: number; class: string }[] = [];
+    set.between(0, docLen, (from, to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      const cls = spec.class ?? '';
+      if (cls.includes(substr)) {
+        hits.push({ from, to, class: cls });
+      }
+    });
+    return hits;
+  }
+
+  it('emits a top-level URL node for a bare `https://` link in prose', () => {
+    // lezer-markdown's Autolink extension calls `cx.addElement(cx.elt("URL",
+    // …))` for matches against `https?://`, `www.`, `mailto:`, `xmpp:`, and
+    // bare emails. The URL node sits directly under Paragraph (NOT under
+    // a Link node) — that's the marker our decoration walker uses to tell
+    // an autolink apart from a `[label](url)` link's URL child.
+    const state = makeState('Visit https://example.com/foo today.\n');
+    const url = requireNode(findNode(state, 'URL'), 'URL');
+    expect(state.sliceDoc(url.from, url.to)).toBe('https://example.com/foo');
+    // Parent must not be `Link` / `Image` for the autolink branch to fire.
+    const pname = url.parent?.type.name;
+    expect(pname === 'Link' || pname === 'Image').toBe(false);
+  });
+
+  it('paints the URL range with cm-md-link-label when the caret is off-line', () => {
+    const doc = 'Visit https://example.com today\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(state, {
+      from: offLine,
+      to: offLine,
+    });
+    const labels = findMarksByClass(set, 'cm-md-link-label', doc.length);
+    expect(labels.length).toBe(1);
+    expect(doc.slice(labels[0].from, labels[0].to)).toBe('https://example.com');
+  });
+
+  it('skips the autolink paint when the caret is on the same line (Shape A)', () => {
+    const doc = 'Visit https://example.com today\nelsewhere\n';
+    const state = makeState(doc);
+    const sameLine = doc.indexOf('today');
+    const set = buildMarkdownDecorations(state, {
+      from: sameLine,
+      to: sameLine,
+    });
+    const labels = findMarksByClass(set, 'cm-md-link-label', doc.length);
+    expect(labels.length).toBe(0);
+  });
+
+  it('detects a bare email as an autolink URL node', () => {
+    const state = makeState('Email alice@example.com to say hi.\n');
+    const url = requireNode(findNode(state, 'URL'), 'URL');
+    expect(state.sliceDoc(url.from, url.to)).toBe('alice@example.com');
+  });
+
+  it('coexists with wikilinks on the same line (no interference)', () => {
+    // Regression guard: GFM Autolink and the custom wikilink inline
+    // parser register independently. Confirm both still produce their
+    // expected nodes for `[[wikilink]]` and `https://example.com` in
+    // the same paragraph.
+    const doc = '[[Note]] and https://example.com both work\nelsewhere\n';
+    const state = makeState(doc);
+    expect(findNode(state, 'Wikilink')).not.toBeNull();
+    expect(findNode(state, 'URL')).not.toBeNull();
+  });
+});
+
+describe('task lists (Slice 3 Apple) — parse + decoration', () => {
+  /**
+   * Walk a DecorationSet for replace decos whose widget is a
+   * TaskCheckboxWidget. Returns `{from, to, checked}` per hit in source
+   * order. We don't import the widget class directly (it's not exported)
+   * — we identify by the cm-md-task-checkbox shape via `toDOM` is too
+   * heavyweight without a DOM env, so we shape-match the widget's
+   * constructor-arg surface via duck-typing.
+   */
+  function findTaskWidgets(
+    set: ReturnType<typeof buildMarkdownDecorations>,
+    docLen: number,
+  ): { from: number; to: number; checked: boolean }[] {
+    const hits: { from: number; to: number; checked: boolean }[] = [];
+    set.between(0, docLen, (from, to, value) => {
+      const spec: { widget?: { checked?: boolean } } = value.spec as {
+        widget?: { checked?: boolean };
+      };
+      const w = spec.widget;
+      // The TaskCheckboxWidget carries a `checked` boolean field; the
+      // ImageWidget and TableWidget don't. This duck-test cleanly
+      // separates them without importing private classes.
+      if (w !== undefined && typeof w.checked === 'boolean') {
+        hits.push({ from, to, checked: w.checked });
+      }
+    });
+    return hits;
+  }
+
+  /** Find all visible-syntax marks (cm-md-syntax without cm-hidden). */
+  function findVisibleSyntaxAt(
+    set: ReturnType<typeof buildMarkdownDecorations>,
+    docLen: number,
+    from: number,
+    to: number,
+  ): boolean {
+    let found = false;
+    set.between(0, docLen, (f, t, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      if (
+        f === from &&
+        t === to &&
+        spec.class?.includes('cm-md-syntax') &&
+        !spec.class?.includes('cm-hidden')
+      ) {
+        found = true;
+      }
+    });
+    return found;
+  }
+
+  it('parses `- [ ]` as a Task with a TaskMarker child', () => {
+    const state = makeState('- [ ] do the thing\n');
+    const taskMarker = requireNode(findNode(state, 'TaskMarker'), 'TaskMarker');
+    // TaskMarker is always exactly 3 chars: `[ ]` / `[x]` / `[X]`.
+    expect(taskMarker.to - taskMarker.from).toBe(3);
+    expect(state.sliceDoc(taskMarker.from, taskMarker.to)).toBe('[ ]');
+  });
+
+  it('parses `- [x]` as a Task with a checked TaskMarker', () => {
+    const state = makeState('- [x] done already\n');
+    const taskMarker = requireNode(findNode(state, 'TaskMarker'), 'TaskMarker');
+    expect(state.sliceDoc(taskMarker.from, taskMarker.to)).toBe('[x]');
+  });
+
+  it('parses `- [X]` (uppercase) as a Task too', () => {
+    const state = makeState('- [X] also checked\n');
+    const taskMarker = requireNode(findNode(state, 'TaskMarker'), 'TaskMarker');
+    expect(state.sliceDoc(taskMarker.from, taskMarker.to)).toBe('[X]');
+  });
+
+  it('emits a checkbox widget over the TaskMarker range when caret is off the item', () => {
+    // Two-item doc with a BLANK LINE between the list and the footer
+    // paragraph — without the blank line, lezer-markdown's lazy
+    // continuation treats `footer` as a continuation of the last list
+    // item, which would pull the cursor inside the ListItem range and
+    // collapse the widget. The blank-line separator is the canonical
+    // GFM way to close a list block.
+    const doc = '- [ ] alpha\n- [x] beta\n\nfooter\n';
+    const state = makeState(doc);
+    const footerPos = doc.indexOf('footer');
+    const set = buildMarkdownDecorations(state, {
+      from: footerPos,
+      to: footerPos,
+    });
+    const widgets = findTaskWidgets(set, doc.length);
+    expect(widgets.length).toBe(2);
+    expect(widgets[0].checked).toBe(false);
+    expect(widgets[1].checked).toBe(true);
+    // Widget range covers exactly the 3-char marker.
+    expect(doc.slice(widgets[0].from, widgets[0].to)).toBe('[ ]');
+    expect(doc.slice(widgets[1].from, widgets[1].to)).toBe('[x]');
+  });
+
+  it('reveals raw `[ ]` source (no widget) when caret is on the item line', () => {
+    const doc = '- [ ] alpha\n\nfooter\n';
+    const state = makeState(doc);
+    // Caret in the middle of the task-list item.
+    const onLine = doc.indexOf('alpha');
+    const set = buildMarkdownDecorations(state, { from: onLine, to: onLine });
+    const widgets = findTaskWidgets(set, doc.length);
+    expect(widgets.length).toBe(0);
+    // Visible-syntax mark should sit over the TaskMarker range so the
+    // raw `[ ]` is visible in normal weight (no cm-hidden).
+    const markerStart = doc.indexOf('[ ]');
+    expect(findVisibleSyntaxAt(set, doc.length, markerStart, markerStart + 3)).toBe(true);
+  });
+
+  it('hides the widget when the editor is unfocused (Slice F focus-gate behaviour)', () => {
+    // Same caret position as the on-line case above, but focused = false.
+    // The intersects() helper short-circuits to false when unfocused, so
+    // the widget engages even with the caret "on" the line — Bear-style
+    // preview at rest.
+    const doc = '- [ ] alpha\n\nfooter\n';
+    const state = makeState(doc);
+    const onLine = doc.indexOf('alpha');
+    const set = buildMarkdownDecorations(state, { from: onLine, to: onLine }, { focused: false });
+    const widgets = findTaskWidgets(set, doc.length);
+    expect(widgets.length).toBe(1);
+    expect(widgets[0].checked).toBe(false);
+  });
+
+  it('suppresses the bullet on task-list items (Slice L) — no visible ListMark off-cursor', () => {
+    // Slice L reversal of Slice Q: the `- ` bullet on a task-list line
+    // is redundant alongside the checkbox glyph, so we hide it. The
+    // ListMark range still gets a *hidden* cm-md-syntax mark (so the
+    // source position stays selectable) but NOT the visible variant.
+    const doc = '- [ ] alpha\n\nfooter\n';
+    const state = makeState(doc);
+    const footerPos = doc.indexOf('footer');
+    const set = buildMarkdownDecorations(state, {
+      from: footerPos,
+      to: footerPos,
+    });
+    // ListMark is the `-`; it sits at offset 0 with width 1 in our doc.
+    // The build must NOT emit a visible-syntax mark there off-cursor.
+    expect(findVisibleSyntaxAt(set, doc.length, 0, 1)).toBe(false);
+    // And the checkbox widget IS emitted.
+    expect(findTaskWidgets(set, doc.length).length).toBe(1);
+  });
+
+  it('does not throw on a list item without a task marker (`- plain`)', () => {
+    const doc = '- plain item\n- [ ] task item\n\nfooter\n';
+    const state = makeState(doc);
+    expect(() => buildMarkdownDecorations(state, { from: 0, to: 0 })).not.toThrow();
+    const footerPos = doc.indexOf('footer');
+    const set = buildMarkdownDecorations(state, {
+      from: footerPos,
+      to: footerPos,
+    });
+    // Only the task-marker line emits a widget.
+    expect(findTaskWidgets(set, doc.length).length).toBe(1);
+  });
+
+  it('emits the strikethrough line deco for checked task items', () => {
+    const doc = '- [x] done\n- [ ] todo\n\nfooter\n';
+    const state = makeState(doc);
+    const footerPos = doc.indexOf('footer');
+    const set = buildMarkdownDecorations(state, {
+      from: footerPos,
+      to: footerPos,
+    });
+    // Walk for the `cm-md-listitem-task-checked` line deco — its
+    // `from === to` (point-shaped line deco) and should sit at the
+    // line.from of the checked task line only.
+    const checkedLineStarts: number[] = [];
+    set.between(0, doc.length, (from, to, value) => {
+      const cls = (value.spec as { class?: string }).class ?? '';
+      if (from === to && cls.includes('cm-md-listitem-task-checked')) {
+        checkedLineStarts.push(from);
+      }
+    });
+    expect(checkedLineStarts).toEqual([0]); // only the `- [x] done` line
+  });
+});
+
+describe('list rendering redesign (Slice L) — bullets + ordered numbers', () => {
+  /**
+   * Walk a DecorationSet for replace decos whose widget is a
+   * BulletGlyphWidget. We duck-type via the `depth` field which only
+   * the bullet widget exposes.
+   */
+  function findBulletWidgets(
+    set: ReturnType<typeof buildMarkdownDecorations>,
+    docLen: number,
+  ): { from: number; to: number; depth: number }[] {
+    const hits: { from: number; to: number; depth: number }[] = [];
+    set.between(0, docLen, (from, to, value) => {
+      const spec: { widget?: { depth?: number; displayValue?: number } } = value.spec as {
+        widget?: { depth?: number; displayValue?: number };
+      };
+      const w = spec.widget;
+      if (w !== undefined && typeof w.depth === 'number' && typeof w.displayValue !== 'number') {
+        hits.push({ from, to, depth: w.depth });
+      }
+    });
+    return hits;
+  }
+
+  /**
+   * Walk a DecorationSet for replace decos whose widget is an
+   * OrderedNumberWidget. Duck-typed via `displayValue`.
+   */
+  function findOrderedNumberWidgets(
+    set: ReturnType<typeof buildMarkdownDecorations>,
+    docLen: number,
+  ): { from: number; to: number; displayValue: number }[] {
+    const hits: { from: number; to: number; displayValue: number }[] = [];
+    set.between(0, docLen, (from, to, value) => {
+      const spec: { widget?: { displayValue?: number } } = value.spec as {
+        widget?: { displayValue?: number };
+      };
+      const w = spec.widget;
+      if (w !== undefined && typeof w.displayValue === 'number') {
+        hits.push({ from, to, displayValue: w.displayValue });
+      }
+    });
+    return hits;
+  }
+
+  it('replaces bullet ListMarks with shape-glyph widgets off-cursor', () => {
+    const doc = '- one\n- two\n- three\n\nfooter\n';
+    const state = makeState(doc);
+    const footerPos = doc.indexOf('footer');
+    const set = buildMarkdownDecorations(state, {
+      from: footerPos,
+      to: footerPos,
+    });
+    const widgets = findBulletWidgets(set, doc.length);
+    expect(widgets.length).toBe(3);
+    // All at depth 0 (top-level bullets) → glyph cycle index 0.
+    expect(widgets.every((w) => w.depth === 0)).toBe(true);
+    // No ordered number widgets in a pure bullet list.
+    expect(findOrderedNumberWidgets(set, doc.length).length).toBe(0);
+  });
+
+  it('cycles bullet glyphs by depth (0 → 1 → 2 → 3)', () => {
+    // Nested list four deep — each ListItem opens a child BulletList
+    // under itself, bumping `listItemDepth` by one per level.
+    const doc = '- a\n  - b\n    - c\n      - d\n        - e\n\nfooter\n';
+    const state = makeState(doc);
+    const footerPos = doc.indexOf('footer');
+    const set = buildMarkdownDecorations(state, {
+      from: footerPos,
+      to: footerPos,
+    });
+    const widgets = findBulletWidgets(set, doc.length);
+    expect(widgets.length).toBe(5);
+    // Source order matches depth order in this nesting layout.
+    const depths = widgets
+      .slice()
+      .sort((x, y) => x.from - y.from)
+      .map((w) => w.depth);
+    // Depth-5 cycles back through the set; per listItemDepth's clamp
+    // depths are capped at 5, but the widget cycles modulo 4 → depth
+    // 4 → 0, depth 5 → 1.
+    expect(depths).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('reveals raw `-` source (no widget) when cursor is inside the ListItem', () => {
+    const doc = '- one\n- two\n\nfooter\n';
+    const state = makeState(doc);
+    // Caret inside the first list item.
+    const onLine = doc.indexOf('one');
+    const set = buildMarkdownDecorations(state, { from: onLine, to: onLine });
+    const widgets = findBulletWidgets(set, doc.length);
+    // First item's bullet revealed (no widget); second item still has
+    // a widget because the cursor is outside its ListItem range.
+    expect(widgets.length).toBe(1);
+    // The widget's `from` is the ListMark range of the SECOND item.
+    expect(widgets[0].from).toBeGreaterThan(onLine);
+  });
+
+  it('renders auto-numbered widgets for ordered lists (CommonMark sequential)', () => {
+    // All-ones source → renders 1, 2, 3 sequentially.
+    const doc = '1. one\n1. two\n1. three\n\nfooter\n';
+    const state = makeState(doc);
+    const footerPos = doc.indexOf('footer');
+    const set = buildMarkdownDecorations(state, {
+      from: footerPos,
+      to: footerPos,
+    });
+    const widgets = findOrderedNumberWidgets(set, doc.length);
+    expect(widgets.length).toBe(3);
+    const display = widgets
+      .slice()
+      .sort((a, b) => a.from - b.from)
+      .map((w) => w.displayValue);
+    expect(display).toEqual([1, 2, 3]);
+  });
+
+  it('uses the first item source number as the start for ordered lists', () => {
+    // First item `5.` → sequence is 5, 6, 7.
+    const doc = '5. five\n1. six\n9. seven\n\nfooter\n';
+    const state = makeState(doc);
+    const footerPos = doc.indexOf('footer');
+    const set = buildMarkdownDecorations(state, {
+      from: footerPos,
+      to: footerPos,
+    });
+    const widgets = findOrderedNumberWidgets(set, doc.length);
+    const display = widgets
+      .slice()
+      .sort((a, b) => a.from - b.from)
+      .map((w) => w.displayValue);
+    expect(display).toEqual([5, 6, 7]);
+  });
+
+  it('restarts ordered numbering after non-list block boundaries', () => {
+    const doc = [
+      '1. first setup item',
+      '   - nested bullet',
+      '1. second setup item',
+      '',
+      'A paragraph between ordered-list runs.',
+      '',
+      '---',
+      '',
+      '## NEXT SECTION',
+      '',
+      '1. first section item',
+      '1. second section item',
+      '',
+      'Follow-up paragraph.',
+      '',
+      '1. first follow-up item',
+      '1. second follow-up item',
+      '',
+      'footer',
+    ].join('\n');
+    const state = makeState(doc);
+    const footerPos = doc.indexOf('footer');
+    const set = buildMarkdownDecorations(state, {
+      from: footerPos,
+      to: footerPos,
+    });
+    const widgets = findOrderedNumberWidgets(set, doc.length);
+    const display = widgets
+      .slice()
+      .sort((a, b) => a.from - b.from)
+      .map((w) => w.displayValue);
+    expect(display).toEqual([1, 2, 1, 2, 1, 2]);
+  });
+
+  it('does NOT emit a bullet widget for task-list items', () => {
+    // Mix of plain + task: only the plain item emits a bullet widget.
+    const doc = '- plain\n- [ ] task\n\nfooter\n';
+    const state = makeState(doc);
+    const footerPos = doc.indexOf('footer');
+    const set = buildMarkdownDecorations(state, {
+      from: footerPos,
+      to: footerPos,
+    });
+    const widgets = findBulletWidgets(set, doc.length);
+    expect(widgets.length).toBe(1);
+    // The widget is on the `plain` item; the `task` item's ListMark
+    // is suppressed entirely.
+  });
+
+  it('keeps ordered-list display numbers stable while editing item body', () => {
+    const doc = '1. one\n9. two\n\nfooter\n';
+    const state = makeState(doc);
+    const onLine = doc.indexOf('two');
+    const set = buildMarkdownDecorations(state, { from: onLine, to: onLine });
+    const widgets = findOrderedNumberWidgets(set, doc.length);
+    const display = widgets
+      .slice()
+      .sort((a, b) => a.from - b.from)
+      .map((w) => w.displayValue);
+    expect(display).toEqual([1, 2]);
+  });
+
+  it('reveals raw ordered-list source only when the cursor is on the marker', () => {
+    const doc = '1. one\n9. two\n\nfooter\n';
+    const state = makeState(doc);
+    const markerPos = doc.indexOf('9.');
+    const set = buildMarkdownDecorations(state, {
+      from: markerPos,
+      to: markerPos,
+    });
+    const widgets = findOrderedNumberWidgets(set, doc.length);
+    // Second item's marker is being edited directly; the first still
+    // gets the computed widget.
+    expect(widgets.length).toBe(1);
+    expect(widgets[0].displayValue).toBe(1);
+  });
+});
+
+describe('footnotes (Slice 4 Apple) — parse + decoration', () => {
+  /**
+   * Walk a DecorationSet for marks whose `class` property contains the
+   * given substring. Returns the matching (from, to) pairs in source
+   * order. Sibling helper to the wikilink test block above.
+   */
+  function findMarksByClass(
+    set: ReturnType<typeof buildMarkdownDecorations>,
+    substr: string,
+    docLen: number,
+  ): { from: number; to: number; class: string }[] {
+    const hits: { from: number; to: number; class: string }[] = [];
+    set.between(0, docLen, (from, to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      const cls = spec.class ?? '';
+      if (cls.includes(substr)) {
+        hits.push({ from, to, class: cls });
+      }
+    });
+    return hits;
+  }
+
+  /** Find all Decoration.line decos whose class contains the substring. */
+  function findLineDecos(
+    set: ReturnType<typeof buildMarkdownDecorations>,
+    substr: string,
+    docLen: number,
+  ): { from: number; class: string }[] {
+    const hits: { from: number; class: string }[] = [];
+    set.between(0, docLen, (from, _to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      const cls = spec.class ?? '';
+      // Decoration.line decos have from === to (point-shaped).
+      if (from === _to && cls.includes(substr)) {
+        hits.push({ from, class: cls });
+      }
+    });
+    return hits;
+  }
+
+  // -- Inline reference parser ------------------------------------------
+
+  it('parses `[^1]` as a FootnoteRef node with the right children', () => {
+    const state = makeState('see [^1] in the body\n');
+    const ref = requireNode(findNode(state, 'FootnoteRef'), 'FootnoteRef');
+    expect(state.sliceDoc(ref.from, ref.to)).toBe('[^1]');
+    const childNames: string[] = [];
+    let child: SyntaxNode | null = ref.firstChild;
+    while (child !== null) {
+      childNames.push(child.type.name);
+      child = child.nextSibling;
+    }
+    expect(childNames).toEqual(['FootnoteRefMark', 'FootnoteLabel', 'FootnoteRefMark']);
+  });
+
+  it('accepts alphanumeric, `_`, and `-` in the id', () => {
+    const doc = 'see [^src_a-1] in the body\n';
+    const state = makeState(doc);
+    const ref = requireNode(findNode(state, 'FootnoteRef'), 'FootnoteRef');
+    expect(state.sliceDoc(ref.from, ref.to)).toBe('[^src_a-1]');
+  });
+
+  it('does not match `[^]` (empty id)', () => {
+    const state = makeState('not a [^] footnote\n');
+    expect(findNode(state, 'FootnoteRef')).toBeNull();
+  });
+
+  it('does not match `[^a b]` (space inside id)', () => {
+    const state = makeState('not a [^a b] footnote\n');
+    expect(findNode(state, 'FootnoteRef')).toBeNull();
+  });
+
+  it('does not match an unclosed `[^foo`', () => {
+    const state = makeState('not [^foo and never closes\n');
+    expect(findNode(state, 'FootnoteRef')).toBeNull();
+  });
+
+  // -- Block definition parser ------------------------------------------
+
+  it('parses `[^1]: body text` as a FootnoteDef block', () => {
+    const state = makeState('[^1]: the body of the definition\n');
+    const def = requireNode(findNode(state, 'FootnoteDef'), 'FootnoteDef');
+    // FootnoteDef spans the full line up to (but not including) the
+    // newline character.
+    expect(state.sliceDoc(def.from, def.to)).toBe('[^1]: the body of the definition');
+    const childNames: string[] = [];
+    let child: SyntaxNode | null = def.firstChild;
+    while (child !== null) {
+      childNames.push(child.type.name);
+      child = child.nextSibling;
+    }
+    // First three are the structural prefix; trailing children (if any)
+    // are inline-parsed body elements.
+    expect(childNames.slice(0, 3)).toEqual(['FootnoteDefMark', 'FootnoteLabel', 'FootnoteDefMark']);
+  });
+
+  it('does not parse `  [^1]: indented` as a FootnoteDef (indent disallowed)', () => {
+    const state = makeState('  [^1]: indented def\n');
+    expect(findNode(state, 'FootnoteDef')).toBeNull();
+  });
+
+  it('inline-parses emphasis inside the definition body', () => {
+    const state = makeState('[^1]: see **bold** text\n');
+    requireNode(findNode(state, 'FootnoteDef'), 'FootnoteDef');
+    // StrongEmphasis appears inside the definition body, not as a
+    // sibling block. The decoration walker descends into the FootnoteDef
+    // so the bold mark gets emitted normally.
+    const bold = findNode(state, 'StrongEmphasis');
+    expect(bold).not.toBeNull();
+    if (bold !== null) {
+      expect(state.sliceDoc(bold.from, bold.to)).toBe('**bold**');
+    }
+  });
+
+  // -- Decoration: reference painting -----------------------------------
+
+  it('paints the inline `[^1]` ref with cm-md-footnote-ref when a def exists', () => {
+    const doc =
+      'a claim [^1] in the body\n' + '\n' + '[^1]: definition body\n' + '\n' + 'elsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(state, { from: offLine, to: offLine });
+    const labels = findMarksByClass(set, 'cm-md-footnote-ref', doc.length);
+    // One inline ref → one label mark. Definitions don't get the
+    // footnote-ref class; they get the footnote-def line deco.
+    expect(labels.length).toBe(1);
+    // Resolved ref MUST NOT carry the broken modifier.
+    expect(labels[0].class).not.toContain('cm-md-footnote-ref-broken');
+    // Range covers the id text exactly (`1` between `[^` and `]`).
+    expect(doc.slice(labels[0].from, labels[0].to)).toBe('1');
+  });
+
+  it('paints a broken ref with cm-md-footnote-ref-broken when no def exists', () => {
+    const doc = 'a claim [^missing] in the body\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(state, { from: offLine, to: offLine });
+    const brokens = findMarksByClass(set, 'cm-md-footnote-ref-broken', doc.length);
+    expect(brokens.length).toBe(1);
+    expect(doc.slice(brokens[0].from, brokens[0].to)).toBe('missing');
+  });
+
+  it('hides the `[^` and `]` syntax chars when caret is off the line', () => {
+    const doc = 'a [^1] note\n[^1]: body\n\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(state, { from: offLine, to: offLine });
+    // Find hidden-syntax marks over the bracket ranges of the inline ref.
+    const hidden: { from: number; to: number }[] = [];
+    set.between(0, doc.length, (from, to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      if (spec.class?.includes('cm-md-syntax') && spec.class?.includes('cm-hidden')) {
+        hidden.push({ from, to });
+      }
+    });
+    // The inline ref's `[^` is at 2..4, `]` is at 5..6.
+    const ranges = hidden.map((h) => `${String(h.from)}..${String(h.to)}`).sort();
+    expect(ranges).toContain('2..4');
+    expect(ranges).toContain('5..6');
+  });
+
+  it('reveals the brackets when caret is on the ref line', () => {
+    const doc = 'a [^1] note\n[^1]: body\n\nelsewhere\n';
+    const state = makeState(doc);
+    // Caret on the ref line.
+    const set = buildMarkdownDecorations(state, { from: 1, to: 1 });
+    // No cm-md-footnote-ref label paint when the cursor is on the line
+    // (Shape A — raw markdown).
+    const labels = findMarksByClass(set, 'cm-md-footnote-ref', doc.length);
+    expect(labels.length).toBe(0);
+  });
+
+  // -- Decoration: definition line --------------------------------------
+
+  // Bear-style inline render: the def line flows as ordinary prose
+  // with the id painted inline in link color. The `name` portion of
+  // `[^name]:` carries `cm-md-footnote-label`; `[^` and `]` are
+  // hidden via cm-md-syntax.cm-hidden; the `:` stays visible. No
+  // line decoration is emitted (no gutter chip, no card chrome).
+  it('paints the FootnoteLabel name with cm-md-footnote-label and emits no line deco', () => {
+    const doc = '[^1]: definition body\nprose\n';
+    const state = makeState(doc);
+    // Caret on the prose line (off the def line) — label paint emitted.
+    const offLine = doc.indexOf('prose');
+    const set = buildMarkdownDecorations(state, { from: offLine, to: offLine });
+
+    // No line deco anywhere on the def line.
+    const lines = findLineDecos(set, 'cm-md-footnote-def', doc.length);
+    expect(lines.length).toBe(0);
+
+    // The name `1` (positions 2..3) carries cm-md-footnote-label.
+    const labels = findMarksByClass(set, 'cm-md-footnote-label', doc.length);
+    expect(labels.length).toBe(1);
+    expect(labels[0].from).toBe(2);
+    expect(labels[0].to).toBe(3);
+  });
+
+  // Cursor ON the def line drops the label paint and reveals the raw
+  // `[^id]:` source — mirrors the wikilink / fenced-code cursor-reveal
+  // pattern. No `cm-md-footnote-label` mark emitted on the def line.
+  it('drops cm-md-footnote-label when cursor is on the def line', () => {
+    const doc = '[^1]: definition body\nbody\n';
+    const state = makeState(doc);
+    // Caret on the def line (column 0).
+    const set = buildMarkdownDecorations(state, { from: 0, to: 0 });
+    const labels = findMarksByClass(set, 'cm-md-footnote-label', doc.length);
+    expect(labels.length).toBe(0);
+  });
+
+  // Multi-def doc: only the def line under the cursor drops the label
+  // paint; sibling defs keep their inline link-color label.
+  it('drops cm-md-footnote-label only on the cursor-occupied def line in a multi-def doc', () => {
+    const doc = '[^a]: first body\n[^b]: second body\nelsewhere\n';
+    const state = makeState(doc);
+    // Cursor on the SECOND def line.
+    const onSecond = doc.indexOf('[^b]');
+    const set = buildMarkdownDecorations(state, {
+      from: onSecond,
+      to: onSecond,
+    });
+    const labels = findMarksByClass(set, 'cm-md-footnote-label', doc.length);
+    // Exactly one remaining label paint — the first def's `a` (2..3).
+    expect(labels.length).toBe(1);
+    expect(labels[0].from).toBe(2);
+    expect(labels[0].to).toBe(3);
+  });
+
+  // -- Decoration: cursor-on-line drops definition to raw markdown -----
+  //
+  // When the cursor sits on a FootnoteDef line, the entire line drops
+  // back to raw markdown — the `[^id]:` chip vanishes (revealed as
+  // source) AND inline marks in the body unrender so `**bold**`,
+  // `*italic*`, ``` `code` ```, `~~strike~~`, and `[[wikilink]]` all
+  // show their raw syntax. Mirrors the cursor-on-fence behaviour of
+  // FencedCode (`cm-md-code-block-card` chrome drops; raw delimiters
+  // surface). Cursor OFF the line keeps the rendered form.
+
+  it('suppresses inline range marks on a definition line when cursor is on it', () => {
+    const doc = '[^1]: see **bold** and *italic* and `code` text\nbody\n';
+    const state = makeState(doc);
+    // Caret on the def line (column 0).
+    const onLine = buildMarkdownDecorations(state, { from: 0, to: 0 });
+    expect(findMarksByClass(onLine, 'cm-md-bold', doc.length).length).toBe(0);
+    expect(findMarksByClass(onLine, 'cm-md-italic', doc.length).length).toBe(0);
+    expect(findMarksByClass(onLine, 'cm-md-code', doc.length).length).toBe(0);
+    // Off the def line — body line — the inline marks render normally.
+    const offLine = doc.indexOf('body');
+    const off = buildMarkdownDecorations(state, { from: offLine, to: offLine });
+    expect(findMarksByClass(off, 'cm-md-bold', doc.length).length).toBe(1);
+    expect(findMarksByClass(off, 'cm-md-italic', doc.length).length).toBe(1);
+    expect(findMarksByClass(off, 'cm-md-code', doc.length).length).toBe(1);
+  });
+
+  it('reveals inline syntax chars on a definition line when cursor is on it', () => {
+    const doc = '[^1]: see **bold** text\nbody\n';
+    const state = makeState(doc);
+    // Caret on the def line.
+    const on = buildMarkdownDecorations(state, { from: 0, to: 0 });
+    // The `**` syntax marks (EmphasisMark children of StrongEmphasis)
+    // sit at positions 10..12 and 16..18 — they MUST emit a visible
+    // (not hidden) syntax mark when cursor is on the line.
+    const hidden: { from: number; to: number }[] = [];
+    on.between(0, doc.length, (from, to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      if (spec.class?.includes('cm-md-syntax') && spec.class?.includes('cm-hidden')) {
+        hidden.push({ from, to });
+      }
+    });
+    // No hidden syntax marks anywhere on the def line (lines is 0..23).
+    // The EmphasisMark ranges (10..12 + 16..18) live inside that span.
+    const hiddenInRange = hidden.filter((h) => h.from < 24);
+    expect(hiddenInRange.length).toBe(0);
+  });
+
+  it('keeps inline syntax chars hidden on a definition line when cursor is OFF it', () => {
+    const doc = '[^1]: see **bold** text\nbody\n';
+    const state = makeState(doc);
+    // Caret on the body line (off the def line).
+    const offLine = doc.indexOf('body');
+    const off = buildMarkdownDecorations(state, {
+      from: offLine,
+      to: offLine,
+    });
+    // The `**` syntax chars should be hidden (off-line case).
+    const hidden: { from: number; to: number }[] = [];
+    off.between(0, doc.length, (from, to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      if (spec.class?.includes('cm-md-syntax') && spec.class?.includes('cm-hidden')) {
+        hidden.push({ from, to });
+      }
+    });
+    const ranges = hidden.map((h) => `${String(h.from)}..${String(h.to)}`).sort();
+    // `**` at 10..12 and 16..18 → both present as hidden marks.
+    expect(ranges).toContain('10..12');
+    expect(ranges).toContain('16..18');
+  });
+
+  it('reveals the [^id] prefix only on the def line the cursor is on (multi-def doc)', () => {
+    const doc = '[^a]: first body\n[^b]: second body\nelsewhere\n';
+    const state = makeState(doc);
+    // Cursor on the SECOND def line (line 2).
+    const onSecond = doc.indexOf('[^b]');
+    const set = buildMarkdownDecorations(state, {
+      from: onSecond,
+      to: onSecond,
+    });
+    // Bear-style inline render: hidden syntax covers the FIRST def's
+    // `[^` (0..2) and `]` (3..4) only — the `:` at 4..5 is never
+    // hidden (it flows as ordinary punctuation in `name: body…`). The
+    // second def's `[^` (17..19) and `]` (20..21) reveal because the
+    // cursor sits on that line.
+    const hidden: { from: number; to: number }[] = [];
+    set.between(0, doc.length, (from, to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      if (spec.class?.includes('cm-md-syntax') && spec.class?.includes('cm-hidden')) {
+        hidden.push({ from, to });
+      }
+    });
+    const ranges = hidden.map((h) => `${String(h.from)}..${String(h.to)}`).sort();
+    expect(ranges).toContain('0..2'); // first def: `[^` hidden
+    expect(ranges).toContain('3..4'); // first def: `]` hidden, `:` left visible
+    expect(ranges).not.toContain('4..5'); // `:` NEVER hidden in any def
+    expect(ranges).not.toContain('17..19'); // second def: `[^` revealed
+    expect(ranges).not.toContain('20..21'); // second def: `]` revealed
+  });
+
+  // -- Resolution: across-doc def lookup --------------------------------
+
+  it('resolves a ref even when the def appears earlier in the doc', () => {
+    const doc = '[^a]: def earlier\n' + '\n' + 'see [^a] in body\n' + 'elsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(state, { from: offLine, to: offLine });
+    const brokens = findMarksByClass(set, 'cm-md-footnote-ref-broken', doc.length);
+    // Def comes first; ref still resolves.
+    expect(brokens.length).toBe(0);
+    const labels = findMarksByClass(set, 'cm-md-footnote-ref', doc.length);
+    expect(labels.length).toBe(1);
+  });
+
+  // -- Smoke: doesn't shadow wikilinks ---------------------------------
+
+  it('does not shadow `[[wikilink]]` recognition', () => {
+    // Note the blank line before the def — CommonMark paragraphs absorb
+    // non-blank continuation lines, so a definition right after prose
+    // would be inside the paragraph unless the parser's `endLeaf` fires.
+    // We provide that interrupt, but the canonical case still has the
+    // blank-line separator; this test pins both paths work together.
+    const doc = 'see [[Note]] today\n\n[^1]: def\nelsewhere\n';
+    const state = makeState(doc);
+    // Wikilink + FootnoteDef both parse cleanly.
+    expect(findNode(state, 'Wikilink')).not.toBeNull();
+    expect(findNode(state, 'FootnoteDef')).not.toBeNull();
+  });
+
+  it('does not crash on an empty doc with no footnotes', () => {
+    const state = makeState('just prose\n');
+    expect(() => buildMarkdownDecorations(state, { from: 0, to: 0 })).not.toThrow();
+  });
+});
+
+describe('mentions (Apple lane Slice 1, widget-mount edition) — chip decoration', () => {
+  /**
+   * Walk the DecorationSet for `Decoration.replace` decos whose widget
+   * is a `MentionChipWidget`. Returns the source range + the widget's
+   * snapshot props in source order.
+   *
+   * Identifying the widget without importing the private class: the
+   * `MentionChipWidget` carries a `props` field with a unique shape
+   * (`email`, `letter`, `image`, `accent`, `stale`, `displayName`).
+   * Other widget types in this file (TableWidget, ImageWidget,
+   * TaskCheckboxWidget, BulletGlyphWidget, OrderedNumberWidget) don't
+   * have a top-level `props` object, so a duck-test on `spec.widget.props.email`
+   * cleanly isolates mention chips without exposing internals.
+   */
+  function findMentionWidgets(
+    set: ReturnType<typeof buildMarkdownDecorations>,
+    docLen: number,
+  ): {
+    from: number;
+    to: number;
+    email: string;
+    displayName: string;
+    letter: string;
+    image: string | null;
+    accent: string;
+    stale: boolean;
+  }[] {
+    const hits: {
+      from: number;
+      to: number;
+      email: string;
+      displayName: string;
+      letter: string;
+      image: string | null;
+      accent: string;
+      stale: boolean;
+    }[] = [];
+    set.between(0, docLen, (from, to, value) => {
+      const spec: {
+        widget?: {
+          props?: {
+            email?: string;
+            displayName?: string;
+            letter?: string;
+            image?: string | null;
+            accent?: string;
+            stale?: boolean;
+          };
+        };
+      } = value.spec as { widget?: { props?: Record<string, unknown> } };
+      const props = spec.widget?.props;
+      if (
+        props !== undefined &&
+        typeof props.email === 'string' &&
+        typeof props.displayName === 'string' &&
+        typeof props.letter === 'string' &&
+        typeof props.accent === 'string' &&
+        typeof props.stale === 'boolean'
+      ) {
+        hits.push({
+          from,
+          to,
+          email: props.email,
+          displayName: props.displayName,
+          letter: props.letter,
+          image: props.image ?? null,
+          accent: props.accent,
+          stale: props.stale,
+        });
+      }
+    });
+    return hits;
+  }
+
+  it('emits a Decoration.replace + MentionChipWidget for a resolved mention with per-user accent', () => {
+    const doc = '[Alice](mention:alice@kb-1.dev) kicked off\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(
+      state,
+      { from: offLine, to: offLine },
+      {
+        orgPeople: [
+          {
+            id: 'user-alice',
+            email: 'alice@kb-1.dev',
+            name: 'Alice Anderson',
+            image: 'https://cdn.example/alice.png',
+          },
+        ],
+      },
+    );
+    const mentions = findMentionWidgets(set, doc.length);
+    expect(mentions.length).toBe(1);
+    expect(mentions[0].stale).toBe(false);
+    expect(mentions[0].email).toBe('alice@kb-1.dev');
+    expect(mentions[0].displayName).toBe('Alice Anderson');
+    expect(mentions[0].image).toBe('https://cdn.example/alice.png');
+    // Per-user accent is hashed off the resolved person's `id` (their
+    // userId) — same hash `<UserAvatar userId={...}>` uses, so chip
+    // color matches the user's avatar everywhere else in the app.
+    expect(mentions[0].accent).toBe(accentForId('user-alice'));
+    // The widget REPLACES the ENTIRE link source (`[Alice](mention:alice@kb-1.dev)`).
+    // Source-range contract: from = `[`, to = `)` + 1.
+    expect(doc.slice(mentions[0].from, mentions[0].to)).toBe('[Alice](mention:alice@kb-1.dev)');
+  });
+
+  it('threads a null image into widget props when the directory entry has no avatar', () => {
+    const doc = '[Bob](mention:bob@kb-1.dev) is reviewing\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(
+      state,
+      { from: offLine, to: offLine },
+      {
+        orgPeople: [
+          {
+            id: 'user-bob',
+            email: 'bob@kb-1.dev',
+            name: 'Bob Booker',
+            image: null,
+          },
+        ],
+      },
+    );
+    const mentions = findMentionWidgets(set, doc.length);
+    expect(mentions.length).toBe(1);
+    expect(mentions[0].image).toBe(null);
+    expect(mentions[0].accent).toBe(accentForId('user-bob'));
+    expect(mentions[0].stale).toBe(false);
+  });
+
+  it('marks a mention as stale with slate accent and null image when the email does not resolve', () => {
+    const doc = '[Carol](mention:carol@former.example) left\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(
+      state,
+      { from: offLine, to: offLine },
+      {
+        // Empty directory — every mention is stale.
+        orgPeople: [],
+      },
+    );
+    const mentions = findMentionWidgets(set, doc.length);
+    expect(mentions.length).toBe(1);
+    expect(mentions[0].stale).toBe(true);
+    // Stale chips fall back to neutral slate — no person to attribute
+    // a vibrant accent to.
+    expect(mentions[0].accent).toBe('slate');
+    expect(mentions[0].image).toBe(null);
+    expect(mentions[0].email).toBe('carol@former.example');
+  });
+
+  it('does NOT emit the standard cm-md-link-label tint over a mention', () => {
+    // The mention widget owns its visual treatment; the link-label tint
+    // would double-paint if it leaked through.
+    const doc = '[Alice](mention:alice@kb-1.dev)\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(
+      state,
+      { from: offLine, to: offLine },
+      {
+        orgPeople: [{ id: 'user-alice', email: 'alice@kb-1.dev', name: 'Alice', image: null }],
+      },
+    );
+    let linkLabelCount = 0;
+    set.between(0, doc.length, (_from, _to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      if (spec.class === 'cm-md-link-label') linkLabelCount++;
+    });
+    expect(linkLabelCount).toBe(0);
+  });
+
+  it('skips the widget ONLY for the mention the cursor sits inside (per-Link reveal)', () => {
+    // Per-Link reveal: caret inside Alice's `[...](mention:...)` range
+    // reveals ONLY Alice's source; Bob's widget on the same line still
+    // emits. With the widget approach this manifests as Bob having a
+    // mention-widget replace decoration while Alice has none.
+    //
+    // Widget existence on its own is necessary but not sufficient — it
+    // doesn't catch a regression where the widget correctly hides but
+    // the underlying syntax marks (`[`, `]`, `(`, `)`, URL) fail to
+    // emit. To lock the full per-Link reveal contract we ALSO assert:
+    //   - Alice (caret inside): syntax marks emit as VISIBLE
+    //     (`cm-md-syntax` without `cm-hidden`) across her Link range.
+    //   - Bob (caret outside): EITHER the widget is present (which
+    //     visually covers the syntax via `Decoration.replace`) OR the
+    //     syntax marks emit as HIDDEN. Either path satisfies "source
+    //     not shown."
+    const doc =
+      'pinging [Alice](mention:alice@kb-1.dev) and [Bob](mention:bob@kb-1.dev) today\nelsewhere\n';
+    const state = makeState(doc);
+    const aliceLabelStart = doc.indexOf('Alice'); // Inside Alice's Link.
+    const set = buildMarkdownDecorations(
+      state,
+      { from: aliceLabelStart, to: aliceLabelStart },
+      {
+        orgPeople: [
+          { id: 'user-alice', email: 'alice@kb-1.dev', name: 'Alice', image: null },
+          { id: 'user-bob', email: 'bob@kb-1.dev', name: 'Bob', image: null },
+        ],
+      },
+    );
+    const mentions = findMentionWidgets(set, doc.length);
+    // Bob's widget should still emit; Alice's should be suppressed.
+    expect(mentions.length).toBe(1);
+    expect(mentions[0].email).toBe('bob@kb-1.dev');
+
+    // Per-Link cursor-reveal: lock the syntax-mark visibility contract
+    // for each mention's range independently.
+    const aliceLinkFrom = doc.indexOf('[Alice]');
+    const aliceLinkTo = doc.indexOf(')', aliceLinkFrom) + 1;
+    const bobLinkFrom = doc.indexOf('[Bob]');
+    const bobLinkTo = doc.indexOf(')', bobLinkFrom) + 1;
+    let aliceVisibleSyntaxCount = 0;
+    let aliceHiddenSyntaxCount = 0;
+    let bobHiddenSyntaxCount = 0;
+    set.between(0, doc.length, (from, _to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      const cls = spec.class ?? '';
+      const isSyntax = cls.includes('cm-md-syntax');
+      const isHidden = cls.includes('cm-hidden');
+      if (!isSyntax) return;
+      if (from >= aliceLinkFrom && from < aliceLinkTo) {
+        if (isHidden) aliceHiddenSyntaxCount++;
+        else aliceVisibleSyntaxCount++;
+      }
+      if (from >= bobLinkFrom && from < bobLinkTo && isHidden) {
+        bobHiddenSyntaxCount++;
+      }
+    });
+    // Alice (caret inside) — source must be revealed.
+    expect(aliceVisibleSyntaxCount).toBeGreaterThan(0);
+    expect(aliceHiddenSyntaxCount).toBe(0);
+    // Bob (caret outside) — source must be hidden. The replace widget
+    // alone visually covers the range, but the syntax-mark hide gate
+    // should also fire so removing the widget (e.g. orgPeople not yet
+    // loaded) doesn't accidentally leak raw `[`/`]`/`(`/`)`/URL. Lock
+    // both halves with an OR — either path satisfies the contract.
+    const bobWidgetPresent = mentions.some((m) => m.email === 'bob@kb-1.dev');
+    expect(bobWidgetPresent || bobHiddenSyntaxCount > 0).toBe(true);
+  });
+
+  it('reveals the source when caret sits at the very start `[` of a mention (selTo === linkFrom)', () => {
+    // Click-on-chip behaviour: clicking the widget lands the cursor at
+    // `linkFrom`. That should count as "inside" so the source reveals
+    // (no widget for this Link). Matches the per-Link reveal contract.
+    const doc = '[Alice](mention:alice@kb-1.dev) and more\nelsewhere\n';
+    const state = makeState(doc);
+    const linkFrom = 0; // `[` is at offset 0.
+    const set = buildMarkdownDecorations(
+      state,
+      { from: linkFrom, to: linkFrom },
+      {
+        orgPeople: [{ id: 'user-alice', email: 'alice@kb-1.dev', name: 'Alice', image: null }],
+      },
+    );
+    const mentions = findMentionWidgets(set, doc.length);
+    expect(mentions.length).toBe(0);
+  });
+
+  it('keeps the widget emitted when caret sits just after `)` of a mention (selTo === linkTo)', () => {
+    // Typing-after behaviour: cursor immediately after the closing `)`
+    // is OUTSIDE the Link's range, so the widget stays rendered.
+    // Without this, the chip would flicker every time the user types
+    // after a mention.
+    const doc = '[Alice](mention:alice@kb-1.dev) and more\nelsewhere\n';
+    const state = makeState(doc);
+    const linkTo = doc.indexOf(')') + 1;
+    const set = buildMarkdownDecorations(
+      state,
+      { from: linkTo, to: linkTo },
+      {
+        orgPeople: [{ id: 'user-alice', email: 'alice@kb-1.dev', name: 'Alice', image: null }],
+      },
+    );
+    const mentions = findMentionWidgets(set, doc.length);
+    expect(mentions.length).toBe(1);
+    expect(mentions[0].email).toBe('alice@kb-1.dev');
+  });
+
+  it('emits a widget for each of multiple mentions on the same line (off-line)', () => {
+    const doc =
+      'pinging [Alice](mention:alice@kb-1.dev) and [Bob](mention:bob@kb-1.dev) today\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(
+      state,
+      { from: offLine, to: offLine },
+      {
+        orgPeople: [{ id: 'user-alice', email: 'alice@kb-1.dev', name: 'Alice', image: null }],
+      },
+    );
+    const mentions = findMentionWidgets(set, doc.length);
+    expect(mentions.length).toBe(2);
+    // Alice resolved, Bob stale (not in directory).
+    const aliceMention = mentions.find((m) => m.email === 'alice@kb-1.dev');
+    const bobMention = mentions.find((m) => m.email === 'bob@kb-1.dev');
+    expect(aliceMention?.stale).toBe(false);
+    expect(bobMention?.stale).toBe(true);
+  });
+
+  it('threads letter from the resolved name (uppercased first char)', () => {
+    const doc = '[alice](mention:alice@kb-1.dev)\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(
+      state,
+      { from: offLine, to: offLine },
+      {
+        orgPeople: [
+          {
+            id: 'user-alice',
+            email: 'alice@kb-1.dev',
+            name: 'Alice Anderson',
+            image: null,
+          },
+        ],
+      },
+    );
+    const mentions = findMentionWidgets(set, doc.length);
+    expect(mentions.length).toBe(1);
+    expect(mentions[0].letter).toBe('A');
+    expect(mentions[0].displayName).toBe('Alice Anderson');
+  });
+
+  it('falls back to the email handle (first char uppercased) for letter when the mention is stale', () => {
+    const doc = '[Carol](mention:carol@former.example) left\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(
+      state,
+      { from: offLine, to: offLine },
+      {
+        orgPeople: [],
+      },
+    );
+    const mentions = findMentionWidgets(set, doc.length);
+    expect(mentions.length).toBe(1);
+    expect(mentions[0].stale).toBe(true);
+    expect(mentions[0].letter).toBe('C');
+    expect(mentions[0].displayName).toBe('carol');
+  });
+
+  it('promotes a stale chip when orgPeople gains the matching entry (eq invalidates on resolution)', () => {
+    // Reactivity contract — when the directory loads after first paint,
+    // the widget's `eq` must return false so CM6 rebuilds the chip with
+    // fresh props. Two builds at the same selection but different
+    // orgPeople snapshots — the widgets must NOT compare equal.
+    const doc = '[Alice](mention:alice@kb-1.dev) kicked off\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const staleSet = buildMarkdownDecorations(
+      state,
+      { from: offLine, to: offLine },
+      { orgPeople: [] },
+    );
+    const resolvedSet = buildMarkdownDecorations(
+      state,
+      { from: offLine, to: offLine },
+      {
+        orgPeople: [
+          {
+            id: 'user-alice',
+            email: 'alice@kb-1.dev',
+            name: 'Alice Anderson',
+            image: 'https://cdn.example/alice.png',
+          },
+        ],
+      },
+    );
+    let staleWidget: { eq: (w: unknown) => boolean } | undefined;
+    staleSet.between(0, doc.length, (_f, _t, value) => {
+      const spec: { widget?: unknown } = value.spec as { widget?: unknown };
+      if (
+        spec.widget !== undefined &&
+        typeof (spec.widget as { props?: { email?: string } }).props?.email === 'string'
+      ) {
+        staleWidget = spec.widget as { eq: (w: unknown) => boolean };
+      }
+    });
+    let resolvedWidget: unknown;
+    resolvedSet.between(0, doc.length, (_f, _t, value) => {
+      const spec: { widget?: unknown } = value.spec as { widget?: unknown };
+      if (
+        spec.widget !== undefined &&
+        typeof (spec.widget as { props?: { email?: string } }).props?.email === 'string'
+      ) {
+        resolvedWidget = spec.widget;
+      }
+    });
+    if (staleWidget === undefined || resolvedWidget === undefined) {
+      throw new Error('expected both stale + resolved widgets to be found');
+    }
+    // eq must return FALSE so CM6 rebuilds; otherwise the stale chip
+    // would persist visually after the directory lands.
+    expect(staleWidget.eq(resolvedWidget)).toBe(false);
+  });
+
+  it('falls through to the standard link-label tint when the URL is not a mention scheme', () => {
+    // Sanity check the Link branch still emits the regular link tint
+    // for non-mention URLs after the mention-detection wedge.
+    const doc = '[Anthropic](https://anthropic.com)\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(state, {
+      from: offLine,
+      to: offLine,
+    });
+    const mentions = findMentionWidgets(set, doc.length);
+    expect(mentions.length).toBe(0);
+    let linkLabelCount = 0;
+    set.between(0, doc.length, (_from, _to, value) => {
+      const spec: { class?: string } = value.spec as { class?: string };
+      if (spec.class === 'cm-md-link-label') linkLabelCount++;
+    });
+    expect(linkLabelCount).toBe(1);
+  });
+});

--- a/packages/editor/src/lib/plaintext-decorations.ts
+++ b/packages/editor/src/lib/plaintext-decorations.ts
@@ -1,0 +1,3819 @@
+/**
+ * Live-Preview-style markdown decorations for the plaintext editor.
+ *
+ * Current scope (post-Slice-4 fix-pass + Slice p polish):
+ *   - Headings (ATX h1–h6) with `# `-mark hide that extends one char
+ *     past the HeaderMark to swallow the trailing space (so heading
+ *     text starts flush at the left edge when the cursor is off-line).
+ *   - Inline emphasis: bold (`**...**` / `__...__`), italic, GFM
+ *     strikethrough (`~~...~~`), inline code (`` `...` ``).
+ *   - Bullet + ordered lists with nested depth (0..5+, clamped).
+ *   - Blockquotes (rendered as a callout: accent bar + tinted bg
+ *     via the CSS in PlaintextEditor.svelte).
+ *   - Fenced code blocks with syntax highlighting for a curated set
+ *     of inner languages (TS/JS/TSX/JSX, Python, JSON, HTML, CSS).
+ *   - GFM tables as block widgets (real `<table>` with rounded
+ *     corners + header tint + subtle zebra; see TableWidget below
+ *     and the `table.cm-md-table` rules in PlaintextEditor.svelte).
+ *   - Inline images as widgets (`![alt](path)` → `<img>`), with
+ *     attachment-path remapping via the optional `attachmentSrc`
+ *     option threaded down from the editor mount.
+ *   - GFM task lists (`- [ ]` / `- [x]`) rendering the 3-char marker
+ *     as an interactive `<input type="checkbox">` widget. Click toggles
+ *     the source via a single `view.dispatch` (undoable via Ctrl-Z).
+ *     Cursor-on-line reveals the raw `[ ]`/`[x]` source for keyboard
+ *     editing — same focus-aware reveal pattern as ListMark.
+ *
+ * Still deferred to later slices: GFM autolinks, footnotes, link
+ * click/hover affordances.
+ *
+ * Slice F (focus-aware reveal): cursor-reveal AND-gated by editor
+ * focus. When the editor loses DOM focus, every syntax char hides —
+ * the document reads as a full Bear-style preview at rest. When the
+ * editor regains focus, normal cursor-reveal resumes. Focus is a
+ * VIEW-level concept (`EditorView.hasFocus`), but our decorations
+ * live in a StateField (block widgets require that — see the
+ * StateField comment at the bottom of this file). The fix is a tiny
+ * bridge: a `ViewPlugin` listens for `update.focusChanged`, dispatches
+ * a `focusEffect` carrying `view.hasFocus`, and a sibling
+ * `editorFocusField` stores the boolean. The decoration field reads
+ * that field via `tr.state.field(...)` and ANDs it with the cursor-
+ * inside predicate. ListMarks follow the Slice L reveal pattern
+ * (replacing Slice Q's always-visible behaviour): off-cursor, bullets
+ * render as shape-glyph widgets (○/▷/●/▶ by depth) and ordered
+ * numbers render as auto-numbered widgets. Bullet/task items reveal
+ * the raw marker when the cursor is inside the item. Ordered items
+ * reveal the raw marker only when the cursor is directly on the marker,
+ * so body editing does not surface stale source numbers. Task-bearing
+ * list items suppress the bullet entirely off-cursor — the checkbox IS
+ * the leading affordance.
+ *
+ * Pattern target: Obsidian Live Preview. When the cursor (or selection
+ * range) is outside a decorated range, the syntax characters (`**`,
+ * `*`, `_`, `~~`, `` ` ``, `# `, `- `, `1. `, `> `, ` ``` `, image /
+ * table source) are hidden — for inline marks via the
+ * `.cm-md-syntax.cm-hidden` rule, for block widgets via
+ * `Decoration.replace({ widget })`. When the cursor enters a range,
+ * the syntax characters are revealed so the user can edit them.
+ *
+ * --- Pipeline placement ----------------------------------------------
+ *
+ * Markdown decorations are document-driven: they rebuild on doc changes
+ * (the lezer-markdown parse tree updates) and on selection changes
+ * (cursor-reveal). The result is exposed through EditorView.decorations.
+ *
+ * --- Architecture ----------------------------------------------------
+ *
+ * 1. `markdown({ extensions: [Strikethrough, Table, TaskList], codeLanguages })`
+ *    from `@codemirror/lang-markdown` parses the doc into a lezer-
+ *    markdown tree. GFM Strikethrough + GFM Table + GFM TaskList are
+ *    enabled; Autolink remains off (later slice).
+ *    `codeLanguages` nests an inner CodeMirror language inside fenced
+ *    code blocks so `syntaxHighlighting(defaultHighlightStyle)`
+ *    (mounted in the extension list below) lights up token classes
+ *    via the lezer highlighter tags emitted by the inner parser.
+ *
+ * 2. A `StateField` (not a `ViewPlugin` — see the StateField comment
+ *    near the bottom of this file for the block-decoration rationale)
+ *    walks the tree via `syntaxTree(state).iterate(...)` on every
+ *    transaction where the doc or selection changed, accumulating
+ *    `Decoration.line(...)` for line-shaped nodes, `Decoration.mark(...)`
+ *    for inline emphasis / inline-code / syntax characters, and
+ *    `Decoration.replace({ widget })` for block widgets (Table) and
+ *    inline widgets (Image). Items are sorted and fed through a
+ *    single `RangeSetBuilder` so CM6's monotonic-position invariant
+ *    holds at every offset.
+ *
+ * 3. The result is exposed via `EditorView.decorations.from(field)` so
+ *    the rendered DOM picks them up. Block widgets force the StateField
+ *    shape; mark + line decorations are happy from either side. See
+ *    `markdownDecorationField` below.
+ *
+ * --- Lezer-markdown node names used here -----------------------------
+ *
+ *   Line-shaped:
+ *     ATXHeading1..ATXHeading6  — `# Foo`, `## Foo`, ...
+ *     ListItem                  — one entry in a BulletList or OrderedList
+ *     Blockquote                — `> ...` (one or more contiguous lines)
+ *     FencedCode                — ```lang ... ``` block
+ *
+ *   Inline-shaped (mark):
+ *     StrongEmphasis            — `**bold**` or `__bold__`
+ *     Emphasis                  — `*italic*` or `_italic_`
+ *     Strikethrough             — `~~strike~~` (GFM)
+ *     InlineCode                — `` `code` ``
+ *
+ *   Syntax-character children of the above (hidden when cursor outside):
+ *     HeaderMark, EmphasisMark, StrikethroughMark, CodeMark,
+ *     ListMark (the `-` / `*` / `1.` token), QuoteMark (the `>` token).
+ *     For FencedCode the opening / closing fence is also `CodeMark`
+ *     children of the FencedCode parent — we disambiguate by parent
+ *     name.
+ *
+ * --- Cursor-reveal pattern -------------------------------------------
+ *
+ * For each decorated range we check whether the main selection's head
+ * falls strictly within `[range.from, range.to]` (inclusive at both
+ * ends so caret-at-boundary reveals — Obsidian behaviour). If yes, we
+ * skip emitting `cm-hidden` marks for that range's syntax characters.
+ * If no, we emit them. The decoration mark itself (bold/italic/...)
+ * is always emitted; only the syntax-char visibility flips.
+ *
+ * For line-anchored block constructs (lists, blockquotes, fences) the
+ * enclosing range is the entire BLOCK — so the cursor anywhere on
+ * any line of a multi-line blockquote / fence reveals the syntax on
+ * every line of that block. This matches Obsidian: enter the fence,
+ * the ```` ``` ```` markers come into view; leave, they vanish.
+ *
+ * --- Nesting (lists) -------------------------------------------------
+ *
+ * BulletList and OrderedList nodes contain ListItems; each ListItem
+ * may contain its own nested BulletList/OrderedList. We compute the
+ * nesting depth on each ListItem by walking up via `node.parent` and
+ * counting list ancestors. The depth feeds `cm-md-listitem-depth-N`
+ * (N = 0..5+, clamped at 5 in CSS) which the stylesheet maps to a
+ * `padding-left` proportional to depth.
+ */
+
+import {
+  EditorView,
+  Decoration,
+  WidgetType,
+  ViewPlugin,
+  type DecorationSet,
+  type ViewUpdate,
+} from '@codemirror/view';
+import {
+  RangeSetBuilder,
+  StateEffect,
+  StateField,
+  type Extension,
+  type Transaction,
+} from '@codemirror/state';
+import {
+  syntaxTree,
+  syntaxHighlighting,
+  HighlightStyle,
+  forceParsing,
+  type Language,
+} from '@codemirror/language';
+import { tags as t } from '@lezer/highlight';
+import { markdown } from '@codemirror/lang-markdown';
+import {
+  Autolink,
+  parser as commonmarkParser,
+  Strikethrough,
+  Table,
+  TaskList,
+  type BlockContext,
+  type Element as MarkdownElement,
+  type InlineContext,
+  type Line,
+  type MarkdownConfig,
+  type MarkdownParser,
+} from '@lezer/markdown';
+import { javascript } from '@codemirror/lang-javascript';
+import { python } from '@codemirror/lang-python';
+import { json } from '@codemirror/lang-json';
+import { html } from '@codemirror/lang-html';
+import { css } from '@codemirror/lang-css';
+import type { EditorState } from '@codemirror/state';
+import type { SyntaxNodeRef, SyntaxNode } from '@lezer/common';
+import {
+  parseMentionUrl,
+  parseWikilinkInner,
+  resolveLinkTarget,
+  resolvePerson,
+  accentForId,
+  type LivePath,
+  type OrgPerson,
+} from './markdown-core';
+import { MentionChipWidget, type MentionChipProps } from './plaintext-mention-widget';
+
+/* ---------------------------------------------------------------- *
+ * Decoration tokens — kept module-private and reused per build so   *
+ * RangeSet de-dup picks them up instead of allocating fresh marks.  *
+ * Decoration.line decos are keyed by class — repeated `.add()` of   *
+ * the same Decoration at the same line offset is a no-op, which is  *
+ * what we want when a line has both (e.g.) a ListItem deco and a    *
+ * nested code-block deco; we only add the most-specific one.        *
+ * ---------------------------------------------------------------- */
+
+const headingDeco = {
+  1: Decoration.line({ class: 'cm-md-h1' }),
+  2: Decoration.line({ class: 'cm-md-h2' }),
+  3: Decoration.line({ class: 'cm-md-h3' }),
+  4: Decoration.line({ class: 'cm-md-h4' }),
+  5: Decoration.line({ class: 'cm-md-h5' }),
+  6: Decoration.line({ class: 'cm-md-h6' }),
+} as const;
+
+// ListItem line decos by depth (0 = top-level, 1 = one nesting level, …).
+// Clamp depth at 5 in the builder; the CSS handles 0..5.
+const listItemDeco: readonly Decoration[] = [
+  Decoration.line({ class: 'cm-md-listitem cm-md-listitem-depth-0' }),
+  Decoration.line({ class: 'cm-md-listitem cm-md-listitem-depth-1' }),
+  Decoration.line({ class: 'cm-md-listitem cm-md-listitem-depth-2' }),
+  Decoration.line({ class: 'cm-md-listitem cm-md-listitem-depth-3' }),
+  Decoration.line({ class: 'cm-md-listitem cm-md-listitem-depth-4' }),
+  Decoration.line({ class: 'cm-md-listitem cm-md-listitem-depth-5' }),
+];
+
+// Task-list "checked" decorations (Slice L). Two decos work together:
+//   - line deco dims the whole row (checkbox + text together).
+//   - body mark applies the strikethrough to JUST the body text range
+//     (after the TaskMarker), NOT the leading hidden syntax chars.
+// We can't put line-through on the line itself: parent text-decoration
+// in CSS draws across every in-flow descendant regardless of the
+// child's own `text-decoration: none`, so the line-through would bleed
+// across the zero-width hidden `-` / `[x]` chars and read as a short
+// leading dash before the checkbox widget.
+// Task-line marker (checked OR unchecked). Sibling of -task-checked,
+// emitted on every task-bearing list item so CSS can gate task-line-
+// specific styling (e.g. the on-cursor alignment column in
+// PlaintextEditor.svelte excludes task lines via this class to keep
+// the checkbox flush — task lines have their own visual column).
+const listItemTaskDeco = Decoration.line({
+  class: 'cm-md-listitem-task',
+});
+const listItemTaskCheckedDeco = Decoration.line({
+  class: 'cm-md-listitem-task-checked',
+});
+const taskCheckedBodyMark = Decoration.mark({
+  class: 'cm-md-listitem-task-checked-body',
+});
+
+const blockquoteLineDeco = Decoration.line({ class: 'cm-md-blockquote' });
+// Fence-frame line decos (Slice T polish, decomposed in Slice T-polish-2).
+//
+// Two-layer decomposition so the monospace font-family survives the
+// cursor-enter "reveal" transition:
+//   - `cm-md-code-block-text`  → font-family + font-size + line-height.
+//     ALWAYS applied to content lines, regardless of cursor position. The
+//     "this is code, not prose" typography signal that must NOT toggle as
+//     the user clicks in / out of the fence — otherwise the body reflows
+//     into the editor's serif body face and the visual jump is jarring.
+//   - `cm-md-code-block-card`  → background-tint + side padding. ONLY
+//     applied off-fence. Paired with positional classes
+//     (`-fence-top` / `-middle` / `-bottom` / `-only`) that add the
+//     border + radius so the run reads as a single rounded slab.
+// `code-fence-delim` still carries the collapse trigger for delimiter
+// lines off-fence; on-fence the delimiter lines get NO decoration at all
+// so the raw ` ```ts ` / ` ``` ` reveals as plain prose for editing.
+const codeFenceDelimDeco = Decoration.line({
+  class: 'cm-md-code-block-text cm-md-code-block-card cm-md-code-fence-delim',
+});
+const codeFenceTopDeco = Decoration.line({
+  class: 'cm-md-code-block-text cm-md-code-block-card cm-md-code-fence-top',
+});
+const codeFenceBottomDeco = Decoration.line({
+  class: 'cm-md-code-block-text cm-md-code-block-card cm-md-code-fence-bottom',
+});
+const codeFenceMiddleDeco = Decoration.line({
+  class: 'cm-md-code-block-text cm-md-code-block-card cm-md-code-fence-middle',
+});
+const codeFenceOnlyDeco = Decoration.line({
+  class: 'cm-md-code-block-text cm-md-code-block-card cm-md-code-fence-only',
+});
+// On-fence content-line deco — text-layer ONLY (monospace persists; no
+// card chrome, no positional class, no language label).
+const codeFenceTextOnlyDeco = Decoration.line({
+  class: 'cm-md-code-block-text',
+});
+const horizontalRuleLineDeco = Decoration.line({ class: 'cm-md-hr' });
+
+const boldMark = Decoration.mark({ class: 'cm-md-bold' });
+const italicMark = Decoration.mark({ class: 'cm-md-italic' });
+const strikeMark = Decoration.mark({ class: 'cm-md-strike' });
+const codeMark = Decoration.mark({ class: 'cm-md-code' });
+const linkLabelMark = Decoration.mark({ class: 'cm-md-link-label' });
+const wikilinkLabelMark = Decoration.mark({ class: 'cm-md-wikilink-label' });
+
+/**
+ * Build the snapshot prop bag the `MentionChipWidget` mounts with. All
+ * resolution happens here — the widget itself is a dumb prop sink so
+ * the Svelte component never has to read query contexts (see the long
+ * comment in `plaintext-mention-widget.ts` for the Path-α-vs-β rationale).
+ *
+ * Resolution falls through the same three layers UserAvatar uses:
+ *   1. directory hit + `name`   → display name, letter from first char.
+ *   2. directory hit + email    → email handle, letter from handle.
+ *   3. directory miss (stale)   → email handle, letter from email,
+ *                                  accent = slate, stale = true.
+ *
+ * The accent is hashed off the resolved person's `id` (their userId) —
+ * the same input `<UserAvatar userId={...}>` consumes — so the editor
+ * chip and the user's avatar everywhere else in the app paint in the
+ * SAME accent. Stale chips fall back to neutral slate because there's
+ * no person to attribute a color to.
+ */
+function buildMentionWidgetProps(email: string, resolved: OrgPerson | null): MentionChipProps {
+  if (resolved === null) {
+    const handle = email.split('@')[0] ?? email;
+    const letter = (handle.length > 0 ? handle.charAt(0) : '?').toUpperCase();
+    return {
+      email,
+      displayName: handle.length > 0 ? handle : email,
+      letter,
+      image: null,
+      accent: 'slate',
+      // Hover affordance: surface the full email even when the local-part
+      // is what's shown as the label. Matches the old CSS chip's
+      // `data-mention-email` attribute behavior.
+      title: email,
+      stale: true,
+    };
+  }
+  const hasName = resolved.name.length > 0;
+  const displayName = hasName ? resolved.name : (resolved.email.split('@')[0] ?? resolved.email);
+  const letter = displayName.charAt(0).toUpperCase();
+  return {
+    email,
+    displayName,
+    letter,
+    image: resolved.image ?? null,
+    accent: accentForId(resolved.id),
+    // Hover affordance — full email exposed even when the chip's label is
+    // the resolved display name. Mirrors the old CSS chip's
+    // `data-mention-email` attribute behavior.
+    title: email,
+    stale: false,
+  };
+}
+
+/**
+ * Walk a Link node's children to extract the mention email when the URL
+ * uses the `mention:<email>` scheme. Returns `null` when the Link has no
+ * URL child or the URL doesn't parse as a mention. Mirrors the inline
+ * walk in the Link-branch of the decoration pass below — extracted so
+ * the chip-paint gate AND the syntax-mark hide gate can both classify
+ * a Link as "mention vs URL link" without duplicating the walk.
+ */
+function extractMentionEmailFromLink(link: SyntaxNode, state: EditorState): string | null {
+  let child: SyntaxNode | null = link.firstChild;
+  while (child !== null) {
+    if (child.type.name === 'URL') {
+      let raw = state.sliceDoc(child.from, child.to).trim();
+      if (raw.startsWith('<') && raw.endsWith('>')) {
+        raw = raw.slice(1, -1);
+      }
+      const parts = parseMentionUrl(raw);
+      return parts !== null ? parts.email : null;
+    }
+    child = child.nextSibling;
+  }
+  return null;
+}
+const wikilinkBrokenMark = Decoration.mark({
+  class: 'cm-md-wikilink-label cm-md-wikilink-broken',
+});
+const footnoteRefMark = Decoration.mark({ class: 'cm-md-footnote-ref' });
+const footnoteRefBrokenMark = Decoration.mark({
+  class: 'cm-md-footnote-ref cm-md-footnote-ref-broken',
+});
+// Inline label paint for FootnoteDef — the `name` between `[^` and `]:` gets
+// link-color styling so the def line reads as "name: body" flowing prose, in
+// the Bear Notes style. No gutter chip, no card chrome — just colored prose.
+const footnoteDefLabelMark = Decoration.mark({
+  class: 'cm-md-footnote-label',
+});
+const hiddenSyntaxMark = Decoration.mark({ class: 'cm-md-syntax cm-hidden' });
+const visibleSyntaxMark = Decoration.mark({ class: 'cm-md-syntax' });
+
+/* ---------------------------------------------------------------- *
+ * Inner-language registry for fenced code blocks.                   *
+ *                                                                   *
+ * `@codemirror/lang-markdown`'s `codeLanguages` option accepts a    *
+ * `(info: string) => Language | LanguageDescription | null`. The    *
+ * `info` string is the text after the opening fence (e.g. "ts",     *
+ * "typescript", "js"). We normalize via lower-case + trim and look  *
+ * up the matching LanguageSupport from the imported lang packs.     *
+ *                                                                   *
+ * Returning a `Language` (not `LanguageSupport`) is what the API    *
+ * expects when we already have an instantiated support module;      *
+ * `LanguageSupport.language` is the Language field. We construct    *
+ * the support modules once at module scope to avoid re-parsing the  *
+ * lezer grammar on every fence.                                     *
+ * ---------------------------------------------------------------- */
+
+const jsSupport = javascript();
+const tsSupport = javascript({ typescript: true });
+const tsxSupport = javascript({ typescript: true, jsx: true });
+const jsxSupport = javascript({ jsx: true });
+const pySupport = python();
+const jsonSupport = json();
+const htmlSupport = html();
+const cssSupport = css();
+
+function lookupFenceLanguage(info: string): Language | null {
+  const tag = info.trim().toLowerCase().split(/\s+/)[0] ?? '';
+  switch (tag) {
+    case 'js':
+    case 'javascript':
+    case 'mjs':
+    case 'cjs':
+      return jsSupport.language;
+    case 'jsx':
+      return jsxSupport.language;
+    case 'ts':
+    case 'typescript':
+      return tsSupport.language;
+    case 'tsx':
+      return tsxSupport.language;
+    case 'py':
+    case 'python':
+      return pySupport.language;
+    case 'json':
+    case 'jsonc':
+      return jsonSupport.language;
+    case 'html':
+    case 'htm':
+    case 'xhtml':
+      return htmlSupport.language;
+    case 'css':
+      return cssSupport.language;
+    default:
+      return null;
+  }
+}
+
+/* ---------------------------------------------------------------- *
+ * Widgets — tables + images (Slice 4)                                *
+ *                                                                    *
+ * The Live-Preview pattern for tables and images is "replace the     *
+ * source range with a widget when the cursor is outside; show raw    *
+ * source when the cursor enters". `Decoration.replace({ widget })`   *
+ * is the canonical CM6 mechanism for that swap.                      *
+ *                                                                    *
+ * Block widget = whole-line(s) replacement, used for Tables.         *
+ * Inline widget = mid-line replacement, used for Images.             *
+ * ---------------------------------------------------------------- */
+
+/**
+ * Block widget rendering a parsed markdown table as an HTML `<table>`.
+ *
+ * `rows[0]` is the header row; `rows[1..]` are body rows. Preview-mode
+ * cell content runs through the same inline markdown grammar as prose,
+ * so bold, links, wikilinks, and mention chips don't flatten to raw
+ * source inside cells. Misaligned column counts are normalized to the
+ * header's length (pad with empty cells, truncate extras) per GFM
+ * convention.
+ *
+ * Equality: two TableWidget instances are equal when their normalized
+ * cell grids match, which lets CM6's RangeSet skip DOM updates when the
+ * underlying source didn't change in a way that affects the rendered
+ * output (e.g. a cursor move past the table doesn't rebuild the DOM).
+ */
+export type ColumnAlignment = 'left' | 'center' | 'right';
+
+class TableWidget extends WidgetType {
+  constructor(
+    readonly header: readonly string[],
+    readonly body: readonly (readonly string[])[],
+    readonly alignments: readonly ColumnAlignment[],
+    readonly inlineContext: TableInlineRenderContext,
+  ) {
+    super();
+  }
+
+  eq(other: WidgetType): boolean {
+    if (!(other instanceof TableWidget)) return false;
+    if (this.header.length !== other.header.length) return false;
+    for (let i = 0; i < this.header.length; i++) {
+      if (this.header[i] !== other.header[i]) return false;
+    }
+    if (this.alignments.length !== other.alignments.length) return false;
+    for (let i = 0; i < this.alignments.length; i++) {
+      if (this.alignments[i] !== other.alignments[i]) return false;
+    }
+    if (this.inlineContext.key !== other.inlineContext.key) return false;
+    if (this.body.length !== other.body.length) return false;
+    for (let r = 0; r < this.body.length; r++) {
+      const a = this.body[r];
+      const b = other.body[r];
+      if (a.length !== b.length) return false;
+      for (let c = 0; c < a.length; c++) {
+        if (a[c] !== b[c]) return false;
+      }
+    }
+    return true;
+  }
+
+  toDOM(view: EditorView): HTMLElement {
+    // Wrap the table in a div so vertical spacing lives inside the
+    // widget's outer border-box. Same shape as the heading
+    // margin→padding fix (commit e8875767): CM6's heightmap measures
+    // line/widget height via `getBoundingClientRect().height`, which
+    // is the border-box and excludes margin. A bare `<table>` with
+    // `margin: 1em 0` would under-count by ~32px and clicks below the
+    // table would drift below the visual target. The wrap owns the
+    // vertical padding so CM6 sees the full visual height.
+    const wrap = document.createElement('div');
+    wrap.className = 'cm-md-table-wrap';
+    const table = document.createElement('table');
+    table.className = 'cm-md-table';
+    const thead = document.createElement('thead');
+    const headerTr = document.createElement('tr');
+    const cols = this.header.length;
+    for (let c = 0; c < cols; c++) {
+      const th = document.createElement('th');
+      appendTableInlineMarkdown(th, this.header[c] ?? '', view, this.inlineContext);
+      const align = this.alignments[c] ?? 'left';
+      th.style.textAlign = align;
+      headerTr.appendChild(th);
+    }
+    thead.appendChild(headerTr);
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    for (const row of this.body) {
+      const tr = document.createElement('tr');
+      // Pad / truncate to header column count (GFM convention). Empty
+      // cells render as empty `<td>` — no widget collapse.
+      for (let c = 0; c < cols; c++) {
+        const td = document.createElement('td');
+        appendTableInlineMarkdown(td, row[c] ?? '', view, this.inlineContext);
+        const align = this.alignments[c] ?? 'left';
+        td.style.textAlign = align;
+        tr.appendChild(td);
+      }
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    wrap.appendChild(table);
+    return wrap;
+  }
+
+  // Tables are an editing affordance — letting the user click inside
+  // the widget to position the cursor is desirable so they can click a
+  // cell to start editing. CM6 default for block widgets is non-atomic
+  // (clicks pass through to position the cursor at the widget's seam),
+  // which is what we want: clicking the table moves the caret into the
+  // source range, which trips cursor-reveal and shows the raw markdown.
+  ignoreEvent(): boolean {
+    return false;
+  }
+}
+
+interface TableInlineRenderContext {
+  key: string;
+  livePaths: readonly LivePath[];
+  orgPeople: readonly OrgPerson[];
+  onWikilinkClick?: (encodedTarget: string, event: MouseEvent) => void;
+}
+
+type InlineElement = MarkdownElement & {
+  readonly children?: readonly InlineElement[];
+};
+
+export type TableInlinePart =
+  | { kind: 'text'; text: string }
+  | { kind: 'strong' | 'emphasis' | 'strike'; children: readonly TableInlinePart[] }
+  | { kind: 'code'; text: string }
+  | { kind: 'link'; href: string; children: readonly TableInlinePart[] }
+  | { kind: 'mention'; props: MentionChipProps }
+  | { kind: 'wikilink'; target: string; label: string; resolved: boolean };
+
+let tableInlineParser: MarkdownParser | null = null;
+
+function getTableInlineParser(): MarkdownParser {
+  tableInlineParser ??= commonmarkParser.configure([Strikethrough, Autolink, wikilinkExtension]);
+  return tableInlineParser;
+}
+
+function tableInlineContextKey(
+  livePaths: readonly LivePath[],
+  orgPeople: readonly OrgPerson[],
+): string {
+  return JSON.stringify({
+    livePaths: livePaths.map((p) => [p.path, p.noteId]),
+    orgPeople: orgPeople.map((p) => [p.id, p.email, p.name, p.image ?? null]),
+  });
+}
+
+function inlineElementName(parser: MarkdownParser, element: InlineElement): string {
+  return parser.nodeSet.types[element.type]?.name ?? '';
+}
+
+function childElements(element: InlineElement): readonly InlineElement[] {
+  return element.children ?? [];
+}
+
+function stripAngleUrl(raw: string): string {
+  const trimmed = raw.trim();
+  return trimmed.startsWith('<') && trimmed.endsWith('>') ? trimmed.slice(1, -1) : trimmed;
+}
+
+function normalizeInlineHref(raw: string): string {
+  const trimmed = stripAngleUrl(raw);
+  if (
+    trimmed.startsWith('http://') ||
+    trimmed.startsWith('https://') ||
+    trimmed.startsWith('mailto:') ||
+    trimmed.startsWith('xmpp:')
+  ) {
+    return trimmed;
+  }
+  if (trimmed.startsWith('www.')) return `https://${trimmed}`;
+  if (trimmed.includes('@') && !trimmed.includes('/')) return `mailto:${trimmed}`;
+  return trimmed;
+}
+
+function pushTextPart(parts: TableInlinePart[], text: string): void {
+  if (text.length === 0) return;
+  const last = parts[parts.length - 1];
+  if (last?.kind === 'text') {
+    parts[parts.length - 1] = { kind: 'text', text: last.text + text };
+  } else {
+    parts.push({ kind: 'text', text });
+  }
+}
+
+function linkUrlFromElement(
+  parser: MarkdownParser,
+  link: InlineElement,
+  source: string,
+): string | null {
+  for (const child of childElements(link)) {
+    if (inlineElementName(parser, child) === 'URL') {
+      return stripAngleUrl(source.slice(child.from, child.to));
+    }
+  }
+  return null;
+}
+
+function linkLabelEnd(parser: MarkdownParser, link: InlineElement, source: string): number | null {
+  for (const child of childElements(link)) {
+    if (inlineElementName(parser, child) !== 'LinkMark') continue;
+    if (child.to - child.from === 1 && source.slice(child.from, child.to) === ']') {
+      return child.from;
+    }
+  }
+  return null;
+}
+
+function wikilinkPartsFromElement(
+  parser: MarkdownParser,
+  wikilink: InlineElement,
+  source: string,
+): { target: string; label: string } | null {
+  let targetText = '';
+  let aliasText: string | null = null;
+  for (const child of childElements(wikilink)) {
+    const name = inlineElementName(parser, child);
+    if (name === 'WikilinkTarget') targetText = source.slice(child.from, child.to);
+    else if (name === 'WikilinkAlias') aliasText = source.slice(child.from, child.to);
+  }
+  const parts = parseWikilinkInner(targetText + (aliasText !== null ? '|' : ''));
+  if (parts === null) return null;
+  const target = parts.target.trim();
+  if (target.length === 0) return null;
+  return { target, label: aliasText ?? targetText };
+}
+
+function tableInlinePartsFromRange(
+  parser: MarkdownParser,
+  source: string,
+  from: number,
+  to: number,
+  elements: readonly InlineElement[],
+  context: Pick<TableInlineRenderContext, 'livePaths' | 'orgPeople'>,
+): TableInlinePart[] {
+  const parts: TableInlinePart[] = [];
+  let pos = from;
+  for (const element of elements) {
+    if (element.to <= from || element.from >= to) continue;
+    if (element.from > pos) pushTextPart(parts, source.slice(pos, element.from));
+    parts.push(...tableInlinePartsFromElement(parser, source, element, context));
+    pos = Math.max(pos, element.to);
+  }
+  if (pos < to) pushTextPart(parts, source.slice(pos, to));
+  return parts;
+}
+
+function tableInlinePartsFromElement(
+  parser: MarkdownParser,
+  source: string,
+  element: InlineElement,
+  context: Pick<TableInlineRenderContext, 'livePaths' | 'orgPeople'>,
+): TableInlinePart[] {
+  const name = inlineElementName(parser, element);
+  const children = childElements(element);
+  if (
+    name === 'EmphasisMark' ||
+    name === 'StrikethroughMark' ||
+    name === 'CodeMark' ||
+    name === 'LinkMark' ||
+    name === 'WikilinkMark' ||
+    name === 'WikilinkAliasMark'
+  ) {
+    return [];
+  }
+  if (name === 'Escape') {
+    return [{ kind: 'text', text: source.slice(element.from + 1, element.to) }];
+  }
+  if (name === 'StrongEmphasis') {
+    return [
+      {
+        kind: 'strong',
+        children: tableInlinePartsFromRange(
+          parser,
+          source,
+          element.from,
+          element.to,
+          children,
+          context,
+        ),
+      },
+    ];
+  }
+  if (name === 'Emphasis') {
+    return [
+      {
+        kind: 'emphasis',
+        children: tableInlinePartsFromRange(
+          parser,
+          source,
+          element.from,
+          element.to,
+          children,
+          context,
+        ),
+      },
+    ];
+  }
+  if (name === 'Strikethrough') {
+    return [
+      {
+        kind: 'strike',
+        children: tableInlinePartsFromRange(
+          parser,
+          source,
+          element.from,
+          element.to,
+          children,
+          context,
+        ),
+      },
+    ];
+  }
+  if (name === 'InlineCode') {
+    const childParts = tableInlinePartsFromRange(
+      parser,
+      source,
+      element.from,
+      element.to,
+      children,
+      context,
+    );
+    return [
+      {
+        kind: 'code',
+        text: childParts.map((part) => (part.kind === 'text' ? part.text : '')).join(''),
+      },
+    ];
+  }
+  if (name === 'Link') {
+    const href = linkUrlFromElement(parser, element, source);
+    const labelEnd = linkLabelEnd(parser, element, source);
+    if (href === null || labelEnd === null)
+      return [{ kind: 'text', text: source.slice(element.from, element.to) }];
+    const mention = parseMentionUrl(href);
+    if (mention !== null) {
+      const resolved = resolvePerson(mention.email, context.orgPeople);
+      return [{ kind: 'mention', props: buildMentionWidgetProps(mention.email, resolved) }];
+    }
+    return [
+      {
+        kind: 'link',
+        href: normalizeInlineHref(href),
+        children: tableInlinePartsFromRange(
+          parser,
+          source,
+          element.from + 1,
+          labelEnd,
+          children,
+          context,
+        ),
+      },
+    ];
+  }
+  if (name === 'URL') {
+    const raw = source.slice(element.from, element.to);
+    return [
+      { kind: 'link', href: normalizeInlineHref(raw), children: [{ kind: 'text', text: raw }] },
+    ];
+  }
+  if (name === 'Wikilink') {
+    const parsed = wikilinkPartsFromElement(parser, element, source);
+    if (parsed === null) return [{ kind: 'text', text: source.slice(element.from, element.to) }];
+    const resolved = resolveLinkTarget({ raw: parsed.target, livePaths: context.livePaths });
+    return [
+      {
+        kind: 'wikilink',
+        target: parsed.target,
+        label: parsed.label,
+        resolved: resolved !== null,
+      },
+    ];
+  }
+  if (children.length > 0) {
+    return tableInlinePartsFromRange(parser, source, element.from, element.to, children, context);
+  }
+  return [{ kind: 'text', text: source.slice(element.from, element.to) }];
+}
+
+export function parseTableCellInlineMarkdown(
+  source: string,
+  context: Pick<TableInlineRenderContext, 'livePaths' | 'orgPeople'> = {
+    livePaths: [],
+    orgPeople: [],
+  },
+): TableInlinePart[] {
+  const parser = getTableInlineParser();
+  const elements = parser.parseInline(source, 0) as readonly InlineElement[];
+  return tableInlinePartsFromRange(parser, source, 0, source.length, elements, context);
+}
+
+function appendTableInlineParts(
+  parent: HTMLElement,
+  parts: readonly TableInlinePart[],
+  view: EditorView,
+  context: TableInlineRenderContext,
+): void {
+  for (const part of parts) {
+    if (part.kind === 'text') {
+      parent.appendChild(document.createTextNode(part.text));
+    } else if (part.kind === 'strong') {
+      const strong = document.createElement('strong');
+      strong.className = 'cm-md-bold';
+      appendTableInlineParts(strong, part.children, view, context);
+      parent.appendChild(strong);
+    } else if (part.kind === 'emphasis') {
+      const em = document.createElement('em');
+      em.className = 'cm-md-italic';
+      appendTableInlineParts(em, part.children, view, context);
+      parent.appendChild(em);
+    } else if (part.kind === 'strike') {
+      const strike = document.createElement('s');
+      strike.className = 'cm-md-strike';
+      appendTableInlineParts(strike, part.children, view, context);
+      parent.appendChild(strike);
+    } else if (part.kind === 'code') {
+      const code = document.createElement('code');
+      code.className = 'cm-md-code';
+      code.textContent = part.text;
+      parent.appendChild(code);
+    } else if (part.kind === 'mention') {
+      parent.appendChild(new MentionChipWidget(part.props).toDOM(view));
+    } else if (part.kind === 'link') {
+      const link = document.createElement('a');
+      link.className = 'cm-md-link-label';
+      link.href = part.href;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.addEventListener('mousedown', (event) => {
+        event.stopPropagation();
+      });
+      appendTableInlineParts(link, part.children, view, context);
+      parent.appendChild(link);
+    } else if (part.kind === 'wikilink') {
+      const link = document.createElement('a');
+      link.href = '#';
+      link.className = part.resolved
+        ? 'cm-md-wikilink-label'
+        : 'cm-md-wikilink-label cm-md-wikilink-broken';
+      link.textContent = part.label;
+      link.addEventListener('mousedown', (event) => {
+        event.stopPropagation();
+      });
+      link.addEventListener('click', (event) => {
+        event.preventDefault();
+        context.onWikilinkClick?.(encodeURIComponent(part.target), event);
+      });
+      parent.appendChild(link);
+    }
+  }
+}
+
+function appendTableInlineMarkdown(
+  parent: HTMLElement,
+  source: string,
+  view: EditorView,
+  context: TableInlineRenderContext,
+): void {
+  appendTableInlineParts(parent, parseTableCellInlineMarkdown(source, context), view, context);
+}
+
+/**
+ * Image-widget render mode. Three branches the source URL can take:
+ *
+ *   - `normal`  — render `<img>` against `resolvedSrc`; the existing
+ *                 `onerror` fallback paints the broken-image glyph if
+ *                 the load fails.
+ *   - `pending` — paste/drop optimistic placeholder from documents that
+ *                 already contain a pending upload sentinel. Render a
+ *                 small spinner overlay instead of `<img>`.
+ *   - `failed`  — upload failed sentinel. Render the same broken-image
+ *                 glyph the `onerror` path uses, so the user gets a
+ *                 consistent "didn't load" signal.
+ */
+type ImageWidgetMode = 'normal' | 'pending' | 'failed';
+
+const PENDING_UPLOAD_PREFIX = 'pending-upload://';
+const UPLOAD_FAILED_PREFIX = 'upload-failed://';
+
+function classifyImageUrl(rawUrl: string): ImageWidgetMode {
+  if (rawUrl.startsWith(PENDING_UPLOAD_PREFIX)) return 'pending';
+  if (rawUrl.startsWith(UPLOAD_FAILED_PREFIX)) return 'failed';
+  return 'normal';
+}
+
+const BROKEN_IMAGE_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" width="28" height="28" fill="currentColor" viewBox="0 0 256 256"><path d="M216,42H40A14,14,0,0,0,26,56V200a14,14,0,0,0,14,14h64a6,6,0,0,0,5.69-4.1l15.12-45.36,37.42-15a6,6,0,0,0,3.34-3.34l15-37.42L225.9,93.69A6,6,0,0,0,230,88V56A14,14,0,0,0,216,42ZM117.77,154.43a6,6,0,0,0-3.46,3.67L99.68,202H40a2,2,0,0,1-2-2V171.17l52.58-52.58a2,2,0,0,1,2.83,0L126,151.15ZM218,83.68,174.1,98.31a6,6,0,0,0-3.67,3.46l-15.05,37.61L138.1,146.3l-36.2-36.2a14,14,0,0,0-19.8,0L38,154.2V56a2,2,0,0,1,2-2H216a2,2,0,0,1,2,2Zm9.51,33.18a6,6,0,0,0-5.41-.82L198.3,124a6,6,0,0,0-3.67,3.47L180,164l-36.56,14.63A6,6,0,0,0,140,182.3L132,206.1a6,6,0,0,0,5.69,7.9H216a14,14,0,0,0,14-14V121.73A6,6,0,0,0,227.51,116.86ZM218,200a2,2,0,0,1-2,2H146.06l4.42-13.26,36.37-14.55a6,6,0,0,0,3.34-3.34l14.55-36.37L218,130.06Z"/></svg>';
+
+function renderBrokenFallback(alt: string): HTMLSpanElement {
+  const fallback = document.createElement('span');
+  fallback.className = 'cm-md-image-broken';
+  // Keep `alt` on the aria-label so screen readers can still identify
+  // a failed-image as "broken image: <alt>"; visually we render only
+  // the muted Phosphor ImageBroken glyph (no trailing alt-text span).
+  fallback.setAttribute('aria-label', alt || 'broken image');
+  fallback.innerHTML = BROKEN_IMAGE_SVG;
+  return fallback;
+}
+
+/**
+ * Inline widget rendering a markdown image as an `<img>`. Source range
+ * is `![alt](url)`; widget replaces the whole range when cursor is
+ * outside.
+ *
+ * `resolvedSrc` is the final URL after attachment-path remapping; `alt`
+ * is the raw alt text (may be empty — valid markdown). Sizing is
+ * `max-width: 100%; height: auto` via CSS; v1 has no captions, no
+ * custom sizing syntax, no figure wrapping.
+ *
+ * `mode` carries the optimistic-sentinel state (pending upload /
+ * upload failed / normal) so a paste-in-progress renders a spinner
+ * and a failed paste renders the broken-image glyph. See
+ * `plaintext-image-upload.ts` for the upload pipeline that mints the
+ * sentinel URLs.
+ */
+class ImageWidget extends WidgetType {
+  constructor(
+    readonly resolvedSrc: string,
+    readonly alt: string,
+    readonly mode: ImageWidgetMode = 'normal',
+  ) {
+    super();
+  }
+
+  eq(other: WidgetType): boolean {
+    return (
+      other instanceof ImageWidget &&
+      other.resolvedSrc === this.resolvedSrc &&
+      other.alt === this.alt &&
+      other.mode === this.mode
+    );
+  }
+
+  toDOM(): HTMLElement {
+    const wrapper = document.createElement('span');
+    wrapper.className = 'cm-md-image-widget';
+
+    // Pending upload — small inline spinner. We render an inline
+    // <span> with a CSS-animated rotation; the CSS keyframes live in
+    // PlaintextEditor.svelte alongside the rest of the editor styles.
+    if (this.mode === 'pending') {
+      wrapper.dataset.state = 'pending';
+      const spinner = document.createElement('span');
+      spinner.className = 'cm-md-image-spinner';
+      spinner.setAttribute('role', 'img');
+      spinner.setAttribute('aria-label', this.alt ? `Uploading ${this.alt}…` : 'Uploading image…');
+      // Phosphor CircleNotch — looks like a spinner once we rotate it
+      // via CSS. Single arc + transparent fill so the spin is visually
+      // clean. Same icon weight as the broken-image glyph.
+      spinner.innerHTML =
+        '<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="20" height="20" fill="currentColor" viewBox="0 0 256 256"><path d="M232,128a104,104,0,0,1-208,0c0-41,23.81-78.36,60.66-95.27a8,8,0,0,1,6.68,14.54C60.15,61.59,40,93,40,128a88,88,0,0,0,176,0c0-35-20.15-66.41-51.34-80.73a8,8,0,0,1,6.68-14.54C208.19,49.64,232,87,232,128Z"/></svg>';
+      wrapper.appendChild(spinner);
+      return wrapper;
+    }
+
+    // Upload failed (sentinel persisted across an error) — same
+    // broken-image glyph the runtime `<img>.onerror` falls back to,
+    // so the user gets a consistent "didn't load" signal.
+    if (this.mode === 'failed') {
+      wrapper.dataset.state = 'broken';
+      wrapper.appendChild(renderBrokenFallback(this.alt));
+      return wrapper;
+    }
+
+    // Normal path.
+    const img = document.createElement('img');
+    img.className = 'cm-md-image';
+    img.src = this.resolvedSrc;
+    img.alt = this.alt;
+    img.loading = 'lazy';
+    const alt = this.alt;
+    // On load failure swap the <img> for a muted Phosphor ImageBroken
+    // glyph (light-weight, viewBox 0 0 256 256). The browser's default
+    // broken-image icon is OS-specific and doesn't match kb-1's visual
+    // language — see PlaintextEditor.svelte `.cm-md-image-widget` rules.
+    img.onerror = () => {
+      wrapper.dataset.state = 'broken';
+      wrapper.textContent = '';
+      wrapper.appendChild(renderBrokenFallback(alt));
+    };
+    wrapper.appendChild(img);
+    return wrapper;
+  }
+
+  // Allow clicks to pass through so the caret can land inside the
+  // source range — same affordance as TableWidget. The user clicking
+  // an image to edit its markdown is the expected gesture.
+  ignoreEvent(): boolean {
+    return false;
+  }
+}
+
+/**
+ * Inline widget rendering a GFM task-list checkbox (`- [ ]` / `- [x]`).
+ *
+ * Source-range contract: the widget REPLACES the 3-char `TaskMarker`
+ * range (`[ ]` / `[x]` / `[X]`) only — the leading list bullet (`- `)
+ * is suppressed via the `ListMark`-branch (task-bearing items emit no
+ * bullet glyph; the checkbox IS the leading affordance). The trailing
+ * item text renders normally.
+ *
+ * Visual register (Slice L redesign): the widget renders custom glyphs
+ * in `currentColor`, not the browser-native `<input type="checkbox">`.
+ *   - Unchecked: a small rounded-corner outline square at ~0.45 opacity.
+ *   - Checked:   the Phosphor `Check` SVG path in currentColor, no tint.
+ * Both glyphs sit on the text baseline and read as typographic
+ * punctuation, not a UI control. Bear-clean — the original native
+ * checkbox's blue accent fought the editor's quiet palette.
+ *
+ * Toggle: a `mousedown` listener inside `toDOM` reads the current marker
+ * text from the doc (via the `view` param passed to `toDOM`), flips the
+ * source, and dispatches a single `view.dispatch({ changes })`. The
+ * sync plugin (PlaintextSyncPlugin in PlaintextEditor.svelte) writes
+ * the change back to Y.Text with `PLAINTEXT_USER_ORIGIN`, which is
+ * tracked by the UndoManager — so Ctrl-Z reverses the toggle exactly
+ * like undoing a typed character.
+ *
+ * Why mousedown, not click: when the redecoration after the dispatch
+ * destroys this widget's DOM between mousedown and mouseup, the
+ * browser silently drops the `click` event. mousedown fires before any
+ * DOM mutation so the handler runs reliably. Same class of bug as
+ * `feedback_click_event_cancellation_on_dom_mutation.md`.
+ *
+ * `ignoreEvent` returns `true` so CM6 doesn't repurpose the click to
+ * position the caret at the widget's seam. The widget owns its events.
+ *
+ * Equality: two TaskCheckboxWidgets are equal when their checked state
+ * AND source-range position match. Source position matters because
+ * after edits above the line the same `checked` state at a different
+ * offset is still a logically different widget (different toggle target).
+ */
+// Phosphor `Check` SVG path data (viewBox 0 0 256 256, weight: regular).
+// Hardcoded here so the widget can render inline without mounting a
+// Svelte component inside a CM6 DOM widget. Same inline-SVG pattern as
+// `BROKEN_IMAGE_SVG` above.
+const CHECK_SVG_PATH =
+  'M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z';
+
+class TaskCheckboxWidget extends WidgetType {
+  constructor(
+    readonly checked: boolean,
+    readonly markerFrom: number,
+    readonly markerTo: number,
+  ) {
+    super();
+  }
+
+  eq(other: WidgetType): boolean {
+    return (
+      other instanceof TaskCheckboxWidget &&
+      other.checked === this.checked &&
+      other.markerFrom === this.markerFrom &&
+      other.markerTo === this.markerTo
+    );
+  }
+
+  toDOM(view: EditorView): HTMLElement {
+    const wrap = document.createElement('span');
+    wrap.className = this.checked
+      ? 'cm-md-task-checkbox cm-md-task-checkbox-checked'
+      : 'cm-md-task-checkbox cm-md-task-checkbox-unchecked';
+    // Custom inline-SVG glyph in `currentColor`:
+    //   - Checked   → Phosphor `Check` icon path on a transparent box.
+    //   - Unchecked → an empty rounded-corner square (the box itself).
+    // CSS in PlaintextEditor.svelte sizes the box, sets the opacity,
+    // and paints the border for the unchecked state. The widget DOM
+    // is identical-shape across both states (one <span> wrapper, one
+    // <svg> inner) so CSS class-toggling is the only branch the
+    // browser sees on toggle.
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 256 256');
+    svg.setAttribute('aria-hidden', 'true');
+    svg.setAttribute('focusable', 'false');
+    svg.classList.add('cm-md-task-checkbox-glyph');
+    if (this.checked) {
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('d', CHECK_SVG_PATH);
+      path.setAttribute('fill', 'currentColor');
+      svg.appendChild(path);
+    }
+    // A11y: expose role/state for screen readers; the widget is
+    // visually a checkbox even though it's not an <input>.
+    wrap.setAttribute('role', 'checkbox');
+    wrap.setAttribute('aria-checked', this.checked ? 'true' : 'false');
+    wrap.appendChild(svg);
+
+    const onMouseDown = (event: MouseEvent): void => {
+      // Left-click only — right-click and middle-click stay out of the
+      // toggle path so the browser's context menu / paste-with-middle-
+      // click defaults aren't repurposed.
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.stopPropagation();
+      // Re-read the marker from the live doc — the constructor-captured
+      // positions can stale across edits above the line, but in the
+      // common case (toggling the same widget instance) they're current.
+      // If the slice doesn't look like a TaskMarker any more, bail —
+      // the next decoration rebuild will replace this widget with a
+      // fresh one matching the current parse.
+      const { from, to } = this.currentRange(view);
+      if (from === null || to === null) return;
+      const current = view.state.sliceDoc(from, to);
+      if (!/^\[[ xX]\]$/.test(current)) return;
+      const next = current === '[ ]' ? '[x]' : '[ ]';
+      view.dispatch({
+        changes: { from, to, insert: next },
+      });
+    };
+    wrap.addEventListener('mousedown', onMouseDown);
+    return wrap;
+  }
+
+  /**
+   * Recompute the marker range against the current doc. The widget is
+   * constructed with absolute positions; if edits land BEFORE the marker
+   * the positions drift, but CM6 rebuilds the decoration set on every
+   * doc change so a stale widget rarely survives a click. We still
+   * read fresh from `view.state` here as a belt-and-suspenders: the
+   * constructor positions are the target on the post-rebuild doc, but
+   * inside an in-flight transaction (rare) they might not match.
+   *
+   * Returns `{from, to}` of the marker if the slice still looks like a
+   * task marker; `{null, null}` otherwise.
+   */
+  private currentRange(view: EditorView): {
+    from: number | null;
+    to: number | null;
+  } {
+    const docLen = view.state.doc.length;
+    if (this.markerTo > docLen) return { from: null, to: null };
+    return { from: this.markerFrom, to: this.markerTo };
+  }
+
+  ignoreEvent(): boolean {
+    // Atomic to CM6 — we handle mousedown ourselves; don't let CM6
+    // hijack the event to position the caret at the widget seam.
+    return true;
+  }
+}
+
+/**
+ * Inline widget rendering an unordered-list bullet glyph (Slice L).
+ *
+ * Source-range contract: replaces the `ListMark` range (the `-` / `*` /
+ * `+` char) when the cursor is OFF the ListItem; cursor-inside reveals
+ * the raw `-`. Same toggle pattern as `HorizontalRule`'s reveal.
+ *
+ * Glyph cycle by depth (Phosphor SVG paths, 256×256 viewBox):
+ *   depth 0 → solid circle  (Phosphor Circle weight=fill)
+ *   depth 1 → empty circle  (Phosphor Circle weight=regular)
+ *   depth 2 → solid triangle (Phosphor Triangle weight=fill, points up)
+ *   depth 3 → empty triangle (Phosphor Triangle weight=regular, points up)
+ *   depth 4+ cycles through the set.
+ *
+ * Phosphor paths inlined (rather than mounting Svelte components inside
+ * a CM6 widget) match the same pattern as TaskCheckboxWidget's CHECK_SVG_PATH.
+ *
+ * The widget is non-interactive (no toggle, no click handler).
+ * `ignoreEvent()` returns `true` so CM6 doesn't try to position the
+ * caret at the widget seam; clicks on the bullet pass through to the
+ * surrounding `.cm-content` and CM6 handles cursor placement normally.
+ *
+ * Equality: by depth only — same depth at any source offset renders
+ * identical DOM, so CM6's RangeSet de-dupes correctly across rebuilds.
+ */
+const CIRCLE_FILL_PATH = 'M232,128A104,104,0,1,1,128,24,104.13,104.13,0,0,1,232,128Z';
+const CIRCLE_REGULAR_PATH =
+  'M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Z';
+// Diamond paths (Phosphor `Diamond` icon — fill + regular weights).
+// Lifted verbatim from `phosphor-svelte/lib/Diamond.svelte`. Replaces
+// the earlier triangle pair: deep-nesting bullets read as cleaner /
+// more even alongside the top-level filled dot + level-2 hollow circle
+// (a triangle leans visually heavier on one side; a diamond is radial
+// like the circles).
+const DIAMOND_FILL_PATH =
+  'M240,128a15.85,15.85,0,0,1-4.67,11.28l-96.05,96.06a16,16,0,0,1-22.56,0h0l-96-96.06a16,16,0,0,1,0-22.56l96.05-96.06a16,16,0,0,1,22.56,0l96.05,96.06A15.85,15.85,0,0,1,240,128Z';
+const DIAMOND_REGULAR_PATH =
+  'M235.33,116.72,139.28,20.66a16,16,0,0,0-22.56,0l-96,96.06a16,16,0,0,0,0,22.56l96.05,96.06h0a16,16,0,0,0,22.56,0l96.05-96.06a16,16,0,0,0,0-22.56ZM128,224h0L32,128,128,32,224,128Z';
+
+const BULLET_GLYPH_PATHS = [
+  CIRCLE_FILL_PATH,
+  CIRCLE_REGULAR_PATH,
+  DIAMOND_FILL_PATH,
+  DIAMOND_REGULAR_PATH,
+] as const;
+
+function bulletGlyphPathForDepth(depth: number): string {
+  // Cycle by modulo so depth-4 wraps to depth-0's glyph, depth-5 to
+  // depth-1's, etc. Negative depth shouldn't happen (listItemDepth
+  // clamps at 0) but be defensive.
+  const n = depth < 0 ? 0 : depth;
+  const idx = n % BULLET_GLYPH_PATHS.length;
+  return BULLET_GLYPH_PATHS[idx] ?? BULLET_GLYPH_PATHS[0];
+}
+
+class BulletGlyphWidget extends WidgetType {
+  constructor(readonly depth: number) {
+    super();
+  }
+
+  eq(other: WidgetType): boolean {
+    return other instanceof BulletGlyphWidget && other.depth === this.depth;
+  }
+
+  toDOM(): HTMLElement {
+    const span = document.createElement('span');
+    span.className = 'cm-md-bullet-glyph';
+    span.setAttribute('aria-hidden', 'true');
+    span.innerHTML =
+      '<svg viewBox="0 0 256 256" fill="currentColor" xmlns="http://www.w3.org/2000/svg">' +
+      `<path d="${bulletGlyphPathForDepth(this.depth)}"/>` +
+      '</svg>';
+    return span;
+  }
+
+  ignoreEvent(): boolean {
+    // Not interactive — let CM6 handle clicks via the surrounding
+    // .cm-content so caret placement works normally.
+    return true;
+  }
+}
+
+/**
+ * Inline widget rendering an ordered-list number (Slice L).
+ *
+ * Source-range contract: replaces the `ListMark` range (e.g. `1.` / `5.`)
+ * when the cursor is OFF the enclosing ListItem; cursor-inside reveals
+ * the raw source number.
+ *
+ * Display value: CommonMark-style auto-numbering. The first item in an
+ * `OrderedList` sets the start; subsequent items render `start + offset`
+ * regardless of what was written in source. So:
+ *
+ *   1. foo  → 1.
+ *   1. bar  → 2.
+ *   1. baz  → 3.
+ *
+ * and:
+ *
+ *   5. foo  → 5.
+ *   1. bar  → 6.
+ *
+ * The displayed glyph is `<n>.` (period delimiter) — even when the
+ * source used `)`, we normalize to a period because that's the
+ * canonical CommonMark display in most renderers and reads cleaner.
+ *
+ * Equality: by display value only.
+ */
+class OrderedNumberWidget extends WidgetType {
+  constructor(readonly displayValue: number) {
+    super();
+  }
+
+  eq(other: WidgetType): boolean {
+    return other instanceof OrderedNumberWidget && other.displayValue === this.displayValue;
+  }
+
+  toDOM(): HTMLElement {
+    const span = document.createElement('span');
+    span.className = 'cm-md-ordered-number';
+    span.setAttribute('aria-hidden', 'true');
+    span.textContent = this.displayValue.toFixed(0) + '.';
+    return span;
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+/**
+ * Line widget rendering the fence's info-string (e.g. "ts", "python") as a
+ * small muted label pinned to the top-right corner of the rendered code
+ * box. Emitted only when the cursor is OFF the fence — when the cursor
+ * enters, the opening fence line reveals (raw ```ts) so a corner label
+ * would duplicate information. The label sits inside the bordered region
+ * via absolute positioning anchored to the line's relative-positioned
+ * box (see `.cm-md-code-fence-top::after` rules in
+ * `PlaintextEditor.svelte`).
+ *
+ * We use `Decoration.line({ attributes: { 'data-fence-lang': lang } })`
+ * to attach the label text, then CSS `content: attr(...)` renders it.
+ * That keeps the widget surface a plain HTML attribute — no extra DOM
+ * node, no CM6 widget bookkeeping. The CSS handles font-size, position,
+ * and color.
+ */
+const fenceLangAttrCache = new Map<string, Decoration>();
+function fenceTopWithLang(lang: string): Decoration {
+  // Cache the per-language Decoration.line so repeated builds on the same
+  // doc reuse the same Decoration reference and CM6's RangeSet de-dupes
+  // it identically to the static `codeFenceTopDeco` above.
+  const existing = fenceLangAttrCache.get(lang);
+  if (existing !== undefined) return existing;
+  const deco = Decoration.line({
+    class: 'cm-md-code-block-text cm-md-code-block-card cm-md-code-fence-top',
+    attributes: { 'data-fence-lang': lang },
+  });
+  fenceLangAttrCache.set(lang, deco);
+  return deco;
+}
+function fenceOnlyWithLang(lang: string): Decoration {
+  const key = `__only__${lang}`;
+  const existing = fenceLangAttrCache.get(key);
+  if (existing !== undefined) return existing;
+  const deco = Decoration.line({
+    class: 'cm-md-code-block-text cm-md-code-block-card cm-md-code-fence-only',
+    attributes: { 'data-fence-lang': lang },
+  });
+  fenceLangAttrCache.set(key, deco);
+  return deco;
+}
+
+/* ---------------------------------------------------------------- *
+ * URL resolution — attachment paths vs absolute URLs                *
+ *                                                                    *
+ * Markdown can store attachments as bare paths in `![](path)`. The   *
+ * host may pass `attachmentSrc` to resolve those paths at render      *
+ * time; omitted hooks leave the source URL untouched.                 *
+ *                                                                    *
+ * Heuristic: anything with a recognized URL scheme prefix             *
+ * (`http(s)://`, `data:`, `blob:`, `mailto:`) OR starting with `/`   *
+ * (root-relative) is treated as already-resolved. Anything else is   *
+ * an attachment path → run through `attachmentSrc()`.                *
+ *                                                                    *
+ * `attachmentSrc` is optional — when missing (Storybook / no vault   *
+ * context), bare paths pass through verbatim; the browser will       *
+ * render a broken-image icon, which is the same fallback Milkdown    *
+ * gets when its remap is omitted.                                    *
+ * ---------------------------------------------------------------- */
+
+const ABSOLUTE_URL_RE = /^(?:https?:|data:|blob:|mailto:|file:|\/\/|\/|#)/i;
+
+function resolveImageUrl(
+  rawUrl: string,
+  attachmentSrc: ((path: string) => string) | undefined,
+): string {
+  const url = rawUrl.trim();
+  if (url === '') return url;
+  if (ABSOLUTE_URL_RE.test(url)) return url;
+  if (attachmentSrc) return attachmentSrc(url);
+  return url;
+}
+
+/* ---------------------------------------------------------------- *
+ * Helpers                                                            *
+ * ---------------------------------------------------------------- */
+
+/**
+ * List-item nesting depth — count BulletList/OrderedList ancestors
+ * above this node (exclusive of the node itself; a top-level ListItem
+ * sits directly under one BulletList/OrderedList → its depth is 0).
+ *
+ * Lezer-markdown trees nest as:
+ *   BulletList
+ *     ListItem
+ *       BulletList         ← nested list lives inside the parent ListItem
+ *         ListItem         ← depth = 1
+ *           BulletList
+ *             ListItem     ← depth = 2
+ *
+ * So depth = (# of BulletList/OrderedList ancestors) - 1.
+ */
+function listItemDepth(node: SyntaxNode): number {
+  let depth = -1;
+  let parent: SyntaxNode | null = node.parent;
+  while (parent !== null) {
+    const n = parent.type.name;
+    if (n === 'BulletList' || n === 'OrderedList') depth++;
+    parent = parent.parent;
+  }
+  if (depth < 0) depth = 0;
+  if (depth > 5) depth = 5;
+  return depth;
+}
+
+/**
+ * Does this ListItem contain a GFM `Task` child (i.e. is it a task-list
+ * item, `- [ ] …` / `- [x] …`)?
+ *
+ * Lezer-markdown's TaskList extension nests the `Task` block directly
+ * under `ListItem`:
+ *
+ *   ListItem
+ *     ListMark        ← `- `
+ *     Task            ← block; spans `[ ]` + inline content
+ *       TaskMarker    ← `[ ]` / `[x]` / `[X]`
+ *
+ * Walk the ListItem's direct children looking for a `Task` node. We
+ * stop at the first match — a ListItem has at most one Task child by
+ * GFM's grammar.
+ */
+function listItemHasTask(listItem: SyntaxNode): boolean {
+  let child: SyntaxNode | null = listItem.firstChild;
+  while (child !== null) {
+    if (child.type.name === 'Task') return true;
+    child = child.nextSibling;
+  }
+  return false;
+}
+
+/**
+ * Is this ListItem nested inside an OrderedList (vs a BulletList)?
+ * Looks at the immediate parent only — that's where lezer-markdown
+ * attaches the ListItem under a list-block node.
+ */
+function listItemIsOrdered(listItem: SyntaxNode): boolean {
+  const parent = listItem.parent;
+  if (parent === null) return false;
+  return parent.type.name === 'OrderedList';
+}
+
+/**
+ * Parse the leading numeric run from a `ListMark` source string. Lezer-
+ * markdown's ListMark for an OrderedList item is the literal source
+ * (e.g. `1.`, `42)`, `5.`); we strip the trailing delimiter and parse
+ * the digits. Returns `null` for non-numeric marks (bullet lists).
+ */
+function parseOrderedMark(markText: string): number | null {
+  const m = /^(\d+)/.exec(markText);
+  if (m === null) return null;
+  const n = Number.parseInt(m[1], 10);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+/**
+ * Pre-pass: walk every `OrderedList` in the tree and assign a display
+ * number to each of its direct `ListItem` children. The first item's
+ * source-mark sets the start; subsequent items get `start + offset`
+ * (offset = position among ListItem siblings, 0-indexed). Returns a
+ * `Map<listItemFrom, displayNumber>` keyed by the absolute source
+ * offset of each ListItem so the main walk can look up by position.
+ *
+ * Why a pre-pass: the main walk emits the `ListMark` widget when it
+ * enters the `ListMark` node, which is a grandchild of the OrderedList.
+ * At that point we'd need to walk back up to count siblings — easier
+ * to do it once up-front and look up.
+ *
+ * Cheap — single tree walk; only descends into OrderedList nodes
+ * shallowly to read each ListItem's first ListMark child.
+ */
+function computeOrderedListNumbers(
+  tree: ReturnType<typeof syntaxTree>,
+  state: EditorState,
+): Map<number, number> {
+  const numbers = new Map<number, number>();
+  tree.iterate({
+    enter: (n: SyntaxNodeRef) => {
+      if (n.type.name !== 'OrderedList') return undefined;
+      // Walk direct children — every ListItem under this OrderedList.
+      // Read the first ListMark text inside the FIRST ListItem to set
+      // the start; subsequent items get sequential numbers.
+      let start: number | null = null;
+      let offset = 0;
+      let child: SyntaxNode | null = n.node.firstChild;
+      while (child !== null) {
+        if (child.type.name === 'ListItem') {
+          if (start === null) {
+            // Find this item's leading ListMark child.
+            let mark: SyntaxNode | null = child.firstChild;
+            while (mark !== null) {
+              if (mark.type.name === 'ListMark') {
+                const txt = state.sliceDoc(mark.from, mark.to);
+                const parsed = parseOrderedMark(txt);
+                if (parsed !== null) start = parsed;
+                break;
+              }
+              mark = mark.nextSibling;
+            }
+            // Defensive: if no ListMark found or non-numeric, fall back
+            // to 1. Shouldn't happen for an OrderedList per the grammar.
+            if (start === null) start = 1;
+          }
+          numbers.set(child.from, start + offset);
+          offset += 1;
+        }
+        child = child.nextSibling;
+      }
+      // Nested OrderedLists are still visited by the iterator on their
+      // own enter event and get their own start/offset scope; this
+      // direct-child loop does not fold their ListItems into the parent.
+      return undefined;
+    },
+  });
+  return numbers;
+}
+
+/**
+ * Unescape the subset of inline markdown escapes that GFM permits inside
+ * a regular text run. Per CommonMark §6.1 the escapable set is the ASCII
+ * punctuation: `!"#$%&'()*+,-./:;<=>?@[\]^_\``{|}~`. Anything else after
+ * a backslash stays verbatim (the backslash is preserved). GFM extends
+ * the set with `|` already, which is already an ASCII punct so no
+ * special case.
+ *
+ * Examples:
+ *   `a\|b`     → `a|b`     (pipe inside table cell)
+ *   `\\`       → `\`
+ *   `\*x`      → `*x`      (escaped emphasis marker)
+ *   `\z`       → `\z`      (unescapable — backslash kept)
+ *
+ * Cheap, allocation-free for strings without backslashes — checked first
+ * via `indexOf` so a cell with no escapes pays nothing.
+ */
+export function unescapeMarkdownInline(text: string): string {
+  if (!text.includes('\\')) return text;
+  let out = '';
+  for (let i = 0; i < text.length; i++) {
+    const ch = text.charCodeAt(i);
+    if (ch === 92 /* '\' */ && i + 1 < text.length) {
+      const next = text.charCodeAt(i + 1);
+      // ASCII punctuation set per CommonMark §6.1.
+      const isPunct =
+        (next >= 33 && next <= 47) /* ! " # $ % & ' ( ) * + , - . / */ ||
+        (next >= 58 && next <= 64) /* : ; < = > ? @ */ ||
+        (next >= 91 && next <= 96) /* [ \ ] ^ _ ` */ ||
+        (next >= 123 && next <= 126); /* { | } ~ */
+      if (isPunct) {
+        out += text[i + 1];
+        i++;
+        continue;
+      }
+    }
+    out += text[i];
+  }
+  return out;
+}
+
+/**
+ * Parse a GFM delimiter row's cell content into an alignment per column.
+ *
+ * Per GFM §4.10:
+ *   `:---`   → left
+ *   `:---:`  → center
+ *   `---:`   → right
+ *   `---`    → default (left)
+ *
+ * The cell text we receive has been trimmed and stripped of surrounding
+ * pipes already (caller slices from TableCell or splits the delimiter
+ * line). Whitespace inside is tolerated.
+ */
+export function parseColumnAlignment(cell: string): ColumnAlignment {
+  const trimmed = cell.trim();
+  const left = trimmed.startsWith(':');
+  const right = trimmed.endsWith(':');
+  if (left && right) return 'center';
+  if (right) return 'right';
+  return 'left';
+}
+
+/**
+ * Walk a `Table` lezer node and extract header + body cells as plain
+ * text plus per-column alignment from the delimiter row. Cell text is
+ * unescaped via {@link unescapeMarkdownInline} so escaped pipes (`\|`)
+ * render as literal `|`.
+ *
+ * Lezer-markdown structure for a GFM table:
+ *
+ *   Table
+ *     TableHeader        ← row of TableCells (the header row)
+ *       TableCell
+ *       TableCell
+ *       …
+ *     TableDelimiter     ← the `| --- | --- |` row (one node, line-level)
+ *     TableRow           ← body row 0
+ *       TableCell
+ *       TableCell
+ *       …
+ *     TableRow           ← body row 1
+ *     …
+ *
+ * `TableDelimiter` is a line-shaped node with no `TableCell` children —
+ * we slice its source text directly and split on `|` to get per-column
+ * delimiter tokens.
+ *
+ * Both `(| a | b |)` (trailing-pipe) and `(a | b)` (no-trailing-pipe)
+ * GFM table syntaxes parse to the same TableCell structure — lezer
+ * normalizes them. So cell extraction reads the same regardless.
+ */
+export function parseTableNode(
+  table: SyntaxNode,
+  state: EditorState,
+  options: { unescapeCells?: boolean } = {},
+): { header: string[]; body: string[][]; alignments: ColumnAlignment[] } {
+  const unescapeCells = options.unescapeCells ?? true;
+  const header: string[] = [];
+  const body: string[][] = [];
+  let alignments: ColumnAlignment[] = [];
+  let child: SyntaxNode | null = table.firstChild;
+  while (child !== null) {
+    const cname = child.type.name;
+    if (cname === 'TableHeader' || cname === 'TableRow') {
+      const cells: string[] = [];
+      let cell: SyntaxNode | null = child.firstChild;
+      while (cell !== null) {
+        if (cell.type.name === 'TableCell') {
+          // Slice the cell's source text and trim outer whitespace.
+          // Inner whitespace (multiple spaces between words) survives,
+          // matching how the GFM rendering reads cell content.
+          const raw = state.sliceDoc(cell.from, cell.to).trim();
+          cells.push(unescapeCells ? unescapeMarkdownInline(raw) : raw);
+        }
+        cell = cell.nextSibling;
+      }
+      if (cname === 'TableHeader') {
+        header.push(...cells);
+      } else {
+        body.push(cells);
+      }
+    } else if (cname === 'TableDelimiter') {
+      // Slice the delimiter row's source line and split on bare `|`.
+      // We strip a leading and trailing pipe if present (the optional
+      // outer-pipe form), then split. No escape-aware splitting needed:
+      // delimiter rows contain only `-`, `:`, `|`, and whitespace.
+      let raw = state.sliceDoc(child.from, child.to).trim();
+      if (raw.startsWith('|')) raw = raw.slice(1);
+      if (raw.endsWith('|')) raw = raw.slice(0, -1);
+      alignments = raw.split('|').map((part) => parseColumnAlignment(part));
+    }
+    child = child.nextSibling;
+  }
+  // Pad alignments to header column count with 'left' (default).
+  while (alignments.length < header.length) alignments.push('left');
+  return { header, body, alignments };
+}
+
+/**
+ * Walk an `Image` lezer node and pull out alt text + URL.
+ *
+ * Children for an inline image `![alt](url)` appear as:
+ *
+ *   Image
+ *     LinkMark      ← `![`  (2 chars, from..from+2)
+ *     <inline alt>  ← zero or more inline nodes — the alt text as
+ *                     parsed inline markdown. NOT a LinkLabel — that
+ *                     node only appears for reference-style links.
+ *                     For most plain alt text there are no child
+ *                     nodes here, just raw source between the two
+ *                     LinkMarks.
+ *     LinkMark      ← `]`   (1 char) — the close-bracket
+ *     LinkMark      ← `(`   (1 char)
+ *     URL           ← the bare URL (with `<>` stripped if present)
+ *     LinkTitle     ← optional title (ignored)
+ *     LinkMark      ← `)`   (1 char)
+ *
+ * Reference-style image (`![alt][ref]`) emits a LinkLabel child
+ * instead of `(URL)`. kb-1 has no reference-link infrastructure
+ * today (no link-reference definitions are parsed) so we treat that
+ * shape as malformed and return null.
+ *
+ * Alt-text extraction strategy: rather than walk inline children
+ * (which can be multiple node types: Emphasis, InlineCode, plain
+ * text gaps with no node), slice the source range between the
+ * opening `![` and the close-bracket LinkMark. That's the unambiguous
+ * span the parser already validated. We also unescape the slice so
+ * `![a\]b](url)` recovers `a]b` as the alt text.
+ *
+ * Empty alt (`![](url)`) is valid. Empty URL is degenerate; return
+ * null so the caller falls back to raw markdown rendering. URLs
+ * wrapped in angle brackets (`<url>`) survive as the URL node's
+ * slice — strip the brackets here.
+ */
+export function parseImageNode(
+  image: SyntaxNode,
+  state: EditorState,
+): { alt: string; url: string } | null {
+  let url: string | null = null;
+  let closeBracketPos: number | null = null;
+  let openParenPos: number | null = null;
+  let child: SyntaxNode | null = image.firstChild;
+  while (child !== null) {
+    const cname = child.type.name;
+    if (cname === 'URL') {
+      let raw = state.sliceDoc(child.from, child.to).trim();
+      // Strip `<>` wrapper used for URLs containing parens / spaces.
+      if (raw.startsWith('<') && raw.endsWith('>')) {
+        raw = raw.slice(1, -1);
+      }
+      url = raw;
+    } else if (cname === 'LinkMark') {
+      // LinkMarks come in order: `![`, `]`, `(`, `)`. The `]` is the
+      // first single-char LinkMark we encounter (the `![` is 2 chars).
+      const len = child.to - child.from;
+      if (len === 1 && closeBracketPos === null) {
+        // First single-char LinkMark = the `]`.
+        const ch = state.sliceDoc(child.from, child.to);
+        if (ch === ']') {
+          closeBracketPos = child.from;
+        } else if (ch === '(') {
+          openParenPos = child.from;
+        }
+      } else if (len === 1 && openParenPos === null) {
+        const ch = state.sliceDoc(child.from, child.to);
+        if (ch === '(') openParenPos = child.from;
+      }
+    }
+    child = child.nextSibling;
+  }
+  if (url === null || url === '') return null;
+  // Alt text is everything between `![` (image.from + 2) and the
+  // close-bracket. Fall back to '' if we couldn't locate the close.
+  let alt = '';
+  if (closeBracketPos !== null && closeBracketPos >= image.from + 2) {
+    alt = unescapeMarkdownInline(state.sliceDoc(image.from + 2, closeBracketPos));
+  }
+  return { alt, url };
+}
+
+/* ---------------------------------------------------------------- *
+ * Wikilink inline-parser extension (Slice 5)                         *
+ *                                                                    *
+ * Obsidian-style `[[target]]` / `[[target#heading]]` / `[[target|     *
+ * alias]]` is not part of CommonMark, so lezer-markdown doesn't emit  *
+ * a node for it by default. We add an `InlineParser` that runs        *
+ * BEFORE the standard `Link` parser (which handles `[label](url)`)    *
+ * and recognizes the `[[…]]` shape.                                   *
+ *                                                                    *
+ * The parser emits the following node structure for `[[t|alias]]`:    *
+ *                                                                    *
+ *   Wikilink                   ← outer span [[t|alias]]               *
+ *     WikilinkMark             ← opening `[[`                          *
+ *     WikilinkTarget           ← target text `t` (or `t#heading`)     *
+ *     WikilinkAliasMark        ← pipe `|` (only when alias present)   *
+ *     WikilinkAlias            ← alias text `alias`                   *
+ *     WikilinkMark             ← closing `]]`                          *
+ *                                                                    *
+ * For the plain `[[t]]` case the AliasMark + Alias children are       *
+ * omitted. This keeps the decoration walker's job mechanical: emit    *
+ * the tinted label on Wikilink{Target,Alias}, and the cursor-reveal    *
+ * syntax mark on WikilinkMark + the pipe.                              *
+ *                                                                    *
+ * Constraints — match the local wikilink parser so the same set of    *
+ * inputs round-trips:                                                  *
+ *                                                                    *
+ *   - Inner text may not contain `[`, `]`, or newline. Bail (return  *
+ *     -1) on those — partial input like `[[foo` or `[[a[b]]` stays   *
+ *     unstyled until the user closes it cleanly.                     *
+ *   - Empty target (`[[]]`, `[[|alias]]`) is dropped per              *
+ *     `parseWikilinkInner` — we still emit the structural nodes so   *
+ *     the cursor-reveal mark works (user can see the brackets while  *
+ *     typing), but the decoration walker skips emitting a label for  *
+ *     empty targets so we don't paint a 0-width tinted span.         *
+ * ---------------------------------------------------------------- */
+
+const CHAR_LBRACKET = 91; // '['
+const CHAR_RBRACKET = 93; // ']'
+const CHAR_NEWLINE = 10; // '\n'
+const CHAR_PIPE = 124; // '|'
+
+const wikilinkExtension: MarkdownConfig = {
+  defineNodes: ['Wikilink', 'WikilinkMark', 'WikilinkTarget', 'WikilinkAliasMark', 'WikilinkAlias'],
+  parseInline: [
+    {
+      name: 'Wikilink',
+      // Run before the standard `Link` parser so `[[` is recognized as
+      // a wikilink open rather than two adjacent reference-link opens.
+      // The standard inline parsers list (per the lezer-markdown docs:
+      // Escape, Entity, InlineCode, HTMLTag, Emphasis, HardBreak, Link,
+      // Image) puts Link sixth from the end; we install before it.
+      before: 'Link',
+      parse(cx: InlineContext, next: number, pos: number): number {
+        // Fast bail: the first char must be `[`. CommonMark guarantees
+        // `next === cx.char(pos)` so we use `next` directly.
+        if (next !== CHAR_LBRACKET) return -1;
+        if (cx.char(pos + 1) !== CHAR_LBRACKET) return -1;
+
+        const openEnd = pos + 2;
+        let pipePos = -1;
+        let scan = openEnd;
+        while (scan < cx.end) {
+          const ch = cx.char(scan);
+          // Disallow `[`, `]` in the inner content. A `]` here means we
+          // need the NEXT char to also be `]` (the close); a bare `]`
+          // (or a `[`) inside is invalid wikilink syntax.
+          if (ch === CHAR_RBRACKET) {
+            if (cx.char(scan + 1) === CHAR_RBRACKET) {
+              // Found the close `]]`.
+              const closeStart = scan;
+              const closeEnd = scan + 2;
+              // Build children: open mark, target (and optional
+              // alias-mark + alias), close mark. Empty inner segments
+              // are omitted so positions stay valid (lezer-markdown
+              // rejects zero-width child nodes).
+              const children: ReturnType<typeof cx.elt>[] = [];
+              children.push(cx.elt('WikilinkMark', pos, openEnd));
+              if (pipePos !== -1) {
+                if (pipePos > openEnd) {
+                  children.push(cx.elt('WikilinkTarget', openEnd, pipePos));
+                }
+                children.push(cx.elt('WikilinkAliasMark', pipePos, pipePos + 1));
+                if (closeStart > pipePos + 1) {
+                  children.push(cx.elt('WikilinkAlias', pipePos + 1, closeStart));
+                }
+              } else if (closeStart > openEnd) {
+                children.push(cx.elt('WikilinkTarget', openEnd, closeStart));
+              }
+              children.push(cx.elt('WikilinkMark', closeStart, closeEnd));
+              cx.addElement(cx.elt('Wikilink', pos, closeEnd, children));
+              return closeEnd;
+            }
+            // Bare `]` inside — bail.
+            return -1;
+          }
+          if (ch === CHAR_LBRACKET || ch === CHAR_NEWLINE) return -1;
+          if (ch === CHAR_PIPE && pipePos === -1) pipePos = scan;
+          scan++;
+        }
+        // Ran off the end without finding `]]` — unmatched, bail.
+        return -1;
+      },
+    },
+  ],
+};
+
+/* ---------------------------------------------------------------- *
+ * Footnote extension (Slice 4 of plaintext-editor Apple lane)        *
+ *                                                                    *
+ * GFM-style footnotes: inline references `[^id]` plus block           *
+ * definitions `[^id]: definition text`. Not part of CommonMark or     *
+ * lezer-markdown's bundled extensions, so we define our own with the  *
+ * same shape as `wikilinkExtension` above (inline parser + block      *
+ * parser + node spec list).                                           *
+ *                                                                    *
+ * Inline reference shape `[^foo]`:                                    *
+ *                                                                    *
+ *   FootnoteRef                                                       *
+ *     FootnoteRefMark    ← `[^`                                       *
+ *     FootnoteLabel      ← `foo` (id text)                            *
+ *     FootnoteRefMark    ← `]`                                        *
+ *                                                                    *
+ * Block definition shape `[^foo]: body text`:                         *
+ *                                                                    *
+ *   FootnoteDef                                                       *
+ *     FootnoteDefMark    ← `[^`                                       *
+ *     FootnoteLabel      ← `foo`                                      *
+ *     FootnoteDefMark    ← `]:`                                       *
+ *     (body text inline-parsed by the surrounding paragraph)          *
+ *                                                                    *
+ * The block-definition shape is intentionally simple — single-line     *
+ * canonical, multi-line graceful-fallback. We treat the line as a     *
+ * paragraph-shaped block; if the user puts continuation text on the   *
+ * following lines, the parser will pick it up as a separate paragraph *
+ * which is fine for v1.                                                *
+ *                                                                    *
+ * Id constraint: alphanumeric, `_`, and `-`. Matches GFM's footnote   *
+ * id regex (`[A-Za-z0-9_-]+`). Empty ids bail (-1) and the source     *
+ * stays as raw text — same shape as wikilink's empty-target handling. *
+ * ---------------------------------------------------------------- */
+
+const CHAR_CARET = 94; // '^'
+const CHAR_COLON = 58; // ':'
+
+/** Test whether a char code is a valid footnote-id char. */
+function isFootnoteIdChar(ch: number): boolean {
+  return (
+    (ch >= 48 && ch <= 57) /* 0-9 */ ||
+    (ch >= 65 && ch <= 90) /* A-Z */ ||
+    (ch >= 97 && ch <= 122) /* a-z */ ||
+    ch === 95 /* _ */ ||
+    ch === 45 /* - */
+  );
+}
+
+/**
+ * Test whether a line looks like the start of a footnote definition:
+ * `[^<id>]:` at column 0 (no indent). Used by both the `endLeaf`
+ * predicate (paragraph-interrupt) and `parse` (the actual block
+ * match). Kept as a small shared helper so the two stay in lockstep.
+ */
+function looksLikeFootnoteDefStart(line: Line): boolean {
+  if (line.pos !== line.basePos) return false;
+  const text = line.text;
+  const start = line.pos;
+  if (text.charCodeAt(start) !== CHAR_LBRACKET) return false;
+  if (text.charCodeAt(start + 1) !== CHAR_CARET) return false;
+  let i = start + 2;
+  const idStart = i;
+  while (i < text.length && isFootnoteIdChar(text.charCodeAt(i))) i++;
+  if (i === idStart) return false;
+  if (text.charCodeAt(i) !== CHAR_RBRACKET) return false;
+  if (text.charCodeAt(i + 1) !== CHAR_COLON) return false;
+  return true;
+}
+
+const footnoteExtension: MarkdownConfig = {
+  defineNodes: [
+    'FootnoteRef',
+    'FootnoteRefMark',
+    'FootnoteLabel',
+    'FootnoteDef',
+    'FootnoteDefMark',
+  ],
+  parseInline: [
+    {
+      name: 'FootnoteRef',
+      // Run before the standard `Link` parser (and after `Wikilink` —
+      // wikilink runs `before: 'Link'` too, but `[[` requires two
+      // brackets so the two parsers don't shadow each other; lezer
+      // tries each in order and the first to return >= 0 wins).
+      before: 'Link',
+      parse(cx: InlineContext, next: number, pos: number): number {
+        // Fast bail: must start with `[^`.
+        if (next !== CHAR_LBRACKET) return -1;
+        if (cx.char(pos + 1) !== CHAR_CARET) return -1;
+        // First id char must exist and be valid.
+        let scan = pos + 2;
+        if (scan >= cx.end) return -1;
+        if (!isFootnoteIdChar(cx.char(scan))) return -1;
+        // Consume the id run.
+        const idStart = scan;
+        while (scan < cx.end && isFootnoteIdChar(cx.char(scan))) {
+          scan++;
+        }
+        const idEnd = scan;
+        if (idStart === idEnd) return -1;
+        // Next char must be `]`.
+        if (scan >= cx.end || cx.char(scan) !== CHAR_RBRACKET) return -1;
+        const closeStart = scan;
+        const closeEnd = scan + 1;
+        // Build children + element.
+        const children = [
+          cx.elt('FootnoteRefMark', pos, idStart),
+          cx.elt('FootnoteLabel', idStart, idEnd),
+          cx.elt('FootnoteRefMark', closeStart, closeEnd),
+        ];
+        cx.addElement(cx.elt('FootnoteRef', pos, closeEnd, children));
+        return closeEnd;
+      },
+    },
+  ],
+  parseBlock: [
+    {
+      name: 'FootnoteDef',
+      // Run before LinkReference — same reason wikilink runs before
+      // Link: `[^id]: body` would otherwise be eligible as the start of
+      // a link-reference definition under lezer-markdown's default
+      // parser (which requires `[label]: url` shape, but the leading
+      // `[` matches and we want our parse to win unambiguously).
+      before: 'LinkReference',
+      // CommonMark paragraphs continue across non-blank lines, so a
+      // `[^id]: body` line that immediately follows a paragraph (no
+      // blank line between) would be absorbed into the paragraph and
+      // never reach our `parse()` callback. `endLeaf` lets us interrupt
+      // the running paragraph when we see a definition start, mirroring
+      // how Table / SetextHeading interrupt paragraphs in the bundled
+      // GFM parsers.
+      endLeaf(_cx: BlockContext, line: Line): boolean {
+        return looksLikeFootnoteDefStart(line);
+      },
+      parse(cx: BlockContext, line: Line): boolean {
+        // Footnote definitions must start at column 0 (no indent). This
+        // is a deliberate v1 simplification: indented continuation lines
+        // remain readable as part of the body paragraph that follows.
+        if (!looksLikeFootnoteDefStart(line)) return false;
+        const text = line.text;
+        const start = line.pos;
+        // Re-scan for the id-end + `]:` positions — the predicate above
+        // already verified shape, so this just locates offsets.
+        let i = start + 2;
+        const idStart = i;
+        while (i < text.length && isFootnoteIdChar(text.charCodeAt(i))) {
+          i++;
+        }
+        const idEnd = i;
+        // Convert line-relative offsets to document-absolute.
+        const lineStart = cx.lineStart;
+        const refStart = lineStart + start; // `[`
+        const labelStart = lineStart + idStart;
+        const labelEnd = lineStart + idEnd;
+        const closeStart = lineStart + i; // `]`
+        const closeEnd = lineStart + i + 2; // after `]:`
+        const lineEnd = lineStart + text.length;
+        // Inline-parse the body text after `]:` so emphasis / inline
+        // code / wikilinks inside the definition get their own nodes
+        // (same shape lezer-markdown uses for ATXHeading / TableCell —
+        // see lezer-markdown/dist/index.js parseInline call sites).
+        const bodyChildren = cx.parser.parseInline(text.slice(i + 2), closeEnd);
+        const children = [
+          cx.elt('FootnoteDefMark', refStart, labelStart),
+          cx.elt('FootnoteLabel', labelStart, labelEnd),
+          cx.elt('FootnoteDefMark', closeStart, closeEnd),
+          ...bodyChildren,
+        ];
+        cx.addElement(cx.elt('FootnoteDef', refStart, lineEnd, children));
+        // Consume the line so it's not also parsed as a paragraph.
+        cx.nextLine();
+        return true;
+      },
+    },
+  ],
+};
+
+/* ---------------------------------------------------------------- *
+ * Tree walk + decoration build                                      *
+ * ---------------------------------------------------------------- */
+
+/**
+ * Build the markdown decoration set for the given state. Pulled out
+ * of the plugin class so unit tests can call it without instantiating
+ * an EditorView.
+ *
+ * Cursor-reveal: `cursor` is the main selection head; when it falls
+ * inside an emphasis / code / list / blockquote / fence range
+ * (inclusive boundaries) we skip the `cm-hidden` mark for that range's
+ * syntax children so the user sees the raw markdown around their caret.
+ *
+ * Focus-gating (Slice F): cursor-reveal is AND-gated by `focused`.
+ * When the editor has lost DOM focus we force `intersects()` to return
+ * false everywhere — every syntax char gets `hiddenSyntaxMark`, the
+ * document reads as Bear-style preview. ListMark (Slice L) participates
+ * in this gate too: when unfocused, every bullet renders as its
+ * shape-glyph / auto-number widget and every checkbox engages. Widget
+ * replaces (Table/Image) also re-engage when focus is false, since
+ * their "cursor inside" check uses the same `intersects` helper.
+ *
+ * For ATX heading lines we always hide the `#`-run + the single
+ * trailing space (the `HeaderMark` child); revealing the heading
+ * marker on caret placement isn't part of this slice — line-level
+ * decorations stay stable so the line doesn't visually reflow under
+ * the caret. (Obsidian itself reveals the marker on heading lines,
+ * but adding that affordance is a one-liner future slice.)
+ */
+export function buildMarkdownDecorations(
+  state: EditorState,
+  selection: { from: number; to: number },
+  options: {
+    attachmentSrc?: (path: string) => string;
+    focused?: boolean;
+    livePaths?: readonly LivePath[];
+    /** Org directory for mention chip resolution. Defaults to empty —
+     *  every mention then renders with the stale modifier, which is the
+     *  honest signal in a no-vault context (Storybook, no-org tests). */
+    orgPeople?: readonly OrgPerson[];
+    onWikilinkClick?: (encodedTarget: string, event: MouseEvent) => void;
+  } = {},
+): DecorationSet {
+  const attachmentSrc = options.attachmentSrc;
+  const livePaths = options.livePaths ?? [];
+  const orgPeople = options.orgPeople ?? [];
+  const onWikilinkClick = options.onWikilinkClick;
+  // Default to `true` (focused) when omitted so existing callers / tests
+  // exercise the same cursor-reveal behaviour they always have. The
+  // production wiring in `markdownDecorationField` passes the real
+  // focus state from `editorFocusField`.
+  const focused = options.focused ?? true;
+  const selFrom = selection.from;
+  const selTo = selection.to;
+  // Reveal a widget / decorated range when the user's selection range
+  // intersects [from, to] — drag-right and drag-left across a widget
+  // both reveal, matching Obsidian's behaviour. For a collapsed caret
+  // this collapses to the previous `cursor` semantics (selFrom = selTo
+  // = head). For a heading line we still use the line-as-context
+  // intersection check — selection touching any part of the line
+  // reveals the marker.
+  //
+  // Focus-gate: when the editor is unfocused, no range "intersects" —
+  // ALL syntax chars hide, the doc reads as Bear-style preview at rest.
+  // ListMark (Slice L) participates in this gate: unfocused → every
+  // bullet renders as a shape-glyph widget and every ordered number
+  // as an auto-numbered widget. Same path as focused-but-cursor-out.
+  const intersects = (from: number, to: number): boolean =>
+    focused && selFrom <= to && selTo >= from;
+  // Two passes' worth of items collected first, sorted, then fed into
+  // a single RangeSetBuilder. CM6's RangeSetBuilder requires monotonic
+  // `from` and ordered `startSide` at equal positions. Decoration.line
+  // has startSide -200, Decoration.mark has startSide 5e8, so a single
+  // ordered walk yields the correct sequence once we sort.
+  //
+  // The `replace` kind covers `Decoration.replace({ widget })` for
+  // Table (block) and Image (inline). It packs `from` + `to` like
+  // `mark` but emits via `builder.add(from, to, replaceDeco)`.
+  //
+  // Table / Image source ranges that the cursor is *inside* are
+  // tracked here as `skipChildrenIn` — when set, the iterator's
+  // inner walk skips emitting child decorations (e.g. the `*` and
+  // `_` inside a table cell's text won't get hidden as emphasis
+  // syntax, because the whole table is in "raw markdown" mode).
+  type DecoItem =
+    | { kind: 'line'; pos: number; deco: Decoration }
+    | { kind: 'mark'; from: number; to: number; deco: Decoration }
+    | { kind: 'replace'; from: number; to: number; deco: Decoration };
+  const items: DecoItem[] = [];
+  const pushVisibleMark = (from: number, to: number): void => {
+    items.push({ kind: 'mark', from, to, deco: visibleSyntaxMark });
+  };
+
+  // Widget-replaced ranges (Table / Image) skip child decoration by
+  // returning `false` from the iterate enter callback below, which
+  // prevents descent into the replaced subtree. No separate membership
+  // bookkeeping is needed.
+
+  const tree = syntaxTree(state);
+
+  // -- Footnote definition pre-pass ----------------------------------
+  // Collect the set of footnote ids that are defined somewhere in the
+  // doc, so the inline-reference branch can mark refs without a
+  // matching definition as "broken" (same broken-link visual register
+  // as wikilinks). We walk the tree once cheaply for FootnoteDef nodes
+  // and read their FootnoteLabel child. Two-pass design intentionally
+  // mirrors how `getLivePaths` flows through the wikilink branch — the
+  // resolution context is computed before the main walk emits marks.
+  //
+  // We also collect `rawFootnoteDefLines` in the same pass — the set of
+  // doc-line numbers occupied by a FootnoteDef where the selection's
+  // head sits on that line (focus-gated). Inline decoration branches
+  // consult this set to drop the entire line back to raw markdown when
+  // the cursor is in the def, mirroring how the FencedCode branch
+  // treats a fence's full range as "raw mode" when `cursorOnFence` is
+  // true. FootnoteDef is single-line per the parser (see the
+  // `[^id]: body` parseBlock above — `lineEnd = lineStart + text.length`)
+  // so a per-line set is sufficient; if multi-line continuation lands
+  // later, extend to a per-range structure.
+  const footnoteDefIds = new Set<string>();
+  const rawFootnoteDefLines = new Set<number>();
+  const cursorLineNumber = focused ? state.doc.lineAt(selTo).number : -1;
+  tree.iterate({
+    enter: (n: SyntaxNodeRef) => {
+      if (n.type.name === 'FootnoteDef') {
+        let child: SyntaxNode | null = n.node.firstChild;
+        while (child !== null) {
+          if (child.type.name === 'FootnoteLabel') {
+            footnoteDefIds.add(state.sliceDoc(child.from, child.to));
+            break;
+          }
+          child = child.nextSibling;
+        }
+        if (focused) {
+          const defLine = state.doc.lineAt(n.from).number;
+          if (defLine === cursorLineNumber) {
+            rawFootnoteDefLines.add(defLine);
+          }
+        }
+        return false;
+      }
+      return undefined;
+    },
+  });
+
+  /**
+   * True when `pos` lies on a FootnoteDef line the cursor is currently
+   * on. Used by inline decoration branches to suppress range styling
+   * (bold / italic / strike / inline-code), force visible syntax
+   * marks, and skip widget replacements (mention chips) so the entire
+   * def line drops back to raw markdown — the same shape FencedCode
+   * uses for cursor-on-fence.
+   *
+   * Cheap: O(1) per call (Set lookup + line lookup), and only computed
+   * for nodes whose decoration emission would otherwise change. The
+   * empty-set fast-path covers the common case (no footnote def, or
+   * cursor not on a def line).
+   */
+  const isInRawFootnoteDefLine = (pos: number): boolean => {
+    if (rawFootnoteDefLines.size === 0) return false;
+    return rawFootnoteDefLines.has(state.doc.lineAt(pos).number);
+  };
+
+  // -- Ordered-list auto-numbering pre-pass (Slice L) ----------------
+  // Walk OrderedList nodes and assign a display number to each direct
+  // ListItem child. The main walk's ListMark branch looks up by
+  // `listItem.from` to render the auto-numbered widget instead of the
+  // raw source number.
+  const orderedNumbers = computeOrderedListNumbers(tree, state);
+
+  tree.iterate({
+    enter: (node: SyntaxNodeRef) => {
+      const name = node.type.name;
+
+      // -- Table (GFM) ----------------------------------------------
+      // Block-widget replacement when cursor is outside the table's
+      // source range. Cursor inside any part of the table (header,
+      // delimiter row, body, any cell) → skip the widget and let raw
+      // pipe-syntax render via the underlying source. We also push
+      // the table's range into `widgetRanges` so descending children
+      // (TableHeader / TableRow / TableCell / TableDelimiter / any
+      // inline marks inside cells) don't emit competing decorations
+      // beneath the replace.
+      if (name === 'Table') {
+        const from = node.from;
+        const to = node.to;
+        const cursorInside = intersects(from, to);
+        if (!cursorInside) {
+          const { header, body, alignments } = parseTableNode(node.node, state, {
+            unescapeCells: false,
+          });
+          // Defensive: a Table parse with no header row would render
+          // a useless empty <table>. Fall through to raw markdown in
+          // that pathological case — simplicity-pressure says don't
+          // build mechanism to render nothing, the source is fine.
+          if (header.length > 0) {
+            items.push({
+              kind: 'replace',
+              from,
+              to,
+              deco: Decoration.replace({
+                widget: new TableWidget(header, body, alignments, {
+                  key: tableInlineContextKey(livePaths, orgPeople),
+                  livePaths,
+                  orgPeople,
+                  onWikilinkClick,
+                }),
+                block: true,
+              }),
+            });
+            // Returning false would skip descent; but we need to skip
+            // descent because we don't want child decorations inside
+            // the widget range. The iterate API uses the enter
+            // function's return value: `false` = don't descend. Note
+            // the return signature: tree.iterate's `enter` returning
+            // `false` skips children. We're inside an arrow function
+            // assigned to `enter`, so `return false` works.
+            return false;
+          }
+        }
+        // Cursor inside (or header was empty) → raw source. Do not
+        // descend into TableCell children, otherwise chips/links/bold
+        // render while the user is trying to edit pipe syntax, which
+        // is the backwards half of FC-3294.
+        return false;
+      }
+
+      // -- Image (inline) -------------------------------------------
+      // Inline replacement with `<img>` widget when cursor is outside
+      // the source range. Image children: LinkMark (`![`, `](`, `)`)
+      // / LinkLabel (alt text) / URL (image src). Extract those, build
+      // the resolved URL via the attachment-path remap, and emit the
+      // replace. We don't recurse into children — they're inside the
+      // replaced range anyway.
+      if (name === 'Image') {
+        const from = node.from;
+        const to = node.to;
+        const cursorInside = intersects(from, to);
+        if (cursorInside) {
+          // Cursor inside → show raw `![alt](url)` markdown. Skip
+          // the widget but still descend so LinkMark children get
+          // the standard cm-md-syntax (visible) marker — keeps the
+          // visual model consistent with other syntax marks.
+          return undefined;
+        }
+        const parsed = parseImageNode(node.node, state);
+        if (parsed === null) {
+          // Malformed parse (no URL child); fall back to raw markdown.
+          return undefined;
+        }
+        // Sentinel detection runs on the *raw* URL before attachment-
+        // path remapping, so `pending-upload://<uuid>` /
+        // `upload-failed://<uuid>` short-circuit straight to the spinner
+        // / broken-image rendering — `attachmentSrc` won't recognize
+        // those schemes anyway. Normal paths fall through to the usual
+        // resolve-then-render flow.
+        const mode = classifyImageUrl(parsed.url);
+        const resolvedSrc = mode === 'normal' ? resolveImageUrl(parsed.url, attachmentSrc) : '';
+        items.push({
+          kind: 'replace',
+          from,
+          to,
+          deco: Decoration.replace({
+            widget: new ImageWidget(resolvedSrc, parsed.alt, mode),
+          }),
+        });
+        return false;
+      }
+
+      // -- Link (inline) --------------------------------------------
+      // `[label](url)` — emit a `.cm-md-link-label` mark over the
+      // label range so CSS can paint a subtle tint. The bracket /
+      // paren syntax chars (LinkMark) and the URL slice are handled
+      // by the syntax-mark branch below: line-based reveal — same line
+      // as cursor renders raw markdown, off-line collapses to the
+      // tinted label. Click handling lives in plaintext-link-affordance.
+      //
+      // Mentions ride on this exact shape — `[Name](mention:email)` is a
+      // CommonMark inline link with a custom URL scheme (no new node, no
+      // schema change). When the URL parses via `parseMentionUrl` we emit
+      // a `Decoration.replace` + `MentionChipWidget` (see
+      // `plaintext-mention-widget.ts`) that mounts the canonical
+      // `<Avatar>` Svelte component in place of the link's source range,
+      // instead of the default link tint. Per-Link reveal gating: cursor
+      // INSIDE the source range skips the widget so raw markdown surfaces
+      // for editing; OUTSIDE emits the widget.
+      if (name === 'Link') {
+        // Shape A (URL links): skip the label paint when cursor is on
+        // the Link's line — click lands as text-position (no
+        // `.cm-md-link-label` class for the affordance handler to
+        // match). Use selection head (`selTo` for collapsed cursors).
+        //
+        // Mentions diverge: the chip's click handler doesn't navigate
+        // (it's currently a no-op — see plaintext-link-affordance), so
+        // the click-cancellation problem URL links solve via line-based
+        // gating doesn't apply. Per-Link reveal is what Yoh actually
+        // expects: only the Link the cursor sits inside reveals its
+        // raw `[Name](mention:email)` source; sibling mentions on the
+        // same line stay rendered as chips.
+        //
+        // Inclusion rule: cursor INSIDE iff `selTo >= linkFrom &&
+        // selTo < linkTo`. `selTo === linkFrom` (click landed on the
+        // chip's leading `[`) counts as inside so the click reveals
+        // the source. `selTo === linkTo` (cursor just after `)`)
+        // counts as outside so typing-after doesn't flicker the chip.
+        // Locate the close-bracket position AND classify the Link as
+        // mention vs URL link by walking children. The first single-
+        // char LinkMark equal to `]` is the close-bracket.
+        let closeBracket: number | null = null;
+        let child: SyntaxNode | null = node.node.firstChild;
+        while (child !== null) {
+          if (child.type.name === 'LinkMark') {
+            const len = child.to - child.from;
+            if (len === 1 && closeBracket === null) {
+              const ch = state.sliceDoc(child.from, child.to);
+              if (ch === ']') {
+                closeBracket = child.from;
+              }
+            }
+          }
+          child = child.nextSibling;
+        }
+        const mentionEmail = extractMentionEmailFromLink(node.node, state);
+        // Chip-paint gate: per-Link for mentions, line-based for URL
+        // links. `linkFrom`/`linkTo` are the full Link's source span
+        // (including `[`, `]`, `(url)`). For URL links we keep the
+        // line-based behaviour to preserve the click-cancellation
+        // workaround documented in plaintext-link-affordance.
+        //
+        // Footnote-def override: when the Link sits on a FootnoteDef
+        // line the cursor is on, suppress the chip regardless of the
+        // per-Link rule. This drops mention chips inside a footnote
+        // body back to raw `[Name](mention:email)` source as part of
+        // the line-wide raw-markdown mode the rest of the inline
+        // decorations honor via `isInRawFootnoteDefLine`.
+        const linkFrom = node.from;
+        const linkTo = node.to;
+        let suppressChip: boolean;
+        if (mentionEmail !== null) {
+          const cursorInsideLink = focused && selTo >= linkFrom && selTo < linkTo;
+          suppressChip = cursorInsideLink || isInRawFootnoteDefLine(linkFrom);
+        } else {
+          const linkLine = state.doc.lineAt(linkFrom).number;
+          const cursorLine = state.doc.lineAt(selTo).number;
+          suppressChip = focused && linkLine === cursorLine;
+        }
+        if (!suppressChip && closeBracket !== null && closeBracket > node.from + 1) {
+          if (mentionEmail !== null) {
+            // Mention: emit a Decoration.replace + MentionChipWidget
+            // covering the ENTIRE link source span. The widget mounts
+            // <MentionChip> (which composes the canonical <Avatar>) so
+            // visual parity with HISTORY / byline / file-row avatars is
+            // structural. Skip descent — the widget replaces the source
+            // range completely; child syntax marks (the `[`, `]`, `(`,
+            // `)`, URL slice) aren't visible while the widget renders.
+            //
+            // When the cursor enters the source range (`suppressChip`
+            // true), this branch is skipped, the iterator descends, and
+            // the syntax-mark hide/reveal branch below paints the raw
+            // markdown for in-place editing — exactly the same per-Link
+            // reveal contract the CSS chip honored.
+            const resolved = resolvePerson(mentionEmail, orgPeople);
+            const props = buildMentionWidgetProps(mentionEmail, resolved);
+            items.push({
+              kind: 'replace',
+              from: linkFrom,
+              to: linkTo,
+              deco: Decoration.replace({
+                widget: new MentionChipWidget(props),
+              }),
+            });
+            return false;
+          }
+          items.push({
+            kind: 'mark',
+            from: node.from + 1,
+            to: closeBracket,
+            deco: linkLabelMark,
+          });
+        }
+        // Descend so children (LinkMark, URL, inline emphasis inside
+        // the label) get their own decorations — including the syntax-
+        // mark hide/reveal for `[`, `](`, `mention:email`, `)`.
+        return undefined;
+      }
+
+      // -- Autolink (GFM) -------------------------------------------
+      // GFM's Autolink extension emits a bare `URL` node (no enclosing
+      // `Link`, no `LinkMark` children) for matches against
+      // `http(s)://`, `www.`, `mailto:`, `xmpp:`, and bare emails. See
+      // `@lezer/markdown`'s `Autolink` definition — it calls
+      // `cx.addElement(cx.elt("URL", absPos, end))` directly.
+      //
+      // Detection rule: a `URL` node whose parent is NOT `Link` or
+      // `Image` is an autolink. The `[label](url)` / `![alt](url)`
+      // cases own their URL child via the syntax-mark branch below
+      // (cursor-reveal of the parenthesized URL).
+      //
+      // Decoration: emit `.cm-md-link-label` over the URL range so
+      // CSS paints the sky tint + pointer cursor (same visual register
+      // as inline link labels — semantically equivalent: tinted
+      // clickable text that opens a destination). Shape A line-based
+      // reveal: cursor on the same line → skip the paint so a click
+      // lands as text-position (default CM6) and the user can edit
+      // the URL source character-by-character.
+      //
+      // Click handling lives in `plaintext-link-affordance.ts`; the
+      // handler recognizes `.cm-md-link-label` already, resolves the
+      // ancestor, and now handles the `URL`-as-ancestor case (no
+      // wrapping Link) by slicing the URL text directly.
+      if (name === 'URL') {
+        const parent = node.node.parent;
+        const pname = parent?.type.name;
+        if (pname !== 'Link' && pname !== 'Image') {
+          const urlLine = state.doc.lineAt(node.from).number;
+          const cursorLine = state.doc.lineAt(selTo).number;
+          const cursorOnSameLine = focused && urlLine === cursorLine;
+          if (!cursorOnSameLine) {
+            items.push({
+              kind: 'mark',
+              from: node.from,
+              to: node.to,
+              deco: linkLabelMark,
+            });
+          }
+          // No children to descend into (Autolink's URL node is a
+          // leaf — `cx.elt("URL", from, to)` with no nested elts).
+          return false;
+        }
+      }
+
+      // -- Wikilink (Slice 5) ---------------------------------------
+      // `[[target]]` / `[[target#heading]]` / `[[target|alias]]`.
+      // Emitted by our custom `wikilinkExtension` inline parser (see
+      // top of file). Children: WikilinkMark (`[[` and `]]`),
+      // WikilinkTarget (target+heading text), optional WikilinkAliasMark
+      // (`|`) + WikilinkAlias (alias text).
+      //
+      // Decoration plan:
+      //   - WikilinkMark ranges → cm-md-syntax cursor-reveal (hidden
+      //     when selection is outside the Wikilink; visible when inside).
+      //   - When an alias is present: target+pipe also collapse as
+      //     syntax (the alias is the user-facing label), so off-cursor
+      //     the reader sees just the alias text tinted.
+      //   - When no alias: the target is the visible label.
+      //   - Label range gets `cm-md-wikilink-label` (resolved) or
+      //     `cm-md-wikilink-broken` (unresolved against livePaths) so
+      //     CSS can paint distinct tones.
+      //   - Empty target (`[[]]`) → emit no label, only the syntax
+      //     marks so the user still sees the brackets while typing.
+      //
+      // Resolution uses the same parser and resolver as the click flow,
+      // so visual state stays consistent with interaction.
+      if (name === 'Wikilink') {
+        const wikilinkNode = node.node;
+        const wikilinkFrom = wikilinkNode.from;
+        // Shape A: line-based reveal. Cursor on the wikilink's line →
+        // reveal raw `[[target]]` + skip label paint so a click lands as
+        // text-position (default CM6) instead of follow. Use `selTo` as
+        // the head — collapsed-cursor case is selFrom === selTo, range
+        // selection uses the active end for the line check.
+        const wikilinkLine = state.doc.lineAt(wikilinkFrom).number;
+        const cursorLine = state.doc.lineAt(selTo).number;
+        const cursorOnSameLine = focused && wikilinkLine === cursorLine;
+
+        // Walk children once to identify each segment.
+        let openMark: SyntaxNode | null = null;
+        let closeMark: SyntaxNode | null = null;
+        let targetNode: SyntaxNode | null = null;
+        let aliasMark: SyntaxNode | null = null;
+        let aliasNode: SyntaxNode | null = null;
+        let child: SyntaxNode | null = wikilinkNode.firstChild;
+        while (child !== null) {
+          const cname = child.type.name;
+          if (cname === 'WikilinkMark') {
+            if (openMark === null) openMark = child;
+            else closeMark = child;
+          } else if (cname === 'WikilinkTarget') {
+            targetNode = child;
+          } else if (cname === 'WikilinkAliasMark') {
+            aliasMark = child;
+          } else if (cname === 'WikilinkAlias') {
+            aliasNode = child;
+          }
+          child = child.nextSibling;
+        }
+
+        // Syntax-char marks: the opening `[[` and closing `]]` always.
+        // Line-based reveal — hidden when cursor is off the line, visible
+        // when on the same line.
+        const syntaxDeco = cursorOnSameLine ? visibleSyntaxMark : hiddenSyntaxMark;
+        if (openMark !== null && openMark.from < openMark.to) {
+          items.push({
+            kind: 'mark',
+            from: openMark.from,
+            to: openMark.to,
+            deco: syntaxDeco,
+          });
+        }
+        if (closeMark !== null && closeMark.from < closeMark.to) {
+          items.push({
+            kind: 'mark',
+            from: closeMark.from,
+            to: closeMark.to,
+            deco: syntaxDeco,
+          });
+        }
+
+        // Resolve the target against livePaths so we can pick the
+        // resolved vs broken label tone. Use the canonical parser so
+        // `[[target#heading|alias]]` splits the same way the load/save
+        // path does — heading is part of the target span visually but
+        // we resolve against just the page name.
+        const targetText =
+          targetNode !== null ? state.sliceDoc(targetNode.from, targetNode.to) : '';
+        const parts = parseWikilinkInner(targetText + (aliasNode !== null ? '|' : ''));
+        // `parseWikilinkInner` accepts the full inner including the
+        // optional `|alias` tail; we pass `target+|` so we get back the
+        // bare target without dragging in alias-text again. The trailing
+        // `|` shouldn't normally happen but `parseWikilinkInner` handles
+        // an empty alias by returning `alias: undefined`, which is what
+        // we want — we only care about `parts.target` here.
+        const resolved =
+          parts !== null ? resolveLinkTarget({ raw: parts.target, livePaths }) : null;
+        const labelDeco = resolved !== null ? wikilinkLabelMark : wikilinkBrokenMark;
+
+        // Label emission: alias takes precedence when present. Skip the
+        // label paint entirely when the cursor is on the same line —
+        // Shape A wants the link to render as raw markdown so a click
+        // lands as text-position (the click handler gates on the
+        // `.cm-md-{link,wikilink}-label` class via `closest()`; without
+        // the class, the default CM6 click-to-position runs).
+        if (aliasNode !== null && aliasNode.from < aliasNode.to) {
+          if (!cursorOnSameLine) {
+            // Tint the alias as the visible label.
+            items.push({
+              kind: 'mark',
+              from: aliasNode.from,
+              to: aliasNode.to,
+              deco: labelDeco,
+            });
+            // Hide the target + pipe as syntax (off-cursor only — same-
+            // line already reveals everything via syntaxDeco above).
+            if (targetNode !== null && targetNode.from < targetNode.to) {
+              items.push({
+                kind: 'mark',
+                from: targetNode.from,
+                to: targetNode.to,
+                deco: syntaxDeco,
+              });
+            }
+            if (aliasMark !== null && aliasMark.from < aliasMark.to) {
+              items.push({
+                kind: 'mark',
+                from: aliasMark.from,
+                to: aliasMark.to,
+                deco: syntaxDeco,
+              });
+            }
+          }
+        } else if (!cursorOnSameLine && targetNode !== null && targetNode.from < targetNode.to) {
+          // No alias — the target IS the label.
+          items.push({
+            kind: 'mark',
+            from: targetNode.from,
+            to: targetNode.to,
+            deco: labelDeco,
+          });
+        }
+        // Skip descent — there are no nested decoratable nodes inside a
+        // Wikilink (the children are all syntax-level spans we just
+        // handled).
+        return false;
+      }
+
+      // -- FootnoteRef (Slice 4 of plaintext Apple lane) -------------
+      // Inline `[^id]` reference. Children: FootnoteRefMark `[^`,
+      // FootnoteLabel `id`, FootnoteRefMark `]`. We paint a small
+      // superscript span over the FootnoteLabel range when the cursor
+      // is OFF the line, and hide the surrounding `[^` / `]` syntax
+      // chars; cursor on the line reveals everything as raw text.
+      //
+      // Broken-state: if no matching FootnoteDef exists in the doc,
+      // the label paints with `cm-md-footnote-ref-broken` so CSS can
+      // tint it with the same dotted-underline broken-link register
+      // used by wikilinks.
+      if (name === 'FootnoteRef') {
+        const refNode = node.node;
+        const refLine = state.doc.lineAt(refNode.from).number;
+        const cursorLine = state.doc.lineAt(selTo).number;
+        const cursorOnSameLine = focused && refLine === cursorLine;
+
+        let openMark: SyntaxNode | null = null;
+        let closeMark: SyntaxNode | null = null;
+        let labelNode: SyntaxNode | null = null;
+        let child: SyntaxNode | null = refNode.firstChild;
+        while (child !== null) {
+          const cname = child.type.name;
+          if (cname === 'FootnoteRefMark') {
+            if (openMark === null) openMark = child;
+            else closeMark = child;
+          } else if (cname === 'FootnoteLabel') {
+            labelNode = child;
+          }
+          child = child.nextSibling;
+        }
+
+        const syntaxDeco = cursorOnSameLine ? visibleSyntaxMark : hiddenSyntaxMark;
+        if (openMark !== null && openMark.from < openMark.to) {
+          items.push({
+            kind: 'mark',
+            from: openMark.from,
+            to: openMark.to,
+            deco: syntaxDeco,
+          });
+        }
+        if (closeMark !== null && closeMark.from < closeMark.to) {
+          items.push({
+            kind: 'mark',
+            from: closeMark.from,
+            to: closeMark.to,
+            deco: syntaxDeco,
+          });
+        }
+
+        if (!cursorOnSameLine && labelNode !== null && labelNode.from < labelNode.to) {
+          const id = state.sliceDoc(labelNode.from, labelNode.to);
+          const isBroken = !footnoteDefIds.has(id);
+          items.push({
+            kind: 'mark',
+            from: labelNode.from,
+            to: labelNode.to,
+            deco: isBroken ? footnoteRefBrokenMark : footnoteRefMark,
+          });
+        }
+        // Skip descent — children are syntax-level spans we just
+        // handled.
+        return false;
+      }
+
+      // -- FootnoteDef (Slice 4 + Bear-inline rework) ----------------
+      // Block definition `[^id]: body text`. Rendered in the Bear Notes
+      // style: the line flows as ordinary prose with `name:` painted
+      // inline in link color at the start. No gutter chip, no card
+      // chrome — the def reads as `name: body…` with the `name` portion
+      // colored like a link, and the `:` flowing as plain text.
+      //
+      // Off-line: hide `[^` (open mark) and the `]` of the close mark
+      // via cm-hidden; paint the FootnoteLabel name with
+      // `cm-md-footnote-label` for link-tone color; leave the `:` of
+      // the close mark visible and unstyled so it reads as ordinary
+      // punctuation in the paragraph.
+      //
+      // Cursor ON the def line: drop the ENTIRE presentation back to
+      // raw markdown — the inline-range / syntax-char gates already
+      // keyed off `isInRawFootnoteDefLine` reveal raw `**bold**` /
+      // `*italic*` / `[[wikilink]]` text, and here we likewise reveal
+      // `[^` and `]` and skip the label paint so the source surfaces.
+      if (name === 'FootnoteDef') {
+        const defNode = node.node;
+        const line = state.doc.lineAt(defNode.from);
+        const cursorOnSameLine = focused && state.doc.lineAt(selTo).number === line.number;
+
+        let openMark: SyntaxNode | null = null;
+        let closeMark: SyntaxNode | null = null;
+        let labelNode: SyntaxNode | null = null;
+        let child: SyntaxNode | null = defNode.firstChild;
+        while (child !== null) {
+          const cname = child.type.name;
+          if (cname === 'FootnoteDefMark') {
+            if (openMark === null) openMark = child;
+            else closeMark = child;
+          } else if (cname === 'FootnoteLabel') {
+            labelNode = child;
+          }
+          child = child.nextSibling;
+        }
+
+        // Hide `[^` (open mark) off-line, reveal on-line.
+        const syntaxDeco = cursorOnSameLine ? visibleSyntaxMark : hiddenSyntaxMark;
+        if (openMark !== null && openMark.from < openMark.to) {
+          items.push({
+            kind: 'mark',
+            from: openMark.from,
+            to: openMark.to,
+            deco: syntaxDeco,
+          });
+        }
+        // Paint the label name in link color off-line; on-line drop the
+        // paint so the user edits the raw id text without recolor.
+        if (!cursorOnSameLine && labelNode !== null && labelNode.from < labelNode.to) {
+          items.push({
+            kind: 'mark',
+            from: labelNode.from,
+            to: labelNode.to,
+            deco: footnoteDefLabelMark,
+          });
+        }
+        // Close mark is the two chars `]:`. Hide just the `]` off-line;
+        // leave the `:` visible (it flows as ordinary punctuation in
+        // the Bear-style "name: body" inline render). On-line, reveal
+        // the `]` so the raw `]:` source surfaces. Parser guarantees
+        // closeMark spans `]:` (length 2) when present.
+        if (closeMark !== null && closeMark.from < closeMark.to) {
+          const bracketEnd = Math.min(closeMark.from + 1, closeMark.to);
+          if (bracketEnd > closeMark.from) {
+            items.push({
+              kind: 'mark',
+              from: closeMark.from,
+              to: bracketEnd,
+              deco: syntaxDeco,
+            });
+          }
+        }
+        // Descend so any inline marks (Wikilink, emphasis) inside the
+        // body text get their own decorations.
+        return undefined;
+      }
+
+      // -- Heading lines ---------------------------------------------
+      // ATXHeading1..6 — emit a line decoration for the whole line and
+      // hide the leading `#`s + trailing space (the HeaderMark child)
+      // when the cursor is not on the line.
+      const headingMatch = /^ATXHeading([1-6])$/.exec(name);
+      if (headingMatch) {
+        const level = Number(headingMatch[1]) as 1 | 2 | 3 | 4 | 5 | 6;
+        const line = state.doc.lineAt(node.from);
+        items.push({
+          kind: 'line',
+          pos: line.from,
+          deco: headingDeco[level],
+        });
+        return;
+      }
+
+      // -- TaskMarker (GFM task list) --------------------------------
+      // `[ ]` / `[x]` / `[X]` at the start of a list item's content.
+      // Lezer-markdown's TaskList extension nests inside a ListItem:
+      //
+      //   ListItem
+      //     ListMark            ← `- ` (suppressed on task items — Slice L)
+      //     Task                ← block; spans `[ ]` + inline content
+      //       TaskMarker        ← exactly 3 chars: `[ ]` / `[x]` / `[X]`
+      //       (inline content from offset 3)
+      //
+      // Replace the 3-char TaskMarker range with a custom-glyph checkbox
+      // widget when the cursor is OFF the enclosing ListItem; show raw
+      // `[ ]` / `[x]` source when the cursor is on the line (so the user
+      // can keyboard-edit it). Uses the same `intersects(listItem.from,
+      // listItem.to)` predicate as ListMark — focus-gated by Slice F.
+      if (name === 'TaskMarker') {
+        const parent = node.node.parent;
+        // TaskMarker's parent is the `Task` block; the enclosing ListItem
+        // is one level above. Reveal range is the LISTITEM so cursor on
+        // any source line of the item reveals the checkbox-as-text (the
+        // item itself may span multiple lines via wrap or nested content).
+        const listItem = parent !== null ? parent.parent : null;
+        const revealFrom = listItem !== null ? listItem.from : node.from;
+        const revealTo = listItem !== null ? listItem.to : node.to;
+        const cursorInside = intersects(revealFrom, revealTo);
+        if (cursorInside) {
+          // Same line as cursor (or wrapping in a multi-line item) —
+          // show raw `[ ]`/`[x]` source via the visible-syntax mark so
+          // the user can keyboard-toggle by editing the character.
+          items.push({
+            kind: 'mark',
+            from: node.from,
+            to: node.to,
+            deco: visibleSyntaxMark,
+          });
+          return;
+        }
+        // Off-line: replace with the checkbox widget. Read the marker
+        // text now (build-time) so the widget's initial render matches
+        // the doc; the click-handler re-reads on dispatch in case the
+        // doc shifted between rebuild and click.
+        const markerText = state.sliceDoc(node.from, node.to);
+        const checked = markerText === '[x]' || markerText === '[X]';
+        items.push({
+          kind: 'replace',
+          from: node.from,
+          to: node.to,
+          deco: Decoration.replace({
+            widget: new TaskCheckboxWidget(checked, node.from, node.to),
+          }),
+        });
+        return false;
+      }
+
+      // -- ListItem line ---------------------------------------------
+      // Bullet / ordered list line — emit a line deco per LINE of the
+      // ListItem (a single item can wrap onto multiple display lines
+      // via soft wrap, but lezer's ListItem.from..to spans EXACTLY the
+      // source lines of that item including any nested list). Depth
+      // comes from the ancestor walk; CSS turns it into indent.
+      if (name === 'ListItem') {
+        const depth = listItemDepth(node.node);
+        const deco = listItemDeco[depth] ?? listItemDeco[5];
+        // Apply line deco to every source line in this ListItem that
+        // isn't already covered by a nested ListItem (those will be
+        // emitted by the deeper iterate-enter call with their own
+        // depth). We can't easily know "covered by child" in the
+        // enter callback, but emitting the same Decoration.line at
+        // the same line.from is a no-op in the builder — the deeper
+        // child's line deco will land first (parent enters first but
+        // we sort items by depth-first source position so... no, that
+        // still emits the shallower one first at the same offset).
+        //
+        // Cleanest approach: only emit the ListItem line deco for the
+        // FIRST source line of the item (the one with the marker).
+        // Deeper child ListItems handle their own first lines. Wrapped
+        // content lines of THIS item still get the deco indirectly via
+        // the depth class on the first line — CSS `padding-left` on
+        // .cm-line only affects the directly-decorated line, so wrap
+        // content of a multi-paragraph item won't get indent without
+        // more work. For MVP that's fine; most kb-1 list items are
+        // one line.
+        const startLine = state.doc.lineAt(node.from);
+        // Slice L: if this is a task-list item AND its TaskMarker is
+        // checked, also emit a `cm-md-listitem-task-checked` line deco
+        // so CSS can strike-through + dim the body text (the checkbox
+        // widget's own DOM is excluded by selector specificity).
+        if (listItemHasTask(node.node)) {
+          // Emit the task-line class on every task-bearing item (checked
+          // or unchecked) — sibling of -task-checked, gates task-line-
+          // specific CSS like the on-cursor alignment column exclusion.
+          items.push({
+            kind: 'line',
+            pos: startLine.from,
+            deco: listItemTaskDeco,
+          });
+          // Walk to the Task child → TaskMarker grandchild to read the
+          // marker text + capture the body range. Cheap — at most a
+          // couple of sibling hops.
+          let taskChild: SyntaxNode | null = node.node.firstChild;
+          let markerText = '';
+          let bodyFrom = -1;
+          let bodyTo = -1;
+          while (taskChild !== null) {
+            if (taskChild.type.name === 'Task') {
+              let mc: SyntaxNode | null = taskChild.firstChild;
+              while (mc !== null) {
+                if (mc.type.name === 'TaskMarker') {
+                  markerText = state.sliceDoc(mc.from, mc.to);
+                  bodyFrom = mc.to;
+                  bodyTo = taskChild.to;
+                  break;
+                }
+                mc = mc.nextSibling;
+              }
+              break;
+            }
+            taskChild = taskChild.nextSibling;
+          }
+          if (markerText === '[x]' || markerText === '[X]') {
+            items.push({
+              kind: 'line',
+              pos: startLine.from,
+              deco: listItemTaskCheckedDeco,
+            });
+            if (bodyFrom >= 0 && bodyTo > bodyFrom) {
+              items.push({
+                kind: 'mark',
+                from: bodyFrom,
+                to: bodyTo,
+                deco: taskCheckedBodyMark,
+              });
+            }
+          }
+        }
+        items.push({
+          kind: 'line',
+          pos: startLine.from,
+          deco,
+        });
+        return;
+      }
+
+      // -- Blockquote lines ------------------------------------------
+      // Blockquote.from..to spans every `> ` line in the run. Emit
+      // one line deco per source line within. We don't return early
+      // because the iterator still needs to descend into QuoteMark
+      // children for cursor-reveal.
+      if (name === 'Blockquote') {
+        const fromLine = state.doc.lineAt(node.from).number;
+        const toLine = state.doc.lineAt(node.to).number;
+        for (let i = fromLine; i <= toLine; i++) {
+          const line = state.doc.line(i);
+          items.push({
+            kind: 'line',
+            pos: line.from,
+            deco: blockquoteLineDeco,
+          });
+        }
+        return;
+      }
+
+      // -- Horizontal rule (Slice R) ---------------------------------
+      // `---` / `***` / `___` on its own line. Lezer-markdown emits a
+      // single `HorizontalRule` node spanning the source chars with NO
+      // syntax-mark children — `cx.addNode(Type.HorizontalRule, from)`
+      // creates an atomic node. So we emit the line deco AND the
+      // hide/reveal mark directly here (rather than letting the generic
+      // syntax-mark branch catch a HeaderMark-style child, which doesn't
+      // exist for HR).
+      //
+      // Bear-style render: when cursor is OFF the line, the `---` chars
+      // collapse via cm-md-syntax.cm-hidden and the line renders as a
+      // thin hairline rule via CSS (.cm-line.cm-md-hr:not(.cm-activeLine)
+      // gets a top border). When cursor is ON the line (cm-activeLine),
+      // chars reveal and the border drops, so the user sees raw `---`
+      // for editing.
+      if (name === 'HorizontalRule') {
+        const line = state.doc.lineAt(node.from);
+        items.push({
+          kind: 'line',
+          pos: line.from,
+          deco: horizontalRuleLineDeco,
+        });
+        // Emit the source-char mark. Reveal range is the line itself —
+        // cursor anywhere on the HR line reveals the `---`. Use the same
+        // intersects() helper as everywhere else.
+        const cursorInside = intersects(line.from, line.to);
+        if (node.from < node.to) {
+          items.push({
+            kind: 'mark',
+            from: node.from,
+            to: node.to,
+            deco: cursorInside ? visibleSyntaxMark : hiddenSyntaxMark,
+          });
+        }
+        return false;
+      }
+
+      // -- Fenced code block -----------------------------------------
+      // FencedCode.from..to spans the opening fence line through the
+      // closing fence line (inclusive). Apply line deco to every line
+      // in the block — opening fence, body, closing fence — so they
+      // all get the monospace / background-tint look. Inner-language
+      // syntax highlighting lights up via the nested parser already
+      // configured on the markdown() call; we don't compute any inner
+      // tokens here.
+      //
+      // Frame + focus-aware reveal (Slice T polish):
+      //   - Opening + closing delimiter lines (` ```ts ` / ` ``` `)
+      //     get `cm-md-code-fence-delim` which collapses them to zero
+      //     height when the cursor is OFF-fence (CSS in
+      //     PlaintextEditor.svelte). When the cursor is ON any line of
+      //     the fence, the delim class no longer collapses (the CSS
+      //     scopes the collapse to `:not(.cm-activeLine)` siblings —
+      //     see the rule for why we don't toggle the class itself).
+      //     We toggle classes instead via `cursorInside`: off-fence
+      //     emits the *-delim class; on-fence emits the plain code-block
+      //     line deco so the delimiter lines render full-size for
+      //     editing.
+      //   - First / middle / last content lines get top / middle /
+      //     bottom classes that paint a border + radius so the run
+      //     reads as one rounded box. Single-content-line fence uses
+      //     the `*-only` class (rounds all four corners).
+      //   - The opening fence's info-string (e.g. "ts", "py") becomes
+      //     a `data-fence-lang` attribute on the first content line —
+      //     CSS renders it as a corner label via `::after`. The label
+      //     stays even when on-fence (informational; the on-fence raw
+      //     ` ```ts ` is in a different visual register so they don't
+      //     duplicate).
+      if (name === 'FencedCode') {
+        const fromLine = state.doc.lineAt(node.from).number;
+        const toLine = state.doc.lineAt(node.to).number;
+        const cursorOnFence = intersects(node.from, node.to);
+        // Extract the info-string from the opening fence line — the text
+        // after the opening ` ``` ` (or `~~~`) on the first line. Lezer
+        // emits a `CodeInfo` child for this; fall back to slicing if
+        // it's missing (no language tag → empty label, CSS hides it).
+        let fenceLang = '';
+        let codeInfoNode: SyntaxNode | null = node.node.firstChild;
+        while (codeInfoNode !== null) {
+          if (codeInfoNode.type.name === 'CodeInfo') {
+            fenceLang = state.sliceDoc(codeInfoNode.from, codeInfoNode.to).trim();
+            break;
+          }
+          codeInfoNode = codeInfoNode.nextSibling;
+        }
+
+        // A fence with no content lines (opening + closing on
+        // consecutive lines, e.g. ` ``` `\n` ``` `) has toLine -
+        // fromLine == 1. Both lines are delimiters; no content. We
+        // still emit the delim class on both so they collapse off-
+        // cursor; the box visually disappears. Cheap pathological
+        // case — no border ever shows.
+        const contentFromLine = fromLine + 1;
+        const contentToLine = toLine - 1;
+        const hasContent = contentFromLine <= contentToLine;
+        const singleContent = hasContent && contentFromLine === contentToLine;
+
+        // On-fence: drop the CARD chrome (border, background, padding,
+        // language label) — same Shape-A pattern as links / wikilinks.
+        // The user is editing raw markdown; showing the rendered card
+        // while the delimiters are visible reads as double-rendering
+        // (you see both the markdown source AND the preview).
+        //
+        // BUT — keep the text-layer typography. Content lines still get
+        // `cm-md-code-block-text` so the body stays monospace at the
+        // same font-size / line-height across the toggle. Otherwise the
+        // body reflows into the editor's default serif face as soon as
+        // the cursor enters, and the visual jump is jarring (text width
+        // changes, vertical rhythm changes). Delimiter lines (the
+        // ` ```ts ` and closing ` ``` ` rows) get NO decoration — they
+        // reveal as plain prose at the editor's normal serif body face,
+        // which is what the user expects to see when editing the raw
+        // markdown delimiters.
+        //
+        // The inner-language syntax highlighter
+        // (`syntaxHighlighting(defaultHighlightStyle)`) still colors TS
+        // keywords / strings / numbers via `tok-*` spans, so the code
+        // remains visually distinguishable from prose.
+        if (cursorOnFence) {
+          if (hasContent) {
+            for (let i = contentFromLine; i <= contentToLine; i++) {
+              const line = state.doc.line(i);
+              items.push({
+                kind: 'line',
+                pos: line.from,
+                deco: codeFenceTextOnlyDeco,
+              });
+            }
+          }
+          return;
+        }
+
+        // Off-fence: render the card. Delimiter lines collapse to zero
+        // height; content lines paint a rounded bordered box with the
+        // language label in the top-right corner.
+        for (let i = fromLine; i <= toLine; i++) {
+          const line = state.doc.line(i);
+          let deco: Decoration;
+          if (i === fromLine || i === toLine) {
+            deco = codeFenceDelimDeco;
+          } else if (singleContent) {
+            deco = fenceLang.length > 0 ? fenceOnlyWithLang(fenceLang) : codeFenceOnlyDeco;
+          } else if (i === contentFromLine) {
+            deco = fenceLang.length > 0 ? fenceTopWithLang(fenceLang) : codeFenceTopDeco;
+          } else if (i === contentToLine) {
+            deco = codeFenceBottomDeco;
+          } else {
+            deco = codeFenceMiddleDeco;
+          }
+          items.push({
+            kind: 'line',
+            pos: line.from,
+            deco,
+          });
+        }
+        return;
+      }
+
+      // -- Inline emphasis / inline-code -----------------------------
+      let rangeMark: Decoration | null = null;
+      if (name === 'StrongEmphasis') rangeMark = boldMark;
+      else if (name === 'Emphasis') rangeMark = italicMark;
+      else if (name === 'Strikethrough') rangeMark = strikeMark;
+      else if (name === 'InlineCode') rangeMark = codeMark;
+
+      if (rangeMark !== null) {
+        // Footnote-def cursor-reveal: when the cursor is on a FootnoteDef
+        // line, drop the entire line to raw markdown. Skip emitting the
+        // styling mark (`cm-md-bold` / `cm-md-em` / `cm-md-strike` /
+        // `cm-md-code`) so the asterisks / backticks / tildes show as
+        // literal source characters. The syntax-mark branch below
+        // forces the surrounding `*` / `**` / `` ` `` chars visible
+        // via the same `isInRawFootnoteDefLine` check.
+        if (isInRawFootnoteDefLine(node.from)) {
+          return;
+        }
+        items.push({
+          kind: 'mark',
+          from: node.from,
+          to: node.to,
+          deco: rangeMark,
+        });
+        return;
+      }
+
+      // -- Syntax characters -----------------------------------------
+      // HeaderMark / EmphasisMark / StrikethroughMark / CodeMark /
+      // ListMark / QuoteMark. Reveal when the cursor sits inside the
+      // enclosing decorated range; hide otherwise.
+      //
+      // Reveal range definitions:
+      //   HeaderMark            → enclosing heading line (parent ATXHeading*)
+      //   EmphasisMark /
+      //     StrikethroughMark /
+      //     inline CodeMark     → enclosing inline node (parent StrongEmphasis /
+      //                            Emphasis / Strikethrough / InlineCode)
+      //   ListMark              → enclosing ListItem (so cursor on the
+      //                            list-item line reveals the marker)
+      //   QuoteMark             → enclosing Blockquote (cursor anywhere
+      //                            in the multi-line quote reveals the
+      //                            `>` on every line of that block — the
+      //                            block-as-edit-context behaviour)
+      //   FencedCode's CodeMark → enclosing FencedCode (cursor anywhere
+      //                            in the fence reveals the ``` markers)
+      const isSyntaxMark =
+        name === 'HeaderMark' ||
+        name === 'EmphasisMark' ||
+        name === 'StrikethroughMark' ||
+        name === 'CodeMark' ||
+        name === 'ListMark' ||
+        name === 'QuoteMark' ||
+        // LinkMark / URL — only treat as syntax when their parent is a
+        // Link node (the only context we render). Image's own LinkMark
+        // / URL children are handled via the Image widget-replace path
+        // above and we skip descent when the cursor is outside, so this
+        // branch never sees them in that case; when the cursor is INSIDE
+        // an Image (raw markdown mode), Image returns `undefined` to
+        // descend, and the same hide/reveal logic applies cleanly
+        // because parent.type.name === 'Image' falls through to the
+        // generic `parent.from..parent.to` reveal range, which matches
+        // Image's full source range — same behaviour we want for Link.
+        (name === 'LinkMark' &&
+          node.node.parent !== null &&
+          (node.node.parent.type.name === 'Link' || node.node.parent.type.name === 'Image')) ||
+        (name === 'URL' &&
+          node.node.parent !== null &&
+          (node.node.parent.type.name === 'Link' || node.node.parent.type.name === 'Image'));
+      if (isSyntaxMark) {
+        const parent = node.node.parent;
+        if (parent === null) return;
+        // ListMark (Slice L redesign):
+        //   - Task and bullet items keep the old item-wide reveal:
+        //     cursor inside the enclosing ListItem shows raw source.
+        //   - Ordered items are stricter: body editing still shows the
+        //     computed number, and only a cursor on the `1.` source mark
+        //     reveals it. That keeps stale source numbers from visually
+        //     perturbing the active ordered-list item.
+        //   - Off-cursor:
+        //       * task-bearing ListItem (has a `Task` child) → suppress
+        //         the bullet entirely (the checkbox is the leading
+        //         affordance; emitting any bullet here is redundant).
+        //       * BulletList item → replace with a `BulletGlyphWidget`
+        //         (○ / ▷ / ● / ▶ cycling by depth).
+        //       * OrderedList item → replace with an `OrderedNumberWidget`
+        //         showing the auto-numbered display value (start +
+        //         offset within the OrderedList).
+        // Reversal of Slice Q's "always visible" behaviour: presentation
+        // now switches between raw source (on-cursor) and a typographic
+        // glyph widget (off-cursor), same pattern as HorizontalRule.
+        if (name === 'ListMark') {
+          // ListMark's parent is the ListItem.
+          if (parent.type.name !== 'ListItem') {
+            // Defensive — shouldn't happen per the grammar. Fall back to
+            // the generic cursor-reveal path below.
+          } else {
+            const listItem = parent;
+            // Off-cursor: pick the widget for this ListItem's flavour.
+            if (listItemHasTask(listItem)) {
+              const cursorInside = intersects(listItem.from, listItem.to);
+              if (cursorInside) {
+                pushVisibleMark(node.from, node.to);
+                return;
+              }
+              // Task-bearing item — suppress the bullet entirely. Hide
+              // via the cm-hidden syntax mark so the source range stays
+              // selectable but renders as zero-width. The checkbox
+              // widget (emitted from the TaskMarker branch) is the
+              // leading affordance; a bullet here is redundant + ugly.
+              items.push({
+                kind: 'mark',
+                from: node.from,
+                to: node.to,
+                deco: hiddenSyntaxMark,
+              });
+              return;
+            }
+            if (listItemIsOrdered(listItem)) {
+              const cursorInsideMark = intersects(node.from, node.to);
+              if (cursorInsideMark) {
+                pushVisibleMark(node.from, node.to);
+                return;
+              }
+              const display = orderedNumbers.get(listItem.from);
+              if (display !== undefined) {
+                items.push({
+                  kind: 'replace',
+                  from: node.from,
+                  to: node.to,
+                  deco: Decoration.replace({
+                    widget: new OrderedNumberWidget(display),
+                  }),
+                });
+                return;
+              }
+              // No precomputed number (shouldn't happen) → fall through
+              // to the visible mark so the user still sees the source.
+              items.push({
+                kind: 'mark',
+                from: node.from,
+                to: node.to,
+                deco: visibleSyntaxMark,
+              });
+              return;
+            }
+            // Bullet list item — emit the shape-glyph widget.
+            const cursorInside = intersects(listItem.from, listItem.to);
+            if (cursorInside) {
+              pushVisibleMark(node.from, node.to);
+              return;
+            }
+            const depth = listItemDepth(listItem);
+            items.push({
+              kind: 'replace',
+              from: node.from,
+              to: node.to,
+              deco: Decoration.replace({
+                widget: new BulletGlyphWidget(depth),
+              }),
+            });
+            return;
+          }
+        }
+        let revealFrom: number;
+        let revealTo: number;
+        // Mention-link override: per-Link reveal range with the same
+        // inclusion rule as the chip-paint gate above (selTo INSIDE iff
+        // selTo >= linkFrom && selTo < linkTo). Computed up-front so
+        // the standard `pname === 'Link'` branch keeps line-based reveal
+        // for non-mention URL links.
+        let mentionLinkOverride: boolean | null = null;
+        const pname = parent.type.name;
+        if (pname.startsWith('ATXHeading')) {
+          const line = state.doc.lineAt(parent.from);
+          revealFrom = line.from;
+          revealTo = line.to;
+        } else if (pname === 'ListItem') {
+          revealFrom = parent.from;
+          revealTo = parent.to;
+        } else if (pname === 'Blockquote') {
+          revealFrom = parent.from;
+          revealTo = parent.to;
+        } else if (pname === 'FencedCode') {
+          revealFrom = parent.from;
+          revealTo = parent.to;
+        } else if (pname === 'Link') {
+          // Per-Link reveal for mentions, line-based for URL links.
+          // URL links keep line-based to preserve the documented click-
+          // cancellation workaround in plaintext-link-affordance; mention
+          // chips don't navigate so the workaround doesn't apply, and
+          // per-Link reveal matches Yoh's expectation that clicking a
+          // chip reveals only that one's source.
+          if (extractMentionEmailFromLink(parent, state) !== null) {
+            revealFrom = parent.from;
+            revealTo = parent.to;
+            mentionLinkOverride = focused && selTo >= parent.from && selTo < parent.to;
+          } else {
+            const line = state.doc.lineAt(parent.from);
+            revealFrom = line.from;
+            revealTo = line.to;
+          }
+        } else {
+          revealFrom = parent.from;
+          revealTo = parent.to;
+        }
+        // Footnote-def cursor-reveal override: when the cursor is on a
+        // FootnoteDef line, force the syntax chars on that line visible
+        // regardless of their enclosing inline node. Mirrors the
+        // FencedCode `cursorInside` shape — once the cursor enters the
+        // line, the entire line drops to raw markdown so `**bold**` and
+        // `*italic*` show their asterisks, ``` `code` ``` shows backticks,
+        // `~~strike~~` shows tildes, etc. Computed AFTER the parent-based
+        // reveal so it can only widen the reveal, never narrow it.
+        const inRawFootnoteDef = isInRawFootnoteDefLine(node.from);
+        const cursorInside =
+          inRawFootnoteDef || (mentionLinkOverride ?? intersects(revealFrom, revealTo));
+        // Heading `# `-fix: lezer-markdown's HeaderMark covers only the
+        // `#` run, not the trailing space between `#` and the heading
+        // text. Without extending the hide range, the space stays
+        // visible and the heading reads as indented by one character.
+        // Extend `to` by 1 when the next char is a space AND we're
+        // inside an ATX heading parent. The hidden-mark variant will
+        // collapse the space along with the `#`; the visible-mark
+        // variant keeps both visible so the user can edit naturally.
+        const markFrom = node.from;
+        let markTo = node.to;
+        if (
+          name === 'HeaderMark' &&
+          pname.startsWith('ATXHeading') &&
+          markTo < state.doc.length &&
+          state.doc.sliceString(markTo, markTo + 1) === ' '
+        ) {
+          markTo += 1;
+        }
+        items.push({
+          kind: 'mark',
+          from: markFrom,
+          to: markTo,
+          deco: cursorInside ? visibleSyntaxMark : hiddenSyntaxMark,
+        });
+        return;
+      }
+    },
+  });
+
+  // Sort: by position ascending. At equal positions, `Decoration.line`
+  // (startSide -200) sorts before `Decoration.mark` (startSide 5e8).
+  // The lezer iterator already yields parent-before-child / depth-first
+  // in source order, so for line decos at the same offset we want the
+  // DEEPEST (most specific) one to land last — but RangeSetBuilder
+  // dedupes by class via the Decoration reference, and adding the same
+  // line decoration twice at the same offset is fine (no DOM dup).
+  // For different line decos at the same offset (e.g. a ListItem deco
+  // and an inner blockquote's first line deco), CM6 stacks the classes
+  // on the same `.cm-line` element. Sort stably; order at equal `from`
+  // doesn't materially affect the rendered class set.
+  items.sort((a, b) => {
+    const ap = a.kind === 'line' ? a.pos : a.from;
+    const bp = b.kind === 'line' ? b.pos : b.from;
+    if (ap !== bp) return ap - bp;
+    // At equal positions: line < replace < mark. Decoration.line uses
+    // startSide -200, Decoration.replace uses startSide -1 (block) or
+    // -3e8 (inline replace varies by spec; CM6 normalizes), and
+    // Decoration.mark uses startSide 5e8. RangeSetBuilder asserts
+    // monotonic startSide at equal positions; we emit in the canonical
+    // order so the assertion holds without sorting on the exact side
+    // number ourselves.
+    const order = (k: typeof a.kind): number => (k === 'line' ? 0 : k === 'replace' ? 1 : 2);
+    return order(a.kind) - order(b.kind);
+  });
+
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const item of items) {
+    if (item.kind === 'line') {
+      builder.add(item.pos, item.pos, item.deco);
+    } else {
+      // CM6 mark / replace decorations require from < to (zero-width
+      // marks would be widgets). The lezer parser only emits non-empty
+      // mark nodes for the shapes we listen to, but guard defensively
+      // to avoid throwing on a malformed parse.
+      if (item.from < item.to) {
+        builder.add(item.from, item.to, item.deco);
+      }
+    }
+  }
+  return builder.finish();
+}
+
+/* ---------------------------------------------------------------- *
+ * Focus bridge (Slice F)                                            *
+ *                                                                    *
+ * Focus lives on the EditorView (`view.hasFocus`), not the state.    *
+ * Our decorations live in a StateField (block widgets require it —  *
+ * see the StateField comment below). To get focus into state we use *
+ * a tiny ViewPlugin that listens for `update.focusChanged` and       *
+ * dispatches a `focusEffect` carrying the new `hasFocus` boolean.    *
+ * A sibling `editorFocusField` stores the boolean for the decoration *
+ * field to read.                                                     *
+ *                                                                    *
+ * Why a separate field instead of carrying focus on the decoration   *
+ * field's value: keeps the focus state observable from `tr.state.    *
+ * field(editorFocusField)` in any other extension that might want    *
+ * it, and keeps the decoration field's value type a plain            *
+ * `DecorationSet` (so `EditorView.decorations.from(f)` keeps         *
+ * working unchanged). Two narrow fields beats one widened tuple.     *
+ * ---------------------------------------------------------------- */
+
+const focusEffect = StateEffect.define<boolean>();
+
+/**
+ * Effect carrying a "the livePaths snapshot the editor was constructed
+ * with has changed; rebuild wikilink resolution" signal. Dispatched by
+ * the host whenever its `livePaths` prop reference shifts (vault tree
+ * update, vault switch). Mirrors `livePathsChangedMeta` in the Crepe-
+ * side wikilink plugin — same trigger, different transport (CM6 effects
+ * vs ProseMirror tx meta).
+ *
+ * Carries `null` as a payload (CM6's `StateEffect<T>` requires a typed
+ * payload, and `null` is the cheapest sentinel — the bare existence of
+ * the effect is the signal, not its value).
+ */
+export const livePathsChangedEffect = StateEffect.define();
+
+/**
+ * Sibling of `livePathsChangedEffect` for the org directory — dispatched
+ * when the host's `orgPeople` reference shifts (org switch, member
+ * added/removed). Triggers a decoration rebuild so mention chips re-
+ * resolve from stale to fresh (or vice versa) without needing a doc
+ * edit. Mirrors `orgPeopleChangedMeta` in the Crepe-side
+ * mention-decoration plugin — same trigger, different transport.
+ */
+export const mentionDirectoryChangedEffect = StateEffect.define();
+
+/**
+ * Viewport-driven rebuild signal. The decoration StateField is blind to
+ * pure viewport-scroll transactions and to lezer parser-extension
+ * transactions — without a kick, the DecorationSet built at mount only
+ * covers the initially-parsed prefix of the doc. For long notes that
+ * means the bottom half renders raw markdown until the user touches the
+ * editor.
+ *
+ * `viewportRebuildTrigger` (below) watches view-layer signals
+ * (`viewportChanged`, syntax-tree growth) and dispatches this effect.
+ * The StateField recognizes it the same way it recognizes the other
+ * three custom effects and rebuilds the DecorationSet against the now-
+ * larger parsed region.
+ *
+ * Payload is `null` — the effect itself is the signal.
+ */
+const viewportRebuildEffect = StateEffect.define();
+
+const editorFocusField = StateField.define<boolean>({
+  // Initial focus assumption: editor mounts unfocused. The browser
+  // will fire a focus event (and our bridge will dispatch the effect)
+  // if/when the user clicks in or programmatic focus lands. With this
+  // default the editor renders as Bear-style preview on first paint —
+  // no `#`/`**`/`_` visible — which is exactly the "calm at rest"
+  // behaviour Slice F is after.
+  create: () => false,
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(focusEffect)) return effect.value;
+    }
+    return value;
+  },
+});
+
+const focusBridge = ViewPlugin.fromClass(
+  class {
+    constructor(view: EditorView) {
+      // Reconcile the field's initial-false default against whatever
+      // focus state the view actually has at mount. In practice the
+      // editor is unfocused at construction so both sides agree, but
+      // if a parent component programmatically focuses before the
+      // first update cycle this avoids a one-frame stale render.
+      const initial = view.hasFocus;
+      if (initial !== view.state.field(editorFocusField, false)) {
+        // Dispatch in a microtask — dispatching synchronously inside a
+        // ViewPlugin constructor is rejected by CM6 (it warns about
+        // re-entrant transactions). queueMicrotask defers past the
+        // current update cycle.
+        queueMicrotask(() => {
+          if (view.hasFocus === initial) {
+            view.dispatch({ effects: focusEffect.of(initial) });
+          }
+        });
+      }
+    }
+    update(update: ViewUpdate) {
+      if (update.focusChanged) {
+        // Defer the dispatch — CM6 rejects re-entrant transactions
+        // inside a ViewPlugin's `update`. queueMicrotask runs after the
+        // current update cycle settles. Read `view.hasFocus` again in
+        // the microtask in case focus has bounced (rare but cheap to
+        // guard against — avoids dispatching a stale value).
+        const view = update.view;
+        const target = view.hasFocus;
+        queueMicrotask(() => {
+          if (view.hasFocus === target) {
+            view.dispatch({ effects: focusEffect.of(target) });
+          }
+        });
+      }
+    }
+  },
+);
+
+/* ---------------------------------------------------------------- *
+ * Viewport rebuild trigger (long-note tail-paint fix)               *
+ *                                                                    *
+ * The decoration StateField only rebuilds on `docChanged`, selection *
+ * change, or one of three custom effects. It does NOT see plain      *
+ * viewport-scroll transactions, and it does NOT see the lezer parser-*
+ * extension transactions that fire as CM6's incremental parser walks *
+ * past its initial parse-time budget into the newly-visible region.  *
+ *                                                                    *
+ * Result for long notes: the DecorationSet built at mount only       *
+ * covers the prefix the parser had time to walk before mount-paint;  *
+ * anything past that paints raw markdown until the user touches the  *
+ * editor.                                                             *
+ *                                                                    *
+ * This ViewPlugin watches view-layer signals — `viewportChanged`     *
+ * (the user scrolled, or the editor was just resized into a viewport *
+ * that exposes new content) and syntax-tree growth (the incremental  *
+ * parser walked further on its own) — and dispatches a synthetic     *
+ * effect the StateField listens for.                                  *
+ *                                                                    *
+ * `forceParsing(view, viewport.to, 50)` gives the parser up to 50ms  *
+ * to extend the tree to cover the new visible range before we sample *
+ * `lastTreeLen` — so the "tree grew" baseline reflects post-force    *
+ * state, otherwise the next update would re-fire on the parser's     *
+ * own catch-up.                                                       *
+ * ---------------------------------------------------------------- */
+
+const viewportRebuildTrigger = ViewPlugin.define((view) => {
+  let lastTreeLen = syntaxTree(view.state).length;
+  return {
+    update(u: ViewUpdate) {
+      const treeLen = syntaxTree(u.state).length;
+      const treeGrew = treeLen > lastTreeLen;
+      if (u.viewportChanged || treeGrew) {
+        // Bump the baseline synchronously so a follow-up `update`
+        // landing before the microtask doesn't re-schedule from the
+        // same parser advance. `forceParsing` inside the microtask may
+        // extend the tree further; we re-sync `lastTreeLen` there.
+        lastTreeLen = treeLen;
+        // Defer the entire side-effect chain to a microtask. Both
+        // `forceParsing` (which dispatches its own transactions when the
+        // parser advances) and our own dispatch hit CM6's re-entrant-
+        // update prohibition if called from inside `ViewPlugin.update`
+        // ("Calls to EditorView.update are not allowed while an update
+        // is in progress"). Same shape as `focusBridge` above.
+        const view = u.view;
+        queueMicrotask(() => {
+          forceParsing(view, view.viewport.to, 50);
+          lastTreeLen = syntaxTree(view.state).length;
+          view.dispatch({ effects: viewportRebuildEffect.of(null) });
+        });
+      }
+    },
+  };
+});
+
+/* ---------------------------------------------------------------- *
+ * StateField                                                        *
+ *                                                                    *
+ * Block decorations (Table widget's `block: true` replace) MUST come *
+ * from a StateField — CM6 throws `RangeError: Block decorations may  *
+ * not be specified via plugins` when a ViewPlugin's `decorations`    *
+ * facet contributes a block-shaped deco. The simplest fix is to host *
+ * the entire decoration set in a StateField; mark + line decorations *
+ * are happy from either side, and unifying avoids the bookkeeping of *
+ * a split provider.                                                   *
+ *                                                                    *
+ * Update triggers: doc change (tree contents shifted), selection     *
+ * change (cursor-reveal may have flipped), or a `focusEffect` in the *
+ * transaction (focus-gate flipped). All three are reflected in the   *
+ * `Transaction` object we receive in `update`.                       *
+ * ---------------------------------------------------------------- */
+
+function markdownDecorationField(options: {
+  attachmentSrc?: (path: string) => string;
+  getLivePaths?: () => readonly LivePath[];
+  getOrgPeople?: () => readonly OrgPerson[];
+  onWikilinkClick?: (encodedTarget: string, event: MouseEvent) => void;
+}): StateField<DecorationSet> {
+  // `getLivePaths` / `getOrgPeople` are getters (not snapshots) so each
+  // rebuild reads the latest reactive value the host passes down. Same
+  // pattern as the Crepe-side wikilink + mention plugins.
+  const getLivePaths = options.getLivePaths ?? (() => [] as readonly LivePath[]);
+  const getOrgPeople = options.getOrgPeople ?? (() => [] as readonly OrgPerson[]);
+  return StateField.define<DecorationSet>({
+    create(state) {
+      const sel = state.selection.main;
+      const focused = state.field(editorFocusField, false);
+      return buildMarkdownDecorations(
+        state,
+        { from: sel.from, to: sel.to },
+        {
+          attachmentSrc: options.attachmentSrc,
+          focused,
+          livePaths: getLivePaths(),
+          orgPeople: getOrgPeople(),
+          onWikilinkClick: options.onWikilinkClick,
+        },
+      );
+    },
+    update(value, tr: Transaction) {
+      // Selection change OR doc change OR a focus-effect OR a
+      // livePaths-changed effect OR a mention-directory-changed effect
+      // triggers a rebuild. Other transactions (effects-only, viewport
+      // scroll, …) keep the existing decoration set — but the set's
+      // positions still need to be mapped through `tr.changes` so they
+      // line up with the post-transaction document. CM6's RangeSet has
+      // a `.map(changes)` for exactly this purpose; for doc-changed
+      // transactions we rebuild entirely so mapping is a no-op there.
+      let focusFlipped = false;
+      let livePathsFlipped = false;
+      let mentionDirectoryFlipped = false;
+      let viewportFlipped = false;
+      for (const effect of tr.effects) {
+        if (effect.is(focusEffect)) focusFlipped = true;
+        else if (effect.is(livePathsChangedEffect)) livePathsFlipped = true;
+        else if (effect.is(mentionDirectoryChangedEffect)) {
+          mentionDirectoryFlipped = true;
+        } else if (effect.is(viewportRebuildEffect)) viewportFlipped = true;
+      }
+      if (
+        !tr.docChanged &&
+        !tr.selection &&
+        !focusFlipped &&
+        !livePathsFlipped &&
+        !mentionDirectoryFlipped &&
+        !viewportFlipped
+      ) {
+        return value;
+      }
+      const sel = tr.state.selection.main;
+      const focused = tr.state.field(editorFocusField, false);
+      return buildMarkdownDecorations(
+        tr.state,
+        { from: sel.from, to: sel.to },
+        {
+          attachmentSrc: options.attachmentSrc,
+          focused,
+          livePaths: getLivePaths(),
+          orgPeople: getOrgPeople(),
+          onWikilinkClick: options.onWikilinkClick,
+        },
+      );
+    },
+    provide: (f) => EditorView.decorations.from(f),
+  });
+}
+
+/**
+ * The composed extension: language support + decoration ViewPlugin +
+ * default highlight style (so the nested inner-language tokens inside
+ * fenced code blocks actually paint).
+ *
+ * Mount via `extensions: [..., plaintextDecorations(), ...]` in the
+ * `EditorState.create({...})` call. Safe to compose alongside the
+ * existing peer-cursor consumer — they contribute to the same
+ * `EditorView.decorations` facet and CM6 layers them naturally
+ * (mark decorations stack via DOM nesting; widget + mark from the
+ * peer-cursor layer remain independent of these line/mark decos).
+ */
+/**
+ * Syntax-highlight style for fenced code blocks. Replaces CodeMirror's
+ * `defaultHighlightStyle` (which uses light-mode-tuned hex literals like
+ * `#708` and `#219` that disappear against the dark-mode fence bg) with
+ * a small mapping that reads `--rd-syntax-*` CSS variables — those flip
+ * per `[data-rd-mode]` in tokens.css, so the same style hits good
+ * contrast on both backgrounds.
+ *
+ * Tag groups chosen for the curated set of fence languages
+ * (TypeScript / Python / JSON / HTML / CSS) — covers keywords (control,
+ * modifier, module, definition), strings + regex, numbers/bools/atoms,
+ * function calls, type names, comments (italic), property access, and
+ * operators (subtle). Punctuation deliberately left untinted.
+ */
+const kbCodeHighlightStyle = HighlightStyle.define([
+  {
+    tag: [
+      t.keyword,
+      t.controlKeyword,
+      t.definitionKeyword,
+      t.modifier,
+      t.moduleKeyword,
+      t.operatorKeyword,
+      t.self,
+    ],
+    color: 'var(--rd-syntax-keyword)',
+  },
+  {
+    tag: [t.string, t.special(t.string), t.regexp],
+    color: 'var(--rd-syntax-string)',
+  },
+  { tag: t.escape, color: 'var(--rd-syntax-number)' },
+  {
+    tag: [t.number, t.bool, t.null, t.atom],
+    color: 'var(--rd-syntax-number)',
+  },
+  {
+    tag: [t.function(t.variableName), t.function(t.propertyName)],
+    color: 'var(--rd-syntax-function)',
+  },
+  {
+    tag: [t.typeName, t.standard(t.typeName), t.className, t.namespace],
+    color: 'var(--rd-syntax-type)',
+  },
+  { tag: t.propertyName, color: 'var(--rd-syntax-property)' },
+  {
+    tag: [t.comment, t.lineComment, t.blockComment, t.docComment, t.meta],
+    color: 'var(--rd-syntax-comment)',
+    fontStyle: 'italic',
+  },
+  {
+    tag: [t.operator, t.compareOperator, t.logicOperator, t.arithmeticOperator],
+    color: 'var(--rd-syntax-operator)',
+  },
+]);
+
+export function plaintextDecorations(
+  options: {
+    attachmentSrc?: (path: string) => string;
+    /**
+     * Getter for the vault's live-path snapshot. Passed as a getter (not
+     * a static snapshot) so each decoration rebuild reads the latest
+     * reactive value the host owns — same shape as the Crepe-side
+     * wikilink plugin in `wikilink-decoration-plugin.ts`. Omit when
+     * there's no resolution context (Storybook, no-vault tests); every
+     * wikilink will paint as broken, which matches reality.
+     */
+    getLivePaths?: () => readonly LivePath[];
+    /**
+     * Getter for the org's people directory — used to resolve mention
+     * chips (`[Name](mention:email)`) to the matching `OrgPerson`. Same
+     * getter pattern as `getLivePaths`: each rebuild reads the latest
+     * reactive value the host owns. Omit when there's no org context;
+     * every mention will paint with the stale modifier, which is the
+     * honest signal in a no-vault context.
+     */
+    getOrgPeople?: () => readonly OrgPerson[];
+    onWikilinkClick?: (encodedTarget: string, event: MouseEvent) => void;
+  } = {},
+): Extension {
+  const opts = {
+    attachmentSrc: options.attachmentSrc,
+    getLivePaths: options.getLivePaths,
+    getOrgPeople: options.getOrgPeople,
+    onWikilinkClick: options.onWikilinkClick,
+  };
+  return [
+    // Markdown language + GFM strikethrough + GFM table + GFM task-list
+    // + GFM autolink + wikilink (custom) + nested code-fence languages.
+    // `codeLanguages` returns a LanguageDescription per fence info string —
+    // the markdown parser then mixes in that language's parser for the
+    // fence body, so `defaultHighlightStyle` applied below picks up the
+    // inner tokens (TS keywords, Python `def`, JSON strings, …).
+    //
+    // Autolink ordering note: wikilink's inline parser registers
+    // `before: 'Link'` so `[[target]]` is claimed before the standard
+    // Link parser. GFM Autolink registers its own `Autolink` inline
+    // parser independently and emits bare `URL` nodes for `http://…`,
+    // `https://…`, `www.…`, `mailto:…`, `xmpp:…`, and bare emails. It
+    // does not interact with the `[…](…)` Link path and so coexists
+    // with wikilink without conflict. The autolink decoration branch
+    // recognizes top-level `URL` nodes (those whose parent is NOT a
+    // Link or Image — Link/Image already own their URL children via
+    // the existing cursor-reveal pattern).
+    markdown({
+      extensions: [Strikethrough, Table, TaskList, Autolink, wikilinkExtension, footnoteExtension],
+      // Return the inner Language synchronously per fence info string.
+      // `lang-markdown` accepts either a Language or a LanguageDescription;
+      // since we eagerly construct LanguageSupport for the curated set
+      // at module-load (cheap — five lezer grammars) the synchronous
+      // path is simpler than the async LanguageDescription dance.
+      codeLanguages: lookupFenceLanguage,
+      // No keymap injection — the plaintext editor owns its own
+      // keymap and we don't want lang-markdown's enter-handling
+      // (list continuation, etc.) firing on .txt notes.
+      addKeymap: false,
+    }),
+    // Without this, the nested fence languages parse but emit no
+    // visible token classes. Default highlight style maps the lezer
+    // highlight tags (keyword, string, number, …) to CSS variables on
+    // CM6's theme classes (`.tok-keyword`, `.tok-string`, …) which
+    // the default theme paints.
+    syntaxHighlighting(kbCodeHighlightStyle, { fallback: true }),
+    // StateField host (instead of a ViewPlugin) — block decorations
+    // (Table widget's `block: true` replace) require this. See
+    // `markdownDecorationField` for the rebuild policy.
+    //
+    // No `EditorView.atomicRanges` opt-in here. Earlier experiments
+    // exposed our `DecorationSet` as atomic, intending to make arrow-
+    // key motion jump over Table/Image widgets. Empirically that path
+    // triggered CM6's internal TilePointer.advance to walk off the
+    // parent stack (`Cannot destructure property 'tile' of
+    // 'parents.pop()'`) — most likely an interaction with the
+    // `Decoration.line` ranges this same field emits at coincident
+    // offsets. The widget UX is fine without it: clicks reposition
+    // the caret into the source range (TableWidget / ImageWidget
+    // both set `ignoreEvent() = false`), which triggers cursor-reveal
+    // and shows the raw markdown. Arrow keys step through the source
+    // range character-by-character once revealed.
+    //
+    // Focus-bridge order: register `editorFocusField` (the storage)
+    // before `markdownDecorationField` (the reader) so the field is
+    // available when the decoration field's `create` callback runs.
+    // The `focusBridge` ViewPlugin can sit anywhere — it only fires
+    // effects, never reads sibling fields. Order between StateFields
+    // matters in CM6; order among ViewPlugins doesn't for this case.
+    editorFocusField,
+    focusBridge,
+    markdownDecorationField(opts),
+    // Viewport-driven rebuild trigger — observes scroll / resize and
+    // lezer parser-extension growth, dispatches `viewportRebuildEffect`
+    // so the StateField above rebuilds against the newly-parsed tail.
+    // Without this the bottom half of long notes paints raw markdown
+    // until the user touches the editor. Order doesn't matter (it only
+    // dispatches effects, never reads sibling fields).
+    viewportRebuildTrigger,
+  ];
+}

--- a/packages/editor/src/lib/plaintext-link-affordance.ts
+++ b/packages/editor/src/lib/plaintext-link-affordance.ts
@@ -1,0 +1,512 @@
+/**
+ * Link + wikilink click and hover affordances for the plaintext editor
+ * (Slice 6 of the typography arc).
+ *
+ * Two related extensions live here:
+ *
+ *   - `plaintextLinkClickHandler(onWikilinkClick)` — a
+ *     `EditorView.domEventHandlers({ click })` that listens for clicks
+ *     on `.cm-md-link-label` (inline `[label](url)` link) and
+ *     `.cm-md-wikilink-label` (`[[target]]` / `[[target|alias]]`,
+ *     resolved or broken). URL links open in a new tab via
+ *     `window.open`; wikilinks invoke the host-supplied callback with
+ *     the same URL-encoded target the Markdown editor passes (so
+ *     `DocumentCanvas.handleWikilinkClick` doesn't care which surface
+ *     fired the click).
+ *
+ *   - `plaintextLinkHover(getLivePaths)` — a `hoverTooltip` that
+ *     surfaces the resolved path (or "Note not found") for a wikilink
+ *     when the pointer rests over it. URL links don't get a preview
+ *     in v1: the visible text already conveys destination, and the
+ *     interaction adds noise without value.
+ *
+ * Why a sibling file and not an addition to plaintext-decorations.ts:
+ * decorations are about *painting* nodes; clicks and hovers are about
+ * *interpreting* nodes. The syntax-tree walk to find the enclosing
+ * Link / Wikilink at a position is symmetrical to the decoration
+ * walk but the trigger (DOM event vs document/selection change) and
+ * output (callback / tooltip vs `Decoration`) are different. Keeping
+ * them split makes each easier to reason about; both consume the
+ * lezer-markdown tree the decoration pipeline already mounts.
+ *
+ * Contract parity with MarkdownEditor.svelte's `handleHostClick`:
+ *
+ *   1. Wikilink click fires `onWikilinkClick(encodeURIComponent(target), event)`.
+ *      The encoding mirrors `wikilink-decoration-plugin.ts` and is
+ *      decoded by `DocumentCanvas.handleWikilinkClick`. Resolved and
+ *      broken wikilinks both fire — `handleWikilinkClick` decides what
+ *      to navigate to (resolved path / fallback `<target>.md`).
+ *
+ *   2. URL link click opens in a new tab with `noopener,noreferrer`
+ *      and prevents default. Mod-click (cmd/ctrl) follows the same
+ *      "new tab" path on the markdown side (the browser's anchor
+ *      default), so behavior is consistent across both editors.
+ *
+ *   3. Mid-link caret editing is preserved: the click handler only
+ *      fires when the click target is the LABEL element (the visible
+ *      tinted span). Clicks on the syntax characters (`[[`, `]]`,
+ *      `[`, `]`, `(...)`) — which are normally hidden but reveal when
+ *      cursor is inside — land as normal text-position clicks because
+ *      they don't carry the label class.
+ *
+ * Hover tooltip is plaintext-only in this slice; the Markdown editor
+ * has no equivalent affordance today. Flag noted for parity work
+ * later — the resolver chain is the same, so lifting this to a
+ * shared utility once Markdown grows a hover surface is mechanical.
+ */
+
+import { EditorView, hoverTooltip, type Tooltip } from '@codemirror/view';
+import {
+  EditorSelection,
+  type EditorState,
+  type Extension,
+} from '@codemirror/state';
+import { syntaxTree } from '@codemirror/language';
+import type { SyntaxNode } from '@lezer/common';
+import {
+  parseMentionUrl,
+  parseWikilinkInner,
+  resolveLinkTarget,
+  type LivePath,
+} from './markdown-core';
+
+/**
+ * Walk up the syntax tree from `pos` to find the nearest enclosing
+ * `Link`, `Wikilink`, or bare `URL` (autolink) node. Returns `null`
+ * when none is found (the click landed in body text or in a different
+ * decorated range).
+ *
+ * A bare `URL` node — one whose parent is NOT `Link` or `Image` — is
+ * emitted by lezer-markdown's `Autolink` extension for `http(s)://`,
+ * `www.`, `mailto:`, `xmpp:`, and bare-email matches. The decoration
+ * pipeline paints these as `.cm-md-link-label` so they share the click
+ * affordance with inline `[label](url)` links.
+ *
+ * `side: -1` biases the resolver to prefer the node ending at `pos`
+ * over one starting there, which matters for clicks near the closing
+ * bracket. Both clicks happen inside the label span anyway (CM6's
+ * `posAtDOM` lands inside the textNode the label wraps), so this is
+ * defensive rather than load-bearing.
+ */
+export function resolveLinkAncestor(
+  view: EditorView,
+  pos: number,
+): SyntaxNode | null {
+  const tree = syntaxTree(view.state);
+  let node: SyntaxNode | null = tree.resolveInner(pos, -1);
+  while (node !== null) {
+    const name = node.type.name;
+    if (name === 'Link' || name === 'Wikilink') return node;
+    if (name === 'URL') {
+      // Distinguish autolink from Link/Image's own URL child — only
+      // the autolink case (top-level URL) is followed by the click
+      // handler. Link/Image URL clicks are handled via the Link
+      // branch reached by continuing to walk up the parent chain.
+      const pname = node.parent?.type.name;
+      if (pname !== 'Link' && pname !== 'Image') return node;
+    }
+    node = node.parent;
+  }
+  return null;
+}
+
+/**
+ * Normalize a bare-URL match to an openable href.
+ *
+ *   - `http://…` / `https://…` / `mailto:…` / `xmpp:…` pass through.
+ *   - `www.…` gets an `https://` prefix (GFM Autolink's `www.` branch
+ *     is shorthand for an https URL).
+ *   - A bare email (no scheme, contains `@`) gets a `mailto:` prefix.
+ *
+ * The Autolink parser's regex (`autolinkRE` in @lezer/markdown) already
+ * guarantees the input matches one of these shapes, so we don't need
+ * to defensively reject other inputs — anything we receive here came
+ * from a URL node the parser produced.
+ */
+function normalizeAutolinkHref(raw: string): string {
+  const trimmed = raw.trim();
+  if (
+    trimmed.startsWith('http://') ||
+    trimmed.startsWith('https://') ||
+    trimmed.startsWith('mailto:') ||
+    trimmed.startsWith('xmpp:')
+  ) {
+    return trimmed;
+  }
+  if (trimmed.startsWith('www.')) {
+    return `https://${trimmed}`;
+  }
+  // Bare email shape (Autolink's email branch).
+  if (trimmed.includes('@')) {
+    return `mailto:${trimmed}`;
+  }
+  return trimmed;
+}
+
+/**
+ * Walk up the syntax tree from `pos` to find the nearest enclosing
+ * `FootnoteRef` node — used by the hover-tooltip + mousedown handlers
+ * to surface the matching definition. Returns `null` when the position
+ * isn't inside a footnote reference.
+ */
+function resolveFootnoteRefAncestor(
+  view: EditorView,
+  pos: number,
+): SyntaxNode | null {
+  const tree = syntaxTree(view.state);
+  let node: SyntaxNode | null = tree.resolveInner(pos, -1);
+  while (node !== null) {
+    if (node.type.name === 'FootnoteRef') return node;
+    node = node.parent;
+  }
+  return null;
+}
+
+/**
+ * Read the label (`id`) text out of a FootnoteRef / FootnoteDef node by
+ * walking its `FootnoteLabel` child. Returns `null` if no label child
+ * is present (defensive — should not happen with a well-formed parse).
+ */
+function extractFootnoteLabel(
+  view: EditorView,
+  footnoteNode: SyntaxNode,
+): string | null {
+  let child: SyntaxNode | null = footnoteNode.firstChild;
+  while (child !== null) {
+    if (child.type.name === 'FootnoteLabel') {
+      const raw = view.state.sliceDoc(child.from, child.to);
+      return raw.length > 0 ? raw : null;
+    }
+    child = child.nextSibling;
+  }
+  return null;
+}
+
+/**
+ * Find the first `FootnoteDef` node in the doc whose `FootnoteLabel`
+ * matches the given id. Returns `null` when no definition exists
+ * (broken-ref case — the caller shows nothing on hover).
+ *
+ * We walk the syntax tree once per call. The doc is bounded in size
+ * (typical kb-1 note is a few hundred lines), so the cost is fine for
+ * an event-driven hover/click handler. Caching would be an
+ * optimization we don't need today.
+ */
+function findFootnoteDef(
+  view: EditorView,
+  id: string,
+): SyntaxNode | null {
+  const tree = syntaxTree(view.state);
+  let match: SyntaxNode | null = null;
+  tree.iterate({
+    enter: (n) => {
+      if (match !== null) return false;
+      if (n.type.name === 'FootnoteDef') {
+        const label = extractFootnoteLabel(view, n.node);
+        if (label === id) {
+          match = n.node;
+          return false;
+        }
+      }
+      return undefined;
+    },
+  });
+  return match;
+}
+
+/**
+ * Slice out the body text of a FootnoteDef node (everything after
+ * the `[^id]:` prefix), trimmed of leading whitespace. Returns the
+ * empty string when there is no body or the def is malformed.
+ */
+function extractFootnoteDefBody(
+  view: EditorView,
+  defNode: SyntaxNode,
+): string {
+  // The FootnoteDef carries three structural children we don't want in
+  // the body: `[^` open mark, label, `]:` close mark. Everything after
+  // the close-mark's `to` is body text.
+  let closeMarkEnd: number | null = null;
+  let child: SyntaxNode | null = defNode.firstChild;
+  let sawLabel = false;
+  while (child !== null) {
+    if (child.type.name === 'FootnoteLabel') {
+      sawLabel = true;
+    } else if (child.type.name === 'FootnoteDefMark' && sawLabel) {
+      closeMarkEnd = child.to;
+      break;
+    }
+    child = child.nextSibling;
+  }
+  if (closeMarkEnd === null) return '';
+  return view.state.sliceDoc(closeMarkEnd, defNode.to).trimStart();
+}
+
+/**
+ * Extract the `(url)` portion of a `Link` node by walking its `URL`
+ * child. Returns `null` for malformed Link nodes (missing URL).
+ *
+ * Mirrors the URL-extraction in `parseImageNode` (same file as the
+ * decoration pipeline) — the lezer-markdown tree emits a `URL` child
+ * for the parenthesized destination of an inline link, optionally
+ * wrapped in `<...>` for URLs containing spaces / parens.
+ */
+export function extractLinkUrl(
+  state: EditorState,
+  linkNode: SyntaxNode,
+): string | null {
+  let child: SyntaxNode | null = linkNode.firstChild;
+  while (child !== null) {
+    if (child.type.name === 'URL') {
+      let raw = state.sliceDoc(child.from, child.to).trim();
+      if (raw.startsWith('<') && raw.endsWith('>')) raw = raw.slice(1, -1);
+      return raw.length > 0 ? raw : null;
+    }
+    child = child.nextSibling;
+  }
+  return null;
+}
+
+/**
+ * Extract the bare target of a `Wikilink` node by walking its
+ * `WikilinkTarget` child and feeding it through `parseWikilinkInner`
+ * (the canonical splitter for `target#heading|alias`). Mirrors the
+ * decoration-pipeline's resolution path so the same input maps to
+ * the same target.
+ *
+ * Returns `null` for empty / malformed wikilinks — callers should
+ * suppress the click in that case (let CM6 handle the position
+ * normally so the user can finish typing the wikilink).
+ */
+function extractWikilinkTarget(
+  view: EditorView,
+  wikilinkNode: SyntaxNode,
+): string | null {
+  let targetChild: SyntaxNode | null = null;
+  let aliasChild: SyntaxNode | null = null;
+  let child: SyntaxNode | null = wikilinkNode.firstChild;
+  while (child !== null) {
+    const cname = child.type.name;
+    if (cname === 'WikilinkTarget') targetChild = child;
+    else if (cname === 'WikilinkAlias') aliasChild = child;
+    child = child.nextSibling;
+  }
+  if (targetChild === null) return null;
+  const targetText = view.state.sliceDoc(targetChild.from, targetChild.to);
+  const parts = parseWikilinkInner(
+    targetText + (aliasChild !== null ? '|' : ''),
+  );
+  if (parts === null) return null;
+  const trimmed = parts.target.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Click handler extension. Pass the host's `onWikilinkClick` callback
+ * to receive wikilink clicks with the URL-encoded target (mirrors
+ * MarkdownEditor's contract).
+ *
+ * URL links open in a new tab unconditionally — `window.open` with
+ * `noopener,noreferrer` so the opened page can't reach back into the
+ * editor's window context. Modifier keys are not special-cased: the
+ * default is already "new tab", and the markdown editor doesn't
+ * special-case Cmd-click either.
+ */
+export function plaintextLinkClickHandler(
+  onWikilinkClick: ((encodedTarget: string, event: MouseEvent) => void) | null,
+): Extension {
+  // Shape A interaction: line-based reveal of links on the cursor's
+  // line means a click that lands ON a label span triggers a chain —
+  // mousedown moves the cursor to that line → decoration rebuild → the
+  // label span is removed from the DOM → mouseup target is gone → the
+  // browser cancels the `click` event entirely. So we cannot wait for
+  // `click` to fire to follow the link.
+  //
+  // Fix: catch the link at MOUSEDOWN time (label is still in DOM,
+  // affordance handler runs before CM6's selection update), and follow
+  // immediately. We also return `true` to short-circuit CM6's own
+  // mousedown handling so the cursor doesn't move to the link's line —
+  // the user's intent was to navigate, not to edit.
+  return EditorView.domEventHandlers({
+    mousedown(event, view) {
+      // Only left-click follows links; modifier-less click. Mod-click
+      // and right-click pass through to default text-selection behavior.
+      if (event.button !== 0) return false;
+      const target = event.target;
+      if (!(target instanceof Element)) return false;
+
+      // Footnote-reference click → scroll the matching definition into
+      // view (and place the caret at the definition for a brief flash
+      // via the editor's normal selection-painted highlight). v1 keeps
+      // it simple: same-doc anchor; no panel, no navigation. Broken
+      // refs (no matching def) just no-op — the broken styling already
+      // signals the missing target.
+      const footnoteRef = target.closest('.cm-md-footnote-ref');
+      if (footnoteRef instanceof HTMLElement) {
+        const refPos = view.posAtDOM(footnoteRef);
+        const refNode = resolveFootnoteRefAncestor(view, refPos + 1);
+        if (refNode === null) return false;
+        const id = extractFootnoteLabel(view, refNode);
+        if (id === null) return false;
+        const defNode = findFootnoteDef(view, id);
+        if (defNode === null) {
+          // Broken ref — suppress the default click so the caret
+          // doesn't jump to a meaningless position; the tinted broken
+          // styling already conveys "no target".
+          event.preventDefault();
+          return true;
+        }
+        // Scroll the definition into view and place the caret at its
+        // start so CM6's active-line highlight gives a quiet flash. The
+        // user can then read / edit the definition in place.
+        view.dispatch({
+          selection: EditorSelection.single(defNode.from),
+          effects: EditorView.scrollIntoView(defNode.from, { y: 'center' }),
+        });
+        event.preventDefault();
+        return true;
+      }
+
+      const label = target.closest(
+        '.cm-md-link-label, .cm-md-wikilink-label',
+      );
+      if (!(label instanceof HTMLElement)) return false;
+      const pos = view.posAtDOM(label);
+      const linkNode = resolveLinkAncestor(view, pos + 1);
+      if (linkNode === null) return false;
+      if (linkNode.type.name === 'Link') {
+        const url = extractLinkUrl(view.state, linkNode);
+        if (url === null) return false;
+        // Mention chips (`[Name](mention:email)`) suppress the click
+        // entirely — the chip is a typographic affordance, not a
+        // navigation surface. Returning false (without preventDefault)
+        // lets CM6's default click-to-position run, so the user's caret
+        // lands inside the source range and the line's Shape A reveal
+        // exposes the raw markdown for editing. Mirrors Crepe-side
+        // behaviour where mention chips have no click handler.
+        if (parseMentionUrl(url) !== null) return false;
+        if (url.startsWith('wikilink:') && onWikilinkClick !== null) {
+          // Defensive: legacy `[label](wikilink:target)` form delegates
+          // to the wikilink path.
+          onWikilinkClick(url.slice('wikilink:'.length), event);
+        } else {
+          window.open(url, '_blank', 'noopener,noreferrer');
+        }
+        event.preventDefault();
+        return true;
+      }
+      if (linkNode.type.name === 'URL') {
+        // Autolink (GFM): the URL node IS the source range. Slice
+        // directly — no `<…>` wrapping for autolinks (lezer's autolink
+        // regex doesn't match angle-bracket forms). Normalize bare
+        // `www.…` and bare emails to openable schemes.
+        const raw = view.state.sliceDoc(linkNode.from, linkNode.to);
+        const href = normalizeAutolinkHref(raw);
+        if (href.length === 0) return false;
+        window.open(href, '_blank', 'noopener,noreferrer');
+        event.preventDefault();
+        return true;
+      }
+      if (linkNode.type.name === 'Wikilink') {
+        if (onWikilinkClick === null) return false;
+        const rawTarget = extractWikilinkTarget(view, linkNode);
+        if (rawTarget === null) return false;
+        // URL-encode to match the markdown side's emission
+        // (`onWikilinkClick(encodeURIComponent(raw), event)` in
+        // MarkdownEditor.svelte's `handleHostClick`). The shared
+        // `DocumentCanvas.handleWikilinkClick` decodes before
+        // resolving, so the two surfaces feed it the same shape.
+        onWikilinkClick(encodeURIComponent(rawTarget), event);
+        event.preventDefault();
+        return true;
+      }
+      return false;
+    },
+  });
+}
+
+/**
+ * Hover-tooltip extension for wikilinks. Resolves the target against
+ * `getLivePaths()` and shows the path (resolved) or "Note not found"
+ * (unresolved). No tooltip for URL links — the destination is already
+ * visible in the source on cursor-reveal, and a tooltip showing the
+ * URL would be noise.
+ *
+ * Returns `null` when the hover position isn't inside a wikilink,
+ * which is how `hoverTooltip` says "no tooltip here". CM6 handles
+ * fade-in / fade-out timing; the default ~300ms delay matches the
+ * usual OS tooltip cadence.
+ */
+export function plaintextLinkHover(
+  getLivePaths: () => readonly LivePath[],
+): Extension {
+  return hoverTooltip((view, pos, _side): Tooltip | null => {
+    // Footnote reference first — the parse tree resolver below would
+    // otherwise descend into Link / Wikilink only; FootnoteRef is its
+    // own top-level inline node. Resolution shape: ref id → matching
+    // FootnoteDef body. No match → no tooltip (the broken styling
+    // already signals the missing target; a "definition not found"
+    // popover would just be noise on every hover).
+    const footnoteRef = resolveFootnoteRefAncestor(view, pos);
+    if (footnoteRef !== null) {
+      const id = extractFootnoteLabel(view, footnoteRef);
+      if (id === null) return null;
+      const defNode = findFootnoteDef(view, id);
+      if (defNode === null) return null;
+      const body = extractFootnoteDefBody(view, defNode);
+      if (body.length === 0) return null;
+      return {
+        pos: footnoteRef.from,
+        end: footnoteRef.to,
+        above: true,
+        create() {
+          // Same visual register as the wikilink preview — the
+          // `cm-md-footnote-preview` class shares the `.cm-tooltip`
+          // shell rules with `.cm-md-wikilink-preview` (see the
+          // `:has(.cm-md-wikilink-preview, .cm-md-footnote-preview)`
+          // shell selector in PlaintextEditor.svelte) so both popovers
+          // get the translucent panel + hairline border treatment.
+          const dom = document.createElement('div');
+          dom.className = 'cm-md-footnote-preview';
+          dom.textContent = body;
+          dom.dataset.footnoteId = id;
+          return { dom };
+        },
+      };
+    }
+
+    const node = resolveLinkAncestor(view, pos);
+    if (node?.type.name !== 'Wikilink') return null;
+
+    const rawTarget = extractWikilinkTarget(view, node);
+    if (rawTarget === null) return null;
+
+    const livePaths = getLivePaths();
+    const resolved = resolveLinkTarget({ raw: rawTarget, livePaths });
+
+    // Only display when fully resolved or fully broken — the parser
+    // already filtered empty / malformed shapes via the null guard
+    // above. Position the tooltip above the wikilink so it doesn't
+    // obscure following text.
+    return {
+      pos: node.from,
+      end: node.to,
+      above: true,
+      create() {
+        const dom = document.createElement('div');
+        dom.className = 'cm-md-wikilink-preview';
+        if (resolved !== null) {
+          // Show the resolved path. If a future LivePath shape grows a
+          // display label / title field we'd surface that instead;
+          // today `path` is what's available.
+          dom.textContent = resolved.path;
+          dom.dataset.state = 'resolved';
+        } else {
+          dom.textContent = `Note not found: ${rawTarget}`;
+          dom.dataset.state = 'broken';
+        }
+        return { dom };
+      },
+    };
+  });
+}

--- a/packages/editor/src/lib/plaintext-link-paste.test.ts
+++ b/packages/editor/src/lib/plaintext-link-paste.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { linkPasteMarkdown, noteLinkLabel } from './plaintext-link-paste';
+
+describe('noteLinkLabel', () => {
+  it('extracts the filename stem from an org vault note URL', () => {
+    const url = new URL(
+      'http://localhost:8797/app/org/dev-org/vault/dev-vault/projects/my-research.md',
+    );
+    expect(noteLinkLabel(url)).toBe('my-research');
+  });
+
+  it('handles private and public vault shapes', () => {
+    expect(
+      noteLinkLabel(new URL('https://kb.example.com/app/private/vault/kb-1/idea.md')),
+    ).toBe('idea');
+    expect(
+      noteLinkLabel(new URL('https://kb.example.com/app/public/vault/kb-1/README.md')),
+    ).toBe('README');
+  });
+
+  it('decodes percent-encoded path segments', () => {
+    const url = new URL(
+      'http://localhost:8797/app/org/dev-org/vault/dev-vault/meeting%20notes.md',
+    );
+    expect(noteLinkLabel(url)).toBe('meeting notes');
+  });
+
+  it('returns null for vault roots and folders (no dot in last segment)', () => {
+    expect(
+      noteLinkLabel(new URL('http://localhost:8797/app/org/dev-org/vault/dev-vault')),
+    ).toBeNull();
+    expect(
+      noteLinkLabel(
+        new URL('http://localhost:8797/app/org/dev-org/vault/dev-vault/projects'),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null for non-vault app routes and external URLs', () => {
+    expect(
+      noteLinkLabel(new URL('http://localhost:8797/app/settings')),
+    ).toBeNull();
+    expect(noteLinkLabel(new URL('https://example.com/some/page.html'))).toBeNull();
+  });
+});
+
+describe('linkPasteMarkdown', () => {
+  const noteUrl =
+    'http://localhost:8797/app/org/dev-org/vault/dev-vault/projects/my-research.md';
+
+  it('inserts [note name](url) for a kb-1 note URL with no selection', () => {
+    expect(linkPasteMarkdown(noteUrl, '')).toBe(`[my-research](${noteUrl})`);
+  });
+
+  it('tolerates surrounding whitespace from the clipboard', () => {
+    expect(linkPasteMarkdown(`${noteUrl}\n`, '')).toBe(
+      `[my-research](${noteUrl})`,
+    );
+  });
+
+  it('wraps a selection for any URL, not just note URLs', () => {
+    expect(linkPasteMarkdown('https://example.com/docs', 'the docs')).toBe(
+      '[the docs](https://example.com/docs)',
+    );
+    expect(linkPasteMarkdown(noteUrl, 'my research note')).toBe(
+      `[my research note](${noteUrl})`,
+    );
+  });
+
+  it('falls through for an external URL with no selection', () => {
+    expect(linkPasteMarkdown('https://example.com/docs', '')).toBeNull();
+  });
+
+  it('falls through for non-URL pastes', () => {
+    expect(linkPasteMarkdown('just some text', 'selected')).toBeNull();
+    expect(linkPasteMarkdown('not a url with spaces', '')).toBeNull();
+  });
+
+  it('falls through for non-http(s) schemes', () => {
+    expect(linkPasteMarkdown('ftp://example.com/file', 'label')).toBeNull();
+    expect(linkPasteMarkdown('javascript:alert(1)', 'label')).toBeNull();
+  });
+
+  it('replaces (does not wrap) a selection that is itself a URL', () => {
+    expect(
+      linkPasteMarkdown('https://example.com/new', 'https://example.com/old'),
+    ).toBeNull();
+  });
+
+  it('falls through for multi-line selections', () => {
+    expect(
+      linkPasteMarkdown('https://example.com', 'line one\nline two'),
+    ).toBeNull();
+  });
+
+  it('falls through for multi-line clipboard text containing a URL', () => {
+    expect(
+      linkPasteMarkdown('check this:\nhttps://example.com', 'label'),
+    ).toBeNull();
+  });
+
+  it('escapes markdown-significant characters in the label', () => {
+    expect(
+      linkPasteMarkdown('https://example.com/docs', 'see [this] \\ that'),
+    ).toBe('[see \\[this\\] \\\\ that](https://example.com/docs)');
+  });
+
+  it('percent-encodes parens in the destination so the link parses', () => {
+    const parenUrl =
+      'http://localhost:8797/app/org/dev-org/vault/dev-vault/plan%20(draft).md';
+    expect(linkPasteMarkdown(parenUrl, '')).toBe(
+      '[plan (draft)](http://localhost:8797/app/org/dev-org/vault/dev-vault/plan%20%28draft%29.md)',
+    );
+  });
+});

--- a/packages/editor/src/lib/plaintext-link-paste.ts
+++ b/packages/editor/src/lib/plaintext-link-paste.ts
@@ -1,0 +1,135 @@
+/**
+ * Paste-a-URL-as-markdown-link for the plaintext (CM6) editor.
+ *
+ * Two behaviors, both editor-side only (the clipboard always holds the
+ * raw URL, so pasting outside the editor is unaffected):
+ *
+ *   1. Any URL pasted over a text selection wraps the selection:
+ *      select "see my research", paste a link → `[see my research](url)`.
+ *      Same convention as GitHub / Obsidian.
+ *
+ *   2. A kb-1 note URL (`/app/org|private|public/vault/<slug>/<path>`)
+ *      pasted with no selection inserts `[<note name>](url)` — the
+ *      label is the note's filename stem taken from the URL itself, so
+ *      links to notes in other vaults resolve without any lookup.
+ *
+ * Everything else falls through to CM6's default paste. Guards on the
+ * wrap path: the selection must be single-line (wrapping a multi-line
+ * selection breaks the markdown link) and must not itself be a URL
+ * (pasting a URL over an old URL should replace it, not nest it).
+ *
+ * Sibling of `plaintext-image-upload.ts` — same `domEventHandlers`
+ * paste hook. The two are disjoint: the image handler only acts when
+ * the clipboard carries files, this one only when it carries plain
+ * text, so mount order doesn't matter.
+ */
+
+import { EditorView } from '@codemirror/view';
+import type { Extension } from '@codemirror/state';
+
+import { parseInVaultSelector } from './selector-url';
+
+/** Matches the three vault route shapes; captures vault slug + selector. */
+const VAULT_ROUTE_RE = /^\/app\/(?:org\/[^/]+|private|public)\/vault\/([^/]+)(\/.+)?$/;
+
+function asHttpUrl(text: string): URL | null {
+  if (/\s/.test(text)) return null;
+  let url: URL;
+  try {
+    url = new URL(text);
+  } catch {
+    return null;
+  }
+  return url.protocol === 'http:' || url.protocol === 'https:' ? url : null;
+}
+
+/**
+ * If `url` points at a note inside a kb-1 vault, return the note's
+ * display label (filename stem, decoded); otherwise null. Routing
+ * shape and note-vs-folder discrimination both delegate to the
+ * canonical parser in `selector-url.ts`.
+ */
+export function noteLinkLabel(url: URL): string | null {
+  const match = VAULT_ROUTE_RE.exec(url.pathname);
+  if (!match) return null;
+  const target = parseInVaultSelector(
+    decodeURIComponent(match[1]),
+    match[2] ?? '',
+  );
+  if (target.kind !== 'note') return null;
+  const base = target.path.split('/').pop() ?? '';
+  const stem = base.replace(/\.[^.]+$/, '');
+  return stem.length > 0 ? stem : null;
+}
+
+/**
+ * Backslash-escape the characters that would terminate or corrupt a
+ * markdown link label: `\` itself, and both square brackets.
+ */
+function escapeLabel(label: string): string {
+  return label.replace(/[\\[\]]/g, '\\$&');
+}
+
+/**
+ * A plain CommonMark link destination ends at the first unescaped `)`.
+ * `encodeURIComponent` leaves parens alone, so note names like
+ * `plan (draft).md` survive into the URL — percent-encode them here so
+ * the destination parses intact. %28/%29 decode back transparently on
+ * navigation.
+ */
+function safeHref(url: URL): string {
+  return url.href.replaceAll('(', '%28').replaceAll(')', '%29');
+}
+
+/**
+ * Pure decision core, exported for tests. Returns the markdown to
+ * insert in place of the pasted text, or null to let the default
+ * paste run.
+ */
+export function linkPasteMarkdown(
+  pasted: string,
+  selected: string,
+): string | null {
+  const url = asHttpUrl(pasted.trim());
+  if (!url) return null;
+  if (selected.length > 0) {
+    if (selected.includes('\n')) return null;
+    if (asHttpUrl(selected.trim())) return null;
+    return `[${escapeLabel(selected)}](${safeHref(url)})`;
+  }
+  const label = noteLinkLabel(url);
+  return label === null ? null : `[${escapeLabel(label)}](${safeHref(url)})`;
+}
+
+/**
+ * Build the CM6 extension. The dispatch goes through the normal
+ * local-edit path (PLAINTEXT_USER_ORIGIN via the sync plugin), so the
+ * inserted link is undoable and visible to peers like any typed text.
+ */
+export function plaintextLinkPaste(): Extension {
+  return EditorView.domEventHandlers({
+    paste(event, view) {
+      if (!view.state.facet(EditorView.editable)) return false;
+      const data = event.clipboardData;
+      if (!data || data.files.length > 0) return false;
+      const text = data.getData('text/plain');
+      if (!text) return false;
+      // Multi-cursor paste: transforming only the main range while
+      // preventDefault() suppresses the rest would silently drop the
+      // other cursors' pastes — fall through to CM6's default, which
+      // handles multi-range correctly.
+      if (view.state.selection.ranges.length !== 1) return false;
+      const { from, to } = view.state.selection.main;
+      const markdown = linkPasteMarkdown(text, view.state.sliceDoc(from, to));
+      if (markdown === null) return false;
+      event.preventDefault();
+      view.dispatch({
+        changes: { from, to, insert: markdown },
+        selection: { anchor: from + markdown.length },
+        scrollIntoView: true,
+        userEvent: 'input.paste',
+      });
+      return true;
+    },
+  });
+}

--- a/packages/editor/src/lib/plaintext-list-keymap.test.ts
+++ b/packages/editor/src/lib/plaintext-list-keymap.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { plaintextDecorations } from './plaintext-decorations';
+import { listIndentChange } from './plaintext-list-keymap';
+
+/**
+ * Unit tests for the list-indent decision function. `listIndentChange`
+ * encapsulates the lezer ListItem gate, FencedCode bail-out, and
+ * leading-whitespace shape check; the keymap's `run` handlers wrap
+ * this with `view.dispatch` and are exercised at the browser-smoke
+ * layer.
+ */
+
+function makeState(doc: string) {
+  return EditorState.create({
+    doc,
+    extensions: [plaintextDecorations()],
+  });
+}
+
+describe('listIndentChange — Tab indents list lines', () => {
+  it('inserts two spaces at line.from on a top-level bullet', () => {
+    const doc = '- alpha';
+    const state = makeState(doc);
+    // Caret somewhere inside the body — exact column doesn't matter,
+    // the change is anchored at line.from.
+    const change = listIndentChange(state, doc.indexOf('alpha'), 1);
+    expect(change).toEqual({ from: 0, to: 0, insert: '  ' });
+  });
+
+  it('inserts two spaces on an already-nested bullet (cumulative)', () => {
+    const doc = '- alpha\n  - beta';
+    const state = makeState(doc);
+    const pos = doc.indexOf('beta');
+    const change = listIndentChange(state, pos, 1);
+    // line.from for the second line is just after the `\n` — the
+    // change inserts at that anchor regardless of existing indent.
+    const lineFrom = doc.indexOf('  - beta');
+    expect(change).toEqual({ from: lineFrom, to: lineFrom, insert: '  ' });
+  });
+
+  it('inserts two spaces on an ordered-list line', () => {
+    const doc = '1. alpha';
+    const state = makeState(doc);
+    const change = listIndentChange(state, doc.indexOf('alpha'), 1);
+    expect(change).toEqual({ from: 0, to: 0, insert: '  ' });
+  });
+
+  it('inserts two spaces on a task-list line', () => {
+    // GFM task list — TaskList extension is mounted by plaintextDecorations.
+    const doc = '- [ ] do the thing';
+    const state = makeState(doc);
+    const change = listIndentChange(state, doc.indexOf('do'), 1);
+    expect(change).toEqual({ from: 0, to: 0, insert: '  ' });
+  });
+
+  it('returns null on plain prose with no ListItem ancestor', () => {
+    const doc = 'just a paragraph with no list';
+    const state = makeState(doc);
+    const change = listIndentChange(state, 5, 1);
+    expect(change).toBeNull();
+  });
+
+  it('returns null inside a fenced code block', () => {
+    // A fenced code block even if visually nested under a list line
+    // bails out at the FencedCode ancestor check before reaching the
+    // ListItem check.
+    const doc = '```ts\nconst x = 1;\n```';
+    const state = makeState(doc);
+    const change = listIndentChange(state, doc.indexOf('const'), 1);
+    expect(change).toBeNull();
+  });
+
+  it('indents when the caret sits at line.from of a list line', () => {
+    // Boundary case: caret at line.from (e.g. pressed Home before Tab).
+    // Single-side resolveInner(-1) would have resolved into the prior
+    // block; the dual-side probe finds the ListItem via the +1 bias.
+    const doc = '- alpha\n- beta';
+    const state = makeState(doc);
+    const betaLineFrom = doc.indexOf('- beta');
+    const change = listIndentChange(state, betaLineFrom, 1);
+    expect(change).toEqual({ from: betaLineFrom, to: betaLineFrom, insert: '  ' });
+  });
+
+  it('indents the very first list line when caret is at doc start', () => {
+    // pos === 0 boundary — earlier single-side -1 probe would walk into
+    // a "before doc" position and miss the ListItem entirely.
+    const doc = '- alpha';
+    const state = makeState(doc);
+    const change = listIndentChange(state, 0, 1);
+    expect(change).toEqual({ from: 0, to: 0, insert: '  ' });
+  });
+
+  it('falls through at the boundary between a list line and a nested fence', () => {
+    // FencedCode wins over ListItem when either side resolves into it:
+    // a fence opening inside a list item should not indent the list
+    // row. Caret sits just before the opening ```.
+    const doc = '- alpha\n  ```ts\n  const x = 1;\n  ```';
+    const state = makeState(doc);
+    const fenceFrom = doc.indexOf('```ts');
+    const change = listIndentChange(state, fenceFrom, 1);
+    expect(change).toBeNull();
+  });
+});
+
+describe('listIndentChange — Shift-Tab outdents list lines', () => {
+  it('removes two leading spaces on an indented bullet', () => {
+    const doc = '- alpha\n  - beta';
+    const state = makeState(doc);
+    const pos = doc.indexOf('beta');
+    const change = listIndentChange(state, pos, -1);
+    const lineFrom = doc.indexOf('  - beta');
+    expect(change).toEqual({ from: lineFrom, to: lineFrom + 2, insert: '' });
+  });
+
+  it('returns null on a top-level bullet (no leading whitespace to remove)', () => {
+    const doc = '- alpha';
+    const state = makeState(doc);
+    const change = listIndentChange(state, doc.indexOf('alpha'), -1);
+    expect(change).toBeNull();
+  });
+
+  it('returns null when the leading whitespace is a single space', () => {
+    // Single-space lead is not the 2-space markdown convention; v1
+    // refuses to normalise mixed indent and falls through.
+    const doc = '- alpha\n - beta';
+    const state = makeState(doc);
+    const pos = doc.indexOf('beta');
+    const change = listIndentChange(state, pos, -1);
+    expect(change).toBeNull();
+  });
+
+  it('returns null when the leading whitespace is a tab', () => {
+    // Tab-indented list line — not a shape we normalise in v1.
+    // Lezer may or may not parse `\t- beta` as a continuation of the
+    // parent ListItem depending on context; the outdent gate refuses
+    // regardless because the first two chars aren't `"  "`.
+    const doc = '- alpha\n\t- beta';
+    const state = makeState(doc);
+    const pos = doc.indexOf('beta');
+    const change = listIndentChange(state, pos, -1);
+    expect(change).toBeNull();
+  });
+});

--- a/packages/editor/src/lib/plaintext-list-keymap.ts
+++ b/packages/editor/src/lib/plaintext-list-keymap.ts
@@ -1,0 +1,113 @@
+/**
+ * Tab / Shift-Tab indent / outdent for list items in the plaintext editor.
+ *
+ * Tab on a line whose lezer ancestry includes a `ListItem` inserts two
+ * spaces at the line start (one markdown nesting level); Shift-Tab
+ * removes two leading spaces. Tab outside any `ListItem` returns false
+ * and cascades to the default keymap — so the browser's natural
+ * focus-traversal behaviour stays intact for keyboard-only users.
+ *
+ * Single-line v1: any non-empty selection (anchor and head on different
+ * lines, or non-empty range at all) falls through. Multi-line block
+ * indent/outdent is a deferred follow-up.
+ */
+
+import { keymap, type EditorView } from '@codemirror/view';
+import { syntaxTree } from '@codemirror/language';
+import type { SyntaxNode } from '@lezer/common';
+import type { EditorState, Extension } from '@codemirror/state';
+
+const INDENT = '  ';
+
+/**
+ * Whether the caret at `pos` sits inside a `ListItem` (and NOT inside
+ * a `FencedCode` block). We probe both left- and right-biased ancestry
+ * because at a line boundary (caret at line.from of a list line, or at
+ * the edge of a fence opening inside a list) one side may resolve into
+ * the prior block while the other resolves into the new one — relying
+ * on a single bias would mis-classify boundary positions.
+ *
+ * `FencedCode` always wins over `ListItem`: if EITHER side sees a fence
+ * we fall through, so Tab inside a code block stays available for an
+ * eventual code-indent slice and never accidentally indents the list
+ * row a nested fence belongs to.
+ */
+function inListItem(state: EditorState, pos: number): boolean {
+  const tree = syntaxTree(state);
+  let hasListItem = false;
+  for (const side of [-1, 1] as const) {
+    let cursor: SyntaxNode | null = tree.resolveInner(pos, side);
+    while (cursor !== null) {
+      if (cursor.type.name === 'FencedCode') return false;
+      if (cursor.type.name === 'ListItem') hasListItem = true;
+      cursor = cursor.parent;
+    }
+  }
+  return hasListItem;
+}
+
+/**
+ * Pure decision function: given a state, a caret position, and the
+ * direction, return the change to dispatch or `null` to fall through.
+ *
+ * direction = +1 → indent (insert two spaces at line.from).
+ * direction = -1 → outdent (remove two leading spaces if present).
+ *
+ * Returns `null` when:
+ *   - caret is not inside a `ListItem` (or sits inside a fenced code
+ *     block under one — bail before the ListItem check),
+ *   - outdenting a line that doesn't start with two spaces (no-op),
+ *   - the leading whitespace is mixed (tabs / single space) — single-
+ *     line v1 stays out of normalisation territory.
+ */
+export function listIndentChange(
+  state: EditorState,
+  pos: number,
+  direction: 1 | -1,
+): { from: number; to: number; insert: string } | null {
+  if (!inListItem(state, pos)) return null;
+  const line = state.doc.lineAt(pos);
+  if (direction === 1) {
+    return { from: line.from, to: line.from, insert: INDENT };
+  }
+  // Outdent: only when the first two chars are spaces. Tabs or a
+  // single leading space → fall through (v1 stays simple).
+  const head = state.doc.sliceString(line.from, line.from + 2);
+  if (head !== INDENT) return null;
+  return { from: line.from, to: line.from + 2, insert: '' };
+}
+
+/**
+ * Keymap extension wiring Tab + Shift-Tab to list indent / outdent.
+ * Mount BEFORE `defaultKeymap` so we get first crack — defaultKeymap
+ * doesn't bind Tab today but the ordering is the safe convention,
+ * matching `plaintextMentionKeymap`'s placement.
+ *
+ * Multi-line selections fall through (return false) — multi-line block
+ * indent is a deferred follow-up. Empty selection only.
+ */
+export function plaintextListKeymap(): Extension {
+  return keymap.of([
+    {
+      key: 'Tab',
+      run(view: EditorView): boolean {
+        return runIndent(view, 1);
+      },
+      shift(view: EditorView): boolean {
+        return runIndent(view, -1);
+      },
+    },
+  ]);
+}
+
+function runIndent(view: EditorView, direction: 1 | -1): boolean {
+  const { state } = view;
+  const sel = state.selection.main;
+  if (!sel.empty) return false;
+  const change = listIndentChange(state, sel.head, direction);
+  if (change === null) return false;
+  // CM6 maps the existing selection through `changes` automatically;
+  // the caret's offset from line.from is preserved.
+  view.dispatch({ changes: change });
+  return true;
+}

--- a/packages/editor/src/lib/plaintext-mention-keymap.test.ts
+++ b/packages/editor/src/lib/plaintext-mention-keymap.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { plaintextDecorations } from './plaintext-decorations';
+import { mentionAtomicDeleteRange } from './plaintext-mention-keymap';
+
+/**
+ * Unit tests for the mention atomic-edge delete logic. The pure
+ * `mentionAtomicDeleteRange(state, pos, key)` helper encapsulates the
+ * right-edge / left-edge / inside detection so we can exercise it
+ * without an EditorView (no DOM in the vitest config; see vitest.config.ts).
+ *
+ * The keymap's `run` handlers wrap this with `view.dispatch` — the
+ * dispatch is a one-liner over the returned range and is exercised in
+ * the browser-smoke side, not here.
+ */
+
+function makeState(doc: string) {
+  return EditorState.create({
+    doc,
+    extensions: [plaintextDecorations()],
+  });
+}
+
+describe('mentionAtomicDeleteRange — Backspace at right edge', () => {
+  it('returns the full mention range when caret is immediately after the closing `)`', () => {
+    const doc = '[Alice](mention:alice@kb-1.dev)';
+    const state = makeState(doc);
+    // Caret at the very end of the doc — right after the `)`.
+    const range = mentionAtomicDeleteRange(state, doc.length, 'Backspace');
+    expect(range).not.toBeNull();
+    expect(range).toEqual({ from: 0, to: doc.length });
+  });
+
+  it('returns null (falls through to per-char delete) when caret is INSIDE the mention', () => {
+    const doc = '[Alice](mention:alice@kb-1.dev)';
+    const state = makeState(doc);
+    // Caret inside the display name — typo-fix carve-out.
+    const range = mentionAtomicDeleteRange(state, 3, 'Backspace');
+    expect(range).toBeNull();
+  });
+
+  it('returns null when caret is in plain text not adjacent to a mention', () => {
+    const doc = 'plain text with no mentions';
+    const state = makeState(doc);
+    const range = mentionAtomicDeleteRange(state, 5, 'Backspace');
+    expect(range).toBeNull();
+  });
+
+  it('returns null when caret is at position 0 (no character to backspace)', () => {
+    const doc = '[Alice](mention:alice@kb-1.dev)';
+    const state = makeState(doc);
+    const range = mentionAtomicDeleteRange(state, 0, 'Backspace');
+    expect(range).toBeNull();
+  });
+
+  it('does not match a non-mention link', () => {
+    // `[label](https://example.com)` is a regular link, not a mention.
+    // Backspace at the right edge should NOT atomic-delete it — the
+    // user typically wants per-char delete on URLs (the URL might be
+    // longer than they want to retype).
+    const doc = '[Anthropic](https://anthropic.com)';
+    const state = makeState(doc);
+    const range = mentionAtomicDeleteRange(state, doc.length, 'Backspace');
+    expect(range).toBeNull();
+  });
+});
+
+describe('mentionAtomicDeleteRange — Delete at left edge', () => {
+  it('returns the full mention range when caret is immediately before the opening `[`', () => {
+    const doc = '[Bob](mention:bob@kb-1.dev) trailing';
+    const state = makeState(doc);
+    // Caret at position 0 — right before the `[`.
+    const range = mentionAtomicDeleteRange(state, 0, 'Delete');
+    expect(range).not.toBeNull();
+    expect(range?.from).toBe(0);
+    // Mention range = `[Bob](mention:bob@kb-1.dev)` = chars 0..27.
+    expect(range?.to).toBe('[Bob](mention:bob@kb-1.dev)'.length);
+  });
+
+  it('returns null (falls through) when caret is INSIDE the mention', () => {
+    const doc = '[Bob](mention:bob@kb-1.dev)';
+    const state = makeState(doc);
+    // Caret inside the display name.
+    const range = mentionAtomicDeleteRange(state, 2, 'Delete');
+    expect(range).toBeNull();
+  });
+
+  it('returns null when caret is at the document end (nothing to delete)', () => {
+    const doc = 'no mention here';
+    const state = makeState(doc);
+    const range = mentionAtomicDeleteRange(state, doc.length, 'Delete');
+    expect(range).toBeNull();
+  });
+
+  it('returns the full range when a mention sits in the middle of a paragraph', () => {
+    const doc = 'pinging [Alice](mention:alice@kb-1.dev) for review';
+    const state = makeState(doc);
+    const mentionStart = doc.indexOf('[');
+    const mentionEnd = doc.indexOf(')') + 1;
+    const range = mentionAtomicDeleteRange(state, mentionStart, 'Delete');
+    expect(range).toEqual({ from: mentionStart, to: mentionEnd });
+  });
+});
+
+describe('mentionAtomicDeleteRange — adjacency edge cases', () => {
+  it('Backspace right after a mention chip in the middle of text', () => {
+    const doc = 'pre [Alice](mention:alice@kb-1.dev) post';
+    const state = makeState(doc);
+    const mentionEnd = doc.indexOf(')') + 1;
+    const range = mentionAtomicDeleteRange(state, mentionEnd, 'Backspace');
+    expect(range).not.toBeNull();
+    expect(range?.from).toBe(doc.indexOf('['));
+    expect(range?.to).toBe(mentionEnd);
+  });
+
+  it('Delete on the SPACE just after a chip does not atomic-delete', () => {
+    // Position right after the `)` is the right edge for Backspace,
+    // but the LEFT edge for Delete is the position of `[` — the space
+    // sits BETWEEN, so neither key triggers atomic delete on the chip.
+    const doc = 'pre [Alice](mention:alice@kb-1.dev) post';
+    const state = makeState(doc);
+    const mentionEnd = doc.indexOf(')') + 1;
+    // Delete at mentionEnd would delete the following space, not the
+    // chip — Delete is the LEFT-edge key, so it only fires when the
+    // caret is at the chip's `from`.
+    const range = mentionAtomicDeleteRange(state, mentionEnd, 'Delete');
+    expect(range).toBeNull();
+  });
+});

--- a/packages/editor/src/lib/plaintext-mention-keymap.ts
+++ b/packages/editor/src/lib/plaintext-mention-keymap.ts
@@ -1,0 +1,130 @@
+/**
+ * Atomic-edge delete keymap for mention chips in the plaintext editor.
+ *
+ * Backspace at the right edge of a `[Name](mention:email)` source range
+ * (caret immediately after the closing `)`) deletes the entire range
+ * in one transaction. Delete at the left edge (caret immediately before
+ * the opening `[`) does the same.
+ *
+ * Caret positions INSIDE the mention's source fall through to default
+ * per-character delete so users can fix typos in the display name —
+ * matches the rationale in `mention-keymap-plugin.ts:25-37` on the
+ * Crepe side.
+ *
+ * The keymap is additive: returning `false` from `run` lets CM6 cascade
+ * to the next handler in the keymap chain (default delete, undo, …).
+ * Both handlers return `true` only after dispatching a delete tx.
+ */
+
+import { keymap, type EditorView } from '@codemirror/view';
+import { syntaxTree } from '@codemirror/language';
+import type { SyntaxNode } from '@lezer/common';
+import type { EditorState, Extension } from '@codemirror/state';
+import { parseMentionUrl } from './markdown-core';
+import { extractLinkUrl } from './plaintext-link-affordance';
+
+/**
+ * Find the nearest enclosing `Link` node at `pos` whose URL is a
+ * `mention:<email>` scheme. Returns the Link node when one exists,
+ * `null` otherwise (caret is not inside / adjacent to a mention).
+ *
+ * `side` biases `tree.resolveInner` left or right depending on whether
+ * we're checking the right edge (Backspace, side=-1: prefer the node
+ * ending at pos) or the left edge (Delete, side=1: prefer the node
+ * starting at pos).
+ *
+ * Exported for unit testing — production callers go through the
+ * keymap's `run` handlers below.
+ */
+export function findMentionAt(
+  state: EditorState,
+  pos: number,
+  side: -1 | 1,
+): SyntaxNode | null {
+  const tree = syntaxTree(state);
+  let node: SyntaxNode | null = tree.resolveInner(pos, side);
+  while (node !== null) {
+    if (node.type.name === 'Link') {
+      // Reuse the link-affordance helper so mention detection lives in
+      // exactly one place (URL extraction with `<…>` unwrap + trim).
+      const url = extractLinkUrl(state, node);
+      if (url !== null && parseMentionUrl(url) !== null) return node;
+      return null;
+    }
+    node = node.parent;
+  }
+  return null;
+}
+
+/**
+ * Pure decision function: given a state, a caret position, and the
+ * key being pressed, return the source range to delete atomically as
+ * one transaction, or `null` to fall through to the next handler.
+ *
+ * Encapsulates the right-edge / left-edge / inside detection so the
+ * keymap and unit tests share one logic path. The keymap's `run`
+ * handlers wrap this with the actual `view.dispatch` call.
+ */
+export function mentionAtomicDeleteRange(
+  state: EditorState,
+  pos: number,
+  key: 'Backspace' | 'Delete',
+): { from: number; to: number } | null {
+  if (key === 'Backspace') {
+    if (pos === 0) return null;
+    // Right-edge case: the mention's Link node ends exactly at the
+    // caret. Caret INSIDE has node.to > pos — strict equality lets the
+    // inside case fall through to default per-char delete (typo-fix).
+    const link = findMentionAt(state, pos, -1);
+    if (link?.to !== pos) return null;
+    return { from: link.from, to: link.to };
+  }
+  // Delete: left-edge case.
+  if (pos >= state.doc.length) return null;
+  const link = findMentionAt(state, pos, 1);
+  if (link?.from !== pos) return null;
+  return { from: link.from, to: link.to };
+}
+
+/**
+ * Keymap extension wiring Backspace + Delete to atomic-edge mention
+ * deletion. Mount alongside the editor's other keymaps; CM6 cascades
+ * through keymap providers in registration order, so this should sit
+ * BEFORE `defaultKeymap` so it gets the first crack at Backspace /
+ * Delete (otherwise the default per-char delete fires first and the
+ * mention's source loses its closing `)` before our handler sees it).
+ */
+export function plaintextMentionKeymap(): Extension {
+  return keymap.of([
+    {
+      key: 'Backspace',
+      run(view: EditorView): boolean {
+        const { state } = view;
+        const sel = state.selection.main;
+        if (!sel.empty) return false;
+        const range = mentionAtomicDeleteRange(state, sel.head, 'Backspace');
+        if (range === null) return false;
+        view.dispatch({
+          changes: { from: range.from, to: range.to, insert: '' },
+          selection: { anchor: range.from },
+        });
+        return true;
+      },
+    },
+    {
+      key: 'Delete',
+      run(view: EditorView): boolean {
+        const { state } = view;
+        const sel = state.selection.main;
+        if (!sel.empty) return false;
+        const range = mentionAtomicDeleteRange(state, sel.head, 'Delete');
+        if (range === null) return false;
+        view.dispatch({
+          changes: { from: range.from, to: range.to, insert: '' },
+          selection: { anchor: range.from },
+        });
+        return true;
+      },
+    },
+  ]);
+}

--- a/packages/editor/src/lib/plaintext-mention-widget.ts
+++ b/packages/editor/src/lib/plaintext-mention-widget.ts
@@ -1,0 +1,197 @@
+/**
+ * CM6 `WidgetType` that mounts a Svelte 5 <MentionChip> in place of a
+ * `[Name](mention:email)` source range.
+ *
+ * Replaces the older CSS-only `.kb1-mention` Decoration.mark approach
+ * (see git history of `plaintext-decorations.ts` / `app.css`). Three
+ * rounds of CSS-only iteration couldn't pixel-match the canonical
+ * `<Avatar>` because the chip lived as `attr()`-rendered pseudo-elements
+ * mirroring Avatar by hand — every Avatar tweak risked drift. The widget
+ * mounts the real component, so visual parity is structural.
+ *
+ * Path α vs β: this is Path β. UserAvatar would have been ideal, but it
+ * pulls in Tanstack svelte-query's `getQueryClientContext` whose context
+ * key is a module-private Symbol — Svelte 5's `mount({ context: Map })`
+ * can't thread the existing QueryClient without re-instantiating the
+ * provider tree, which would create a stale-data subtree. So we resolve
+ * orgPeople → person at decoration-build time (already wired) and pass
+ * snapshot props (id/image/letter/accent) into the widget, then mount
+ * the low-level `<Avatar>` inside `<MentionChip>` directly. No
+ * PersonHoverCard for now (deferred — same trade-off as the old CSS chip).
+ *
+ * Lifecycle:
+ *   - `toDOM` creates the host `<span>` and calls Svelte 5 `mount(...)`
+ *     into it. Returns the host span so CM6 hangs it where the source
+ *     range used to be.
+ *   - `destroy(dom)` calls `unmount(component)` so the Svelte instance
+ *     tears its effects + DOM down cleanly. CM6 calls this when the
+ *     decoration is removed (cursor enters the range → widget skipped
+ *     in next rebuild) or when the editor unmounts.
+ *   - `eq(other)` compares the snapshot prop tuple. Re-resolution
+ *     (orgPeople loads after first paint and promotes a stale chip)
+ *     flips `accent` / `image` / `letter` / `stale`, which `eq` returns
+ *     `false` for → CM6 rebuilds the widget with fresh props.
+ *   - `mousedown` is handled directly on the host span. CM6's default
+ *     posAtCoords places the caret at the widget's right boundary
+ *     (`linkTo`) for right-side clicks, which falls outside the
+ *     `selTo < linkTo` reveal gate in plaintext-decorations and makes
+ *     the right half of the chip look unclickable. Our handler
+ *     dispatches a selection at `posAtDOM(host) + 1` (just inside `[`),
+ *     so any click on the chip reveals the source for in-place editing.
+ *     `ignoreEvent` returns `true` for `mousedown` so CM6 doesn't also
+ *     run its own caret placement; other events pass through.
+ */
+
+import { WidgetType, type EditorView } from '@codemirror/view';
+import { mount, unmount } from 'svelte';
+import type { AccentName } from './markdown-core';
+// Note: `MentionChip.svelte` is imported lazily inside `toDOM()` rather
+// than statically. The test harness for `plaintext-decorations.ts`
+// (which transitively pulls this file in) runs without the Svelte vite
+// plugin — a static import would force vitest to parse the `.svelte`
+// source and crash with "invalid JS syntax." Browser builds don't pay
+// the lazy-import cost (the chunk is cached after first paint), and
+// CM6 never calls `toDOM()` in tests so the dynamic import never runs
+// in vitest.
+
+export interface MentionChipProps {
+  /** Full email parsed out of the `mention:<email>` URL — kept for
+   *  data attribute / aria. */
+  email: string;
+  /** Display name surfaced as the chip's text label. Falls back to the
+   *  email handle when the directory has only an email, or to "Unknown"
+   *  for fully-stale chips — same fallback chain as UserAvatar. */
+  displayName: string;
+  /** Uppercased single character rendered inside the Avatar fallback. */
+  letter: string;
+  /** Resolved profile image URL when the directory entry has one; `null`
+   *  otherwise (avatar renders the letter). */
+  image: string | null;
+  /** Per-user accent — `accentForId(resolved.id)` for resolved chips,
+   *  `'slate'` for stale. Matches the user's accent across the rest of
+   *  the app (HISTORY panel, byline, file rows). */
+  accent: AccentName;
+  /** Native browser tooltip surfaced on hover — defaults to `email` to
+   *  match the old CSS chip's `data-mention-email` hover affordance.
+   *  Required (not optional) so the `<MentionChip>` `title` prop contract
+   *  is satisfied at the type level instead of through a runtime
+   *  `undefined`. */
+  title: string;
+  /** True when the email didn't resolve against the current org
+   *  directory. The chip styles itself muted + line-through. */
+  stale: boolean;
+}
+
+type MountedInstance = ReturnType<typeof mount<MentionChipProps, Record<string, unknown>>>;
+
+export class MentionChipWidget extends WidgetType {
+  readonly props: MentionChipProps;
+  // Tracked per-widget instance so `destroy` can `unmount` the same
+  // component `toDOM` mounted. CM6 holds onto the WidgetType through
+  // the decoration's lifetime; storing the instance here is safe.
+  private component: MountedInstance | null = null;
+  // Set to true between `destroy(dom)` and any race-condition late
+  // arrival of the lazy-imported module. Without this guard a late
+  // `mount(...)` callback could resurrect a Svelte instance inside a
+  // DOM node CM6 has already discarded.
+  private disposed = false;
+
+  constructor(props: MentionChipProps) {
+    super();
+    this.props = props;
+  }
+
+  /**
+   * Snapshot-equal: identical props tuple → reuse the existing DOM.
+   * `email` alone isn't enough — when `orgPeople` lands after first
+   * paint, a previously-stale chip promotes (image/letter/accent flip)
+   * and we need CM6 to rebuild. Comparing every prop field catches all
+   * resolution transitions.
+   */
+  eq(other: WidgetType): boolean {
+    if (!(other instanceof MentionChipWidget)) return false;
+    const a = this.props;
+    const b = other.props;
+    return (
+      a.email === b.email &&
+      a.displayName === b.displayName &&
+      a.letter === b.letter &&
+      a.image === b.image &&
+      a.accent === b.accent &&
+      a.title === b.title &&
+      a.stale === b.stale
+    );
+  }
+
+  toDOM(view: EditorView): HTMLElement {
+    const host = document.createElement('span');
+    host.className = 'kb1-mention-widget';
+    host.dataset.mentionEmail = this.props.email;
+    if (this.props.stale) host.dataset.mentionStale = 'true';
+    // Click-to-edit: place the caret strictly INSIDE the link source
+    // range so the per-Link cursor-reveal gate in plaintext-decorations
+    // (`selTo >= linkFrom && selTo < linkTo`) always fires regardless of
+    // where on the chip the user clicked. Without this, CM6's default
+    // posAtCoords lands the caret at `linkTo` for right-side clicks —
+    // equal to the exclusive upper bound of the reveal range — and the
+    // chip stays rendered. Left-side clicks land at `linkFrom` and
+    // happen to work, so the bug looks like "right half is unclickable."
+    //
+    // `posAtDOM(host)` returns the widget's anchor position (= linkFrom
+    // for a Decoration.replace), robust against doc edits shifting our
+    // position since toDOM ran. `+1` puts the caret just after `[`.
+    //
+    // Bound to `mousedown` not `click`: our dispatch swaps this widget
+    // out for raw markdown between mousedown and mouseup, and the
+    // browser then cancels the click event entirely.
+    host.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      const pos = view.posAtDOM(host);
+      view.dispatch({
+        selection: { anchor: pos + 1 },
+      });
+      if (!view.hasFocus) view.focus();
+    });
+    // Lazy-import the Svelte component so vitest (which loads this
+    // module without the Svelte vite plugin) never has to parse it.
+    // The dynamic import resolves in a microtask; chip renders on
+    // the next frame. Equivalent to v0 "loading" state — empty host
+    // for ~one tick — which is invisible at typical decoration rebuild
+    // cadence.
+    const propsSnapshot = this.props;
+    void import('./MentionChip.svelte').then((mod) => {
+      if (this.disposed) return;
+      // Cast through `unknown` to drop the generic Component<Props>
+      // shape — the dynamic import returns `typeof import(...)` which
+      // doesn't statically know our Props type, and `mount` won't
+      // accept the `default` export of the Svelte module without a
+      // bridge cast. The runtime shape matches Props 1:1.
+      const Component = mod.default as unknown as Parameters<
+        typeof mount<MentionChipProps, Record<string, unknown>>
+      >[0];
+      this.component = mount(Component, {
+        target: host,
+        props: propsSnapshot,
+      });
+    });
+    return host;
+  }
+
+  destroy(_dom: HTMLElement): void {
+    this.disposed = true;
+    if (this.component !== null) {
+      void unmount(this.component);
+      this.component = null;
+    }
+  }
+
+  /**
+   * Tell CM6 to ignore `mousedown` on the widget — we handle it
+   * ourselves in `toDOM` (caret placed strictly inside the link source
+   * so the cursor-reveal gate fires for clicks anywhere on the chip).
+   * Other events fall through to CM6's default handling.
+   */
+  ignoreEvent(event: Event): boolean {
+    return event.type === 'mousedown';
+  }
+}

--- a/packages/editor/src/lib/selector-url.ts
+++ b/packages/editor/src/lib/selector-url.ts
@@ -1,0 +1,20 @@
+type VaultTarget =
+  | { kind: 'vault'; vaultSlug: string }
+  | { kind: 'folder'; vaultSlug: string; path: string }
+  | { kind: 'note'; vaultSlug: string; path: string };
+
+export function parseInVaultSelector(
+  vaultSlug: string,
+  selector: string,
+): VaultTarget {
+  const trimmed = selector.replace(/^\/+|\/+$/g, '');
+  if (trimmed.length === 0) return { kind: 'vault', vaultSlug };
+
+  const segments = trimmed.split('/').map((s) => decodeURIComponent(s));
+  const path = segments.join('/');
+  const last = segments[segments.length - 1] ?? '';
+  return last.includes('.')
+    ? { kind: 'note', vaultSlug, path }
+    : { kind: 'folder', vaultSlug, path };
+}
+

--- a/packages/editor/src/lib/stories/MentionChipStory.svelte
+++ b/packages/editor/src/lib/stories/MentionChipStory.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import MentionChip from '../MentionChip.svelte';
+  import type { AccentName } from '@kb-2/ui';
+
+  interface MentionChipFixture {
+    accent: AccentName;
+    letter: string;
+    image: string | null;
+    displayName: string;
+    title: string;
+    stale: boolean;
+  }
+
+  const chips: MentionChipFixture[] = [
+    {
+      accent: 'butter',
+      letter: 'Y',
+      image: null,
+      displayName: 'Yoh',
+      title: 'yoh@example.com',
+      stale: false,
+    },
+    {
+      accent: 'slate',
+      letter: '?',
+      image: null,
+      displayName: 'Former teammate',
+      title: 'former@example.com',
+      stale: true,
+    },
+  ];
+</script>
+
+<div class="story">
+  {#each chips as chip}
+    <p>
+      Mention:
+      <MentionChip {...chip} />
+    </p>
+  {/each}
+</div>
+
+<style>
+  .story {
+    padding: 32px;
+    color: var(--rd-ink-2);
+    background: var(--rd-panel);
+    font-family: var(--rd-serif);
+    font-size: 16px;
+    line-height: 1.65;
+  }
+
+  p {
+    margin: 0 0 14px;
+  }
+</style>

--- a/packages/editor/src/lib/stories/PlaintextEditorStory.svelte
+++ b/packages/editor/src/lib/stories/PlaintextEditorStory.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { PlaintextEditor } from '@kb-2/editor';
+  import * as Y from 'yjs';
+
+  const doc = new Y.Doc();
+  const text = doc.getText('markdown');
+  text.insert(
+    0,
+    [
+      '# KB-2 Editor Fixture',
+      '',
+      'This **Markdown** editor renders _live preview_ decorations while preserving source editing.',
+      '',
+      '- [ ] Clickable task',
+      '- [x] Completed task',
+      '  - Nested item',
+      '',
+      '> Local-first content is the product boundary.',
+      '',
+      '| Feature | State |',
+      '| --- | --- |',
+      '| Yjs | synced |',
+      '| Markdown | live preview |',
+      '',
+      '```ts',
+      'const localFirst = true;',
+      '```',
+      '',
+      'Mention chip: [Yoh](mention:yoh@example.com)',
+      '',
+      'Wikilink: [[hello-world]]',
+      '',
+    ].join('\n'),
+  );
+
+  const livePaths = [{ path: 'demo-vault/hello-world.md', noteId: 'demo-document' }];
+  const orgPeople = [
+    {
+      id: 'demo-yoh',
+      email: 'yoh@example.com',
+      name: 'Yoh',
+      image: null,
+    },
+  ];
+</script>
+
+<div class="story">
+  <PlaintextEditor ydoc={doc} ytext={text} {livePaths} {orgPeople} />
+</div>
+
+<style>
+  .story {
+    height: 720px;
+    max-width: 760px;
+    margin: 0 auto;
+    border-left: 1px solid var(--rd-rule);
+    border-right: 1px solid var(--rd-rule);
+    background: var(--rd-panel);
+  }
+</style>
+

--- a/packages/editor/svelte.config.js
+++ b/packages/editor/svelte.config.js
@@ -1,0 +1,6 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess()
+};
+

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -1,15 +1,20 @@
 {
-  "extends": "./.svelte-kit/tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "moduleResolution": "bundler",
     "types": ["svelte", "vitest/globals"]
-  }
+  },
+  "include": [
+    "svelte.config.js",
+    "src/**/*.svelte",
+    "src/**/*.ts"
+  ]
 }
+

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -1,0 +1,19 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [svelte()],
+  build: {
+    lib: {
+      entry: 'src/lib/index.ts',
+      formats: ['es']
+    },
+    rollupOptions: {
+      external: ['svelte', 'yjs', '@kb-2/ui']
+    }
+  },
+  test: {
+    environment: 'node',
+    globals: true
+  }
+});

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -2,7 +2,10 @@ import type { StorybookConfig } from '@storybook/sveltekit';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 const config: StorybookConfig = {
-  stories: ['../src/lib/**/*.stories.@(js|ts|svelte)'],
+  stories: [
+    '../src/lib/**/*.stories.@(js|ts|svelte)',
+    '../../editor/src/lib/**/*.stories.@(js|ts|svelte)'
+  ],
   addons: ['@storybook/addon-docs', '@storybook/addon-svelte-csf', 'storybook/viewport'],
   framework: {
     name: '@storybook/sveltekit',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,12 +108,30 @@ importers:
 
   apps/web:
     dependencies:
+      '@fontsource-variable/geist':
+        specifier: ^5.2.8
+        version: 5.2.9
+      '@fontsource/source-serif-4':
+        specifier: 5.2.9
+        version: 5.2.9
+      '@kb-2/editor':
+        specifier: workspace:*
+        version: link:../../packages/editor
       '@kb-2/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      lib0:
+        specifier: 0.2.117
+        version: 0.2.117
       svelte:
         specifier: 'catalog:'
         version: 5.55.5
+      y-protocols:
+        specifier: 1.0.7
+        version: 1.0.7(yjs@13.6.31)
+      yjs:
+        specifier: 13.6.31
+        version: 13.6.31
     devDependencies:
       '@sveltejs/adapter-static':
         specifier: 'catalog:'
@@ -127,6 +145,9 @@ importers:
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.1.18(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@types/ws':
+        specifier: 8.18.1
+        version: 8.18.1
       svelte-check:
         specifier: 'catalog:'
         version: 4.4.4(picomatch@4.0.4)(svelte@5.55.5)(typescript@6.0.3)
@@ -139,6 +160,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+      ws:
+        specifier: 8.21.0
+        version: 8.21.0
 
   packages/doc-session:
     dependencies:
@@ -161,6 +185,76 @@ importers:
       ws:
         specifier: 8.21.0
         version: 8.21.0
+
+  packages/editor:
+    dependencies:
+      '@codemirror/commands':
+        specifier: 6.10.3
+        version: 6.10.3
+      '@codemirror/lang-css':
+        specifier: 6.3.1
+        version: 6.3.1
+      '@codemirror/lang-html':
+        specifier: 6.4.11
+        version: 6.4.11
+      '@codemirror/lang-javascript':
+        specifier: 6.2.5
+        version: 6.2.5
+      '@codemirror/lang-json':
+        specifier: 6.0.2
+        version: 6.0.2
+      '@codemirror/lang-markdown':
+        specifier: 6.5.0
+        version: 6.5.0
+      '@codemirror/lang-python':
+        specifier: 6.2.1
+        version: 6.2.1
+      '@codemirror/language':
+        specifier: 6.11.3
+        version: 6.11.3
+      '@codemirror/state':
+        specifier: 6.6.0
+        version: 6.6.0
+      '@codemirror/view':
+        specifier: 6.41.1
+        version: 6.41.1
+      '@kb-2/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@lezer/common':
+        specifier: 1.5.2
+        version: 1.5.2
+      '@lezer/highlight':
+        specifier: 1.2.3
+        version: 1.2.3
+      '@lezer/markdown':
+        specifier: 1.6.3
+        version: 1.6.3
+      svelte:
+        specifier: 'catalog:'
+        version: 5.55.5
+      yjs:
+        specifier: 13.6.31
+        version: 13.6.31
+    devDependencies:
+      '@storybook/svelte':
+        specifier: 'catalog:'
+        version: 10.2.13(storybook@10.2.13(@testing-library/dom@10.4.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(svelte@5.55.5)
+      '@sveltejs/vite-plugin-svelte':
+        specifier: 'catalog:'
+        version: 6.2.4(svelte@5.55.5)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+      svelte-check:
+        specifier: 'catalog:'
+        version: 4.4.4(picomatch@4.0.4)(svelte@5.55.5)(typescript@6.0.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@25.9.2)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/ui:
     dependencies:
@@ -233,6 +327,45 @@ packages:
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
+
+  '@codemirror/autocomplete@6.20.3':
+    resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
+
+  '@codemirror/lang-python@6.2.1':
+    resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
+
+  '@codemirror/language@6.11.3':
+    resolution: {integrity: sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==}
+
+  '@codemirror/lint@6.9.7':
+    resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/view@6.41.1':
+    resolution: {integrity: sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==}
+
+  '@codemirror/view@6.43.1':
+    resolution: {integrity: sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -564,6 +697,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fontsource-variable/geist@5.2.9':
+    resolution: {integrity: sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==}
+
+  '@fontsource/source-serif-4@5.2.9':
+    resolution: {integrity: sha512-er/Pym9emsEVJNf947umJ4kXarXfsiN6CN7kTYinefKRaHLwiquiiHOZvKvxWgkV8JMCf3pV3g0NcsPFpVCH9w==}
+
   '@hono/node-server@2.0.4':
     resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
     engines: {node: '>=20'}
@@ -589,6 +728,36 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@lezer/markdown@1.6.3':
+    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
+
+  '@lezer/python@1.1.19':
+    resolution: {integrity: sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@mdx-js/react@3.1.1':
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
@@ -1347,6 +1516,9 @@ packages:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -2089,6 +2261,9 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2346,6 +2521,9 @@ packages:
       jsdom:
         optional: true
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -2426,6 +2604,106 @@ snapshots:
   '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/runtime@7.29.7': {}
+
+  '@codemirror/autocomplete@6.20.3':
+    dependencies:
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.11.3
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.11.3
+      '@lezer/json': 1.0.3
+
+  '@codemirror/lang-markdown@6.5.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.6.3
+
+  '@codemirror/lang-python@6.2.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.11.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/python': 1.1.19
+
+  '@codemirror/language@6.11.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.7':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.1
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.41.1':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
+  '@codemirror/view@6.43.1':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -2612,6 +2890,10 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@fontsource-variable/geist@5.2.9': {}
+
+  '@fontsource/source-serif-4@5.2.9': {}
+
   '@hono/node-server@2.0.4(hono@4.12.25)':
     dependencies:
       hono: 4.12.25
@@ -2636,6 +2918,53 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.6.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+
+  '@lezer/python@1.1.19':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
@@ -3294,6 +3623,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@0.6.0: {}
+
+  crelt@1.0.6: {}
 
   css.escape@1.5.1: {}
 
@@ -4085,6 +4416,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  style-mod@4.1.3: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -4297,6 +4630,8 @@ snapshots:
       '@types/node': 25.9.2
     transitivePeerDependencies:
       - msw
+
+  w3c-keyname@2.2.8: {}
 
   wcwidth@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
         specifier: 13.6.31
         version: 13.6.31
     devDependencies:
+      '@kb-2/doc-session':
+        specifier: workspace:*
+        version: link:../../packages/doc-session
       '@sveltejs/adapter-static':
         specifier: 'catalog:'
         version: 3.0.10(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.55.5)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)))

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,9 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "paths": {
-      "@kb-2/doc-session": ["./packages/doc-session/src/index.ts"]
+      "@kb-2/doc-session": ["./packages/doc-session/src/index.ts"],
+      "@kb-2/editor": ["./packages/editor/src/lib/index.ts"],
+      "@kb-2/ui": ["./packages/ui/src/lib/index.ts"]
     },
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- Adds `@kb-2/editor`, a KB-1 CodeMirror 6 plaintext editor transplant bound to a host-supplied `Y.Doc`/`Y.Text`.
- Adds the app-side demo Yjs websocket provider for `/api/demo-document/yjs` and mounts the editor on `/`, with the old status shell moved behind `/status`.
- Ports the KB-1 editor extension tests and adds a web provider convergence/persistence test plus a Storybook fixture.

## Verification
- `pnpm check`
- `pnpm --filter @kb-2/editor test`
- Invariant greps: no `fetch`, `WebSocket`, `EventSource`, `/api/`, `y-protocols`, `awareness`, or `presence` matches under `packages/editor`.
- Browser manual flow with temp `KB2_HOME`: typed real content, observed live H2/bold/code decorations, clicked a task checkbox through to disk, hid/revealed Markdown syntax on focus, verified table/image/mention/wikilink/code-fence decorations, edited concurrently in two Chrome tabs and observed convergence, restarted the daemon and observed persisted content reload.
- Storybook browser check: `app-editor-plaintexteditor--fixture` mounted a static Y.Doc fixture with editor, H1, bold/italic, task checkboxes, blockquote, table, code fence, mention chip, and wikilink decorations.
