### PR TITLE
KB-2 Chunk 006: Direct-Write Detection and Loud Saving

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource/source-serif-4": "5.2.9",
+    "@kb-2/doc-session": "workspace:*",
     "@kb-2/editor": "workspace:*",
     "@kb-2/ui": "workspace:*",
     "lib0": "0.2.117",
@@ -20,7 +21,6 @@
     "yjs": "13.6.31"
   },
   "devDependencies": {
-    "@kb-2/doc-session": "workspace:*",
     "@sveltejs/adapter-static": "catalog:",
     "@sveltejs/kit": "catalog:",
     "@sveltejs/vite-plugin-svelte": "catalog:",

--- a/apps/web/src/lib/yjs/demo-document-provider.test.ts
+++ b/apps/web/src/lib/yjs/demo-document-provider.test.ts
@@ -11,7 +11,12 @@ import * as syncProtocol from 'y-protocols/sync';
 import * as Y from 'yjs';
 import { afterEach, beforeEach, describe, it } from 'vitest';
 
-import { bindYjsWebSocket, OneFileDocumentSession } from '@kb-2/doc-session';
+import {
+  bindYjsWebSocket,
+  OneFileDocumentSession,
+  encodeSessionEvent,
+  type DocumentSessionEvent,
+} from '@kb-2/doc-session';
 import {
   createDemoDocumentProvider,
   DEMO_DOCUMENT_TEXT_NAME,
@@ -94,6 +99,40 @@ describe('demo document provider', () => {
     );
 
     raw.close();
+    provider.destroy();
+  });
+
+  it('surfaces document session events from the shared WebSocket', async () => {
+    const events: DocumentSessionEvent[] = [];
+
+    server = createServer();
+    webSocketServer = new WebSocketServer({ noServer: true });
+    server.on('upgrade', (request, socket, head) => {
+      if (request.url !== DEMO_DOCUMENT_YJS_PATH) {
+        socket.destroy();
+        return;
+      }
+
+      webSocketServer!.handleUpgrade(request, socket, head, (webSocket) => {
+        webSocket.send(encodeSessionEvent({
+          kind: 'persist-failure',
+          path: join(kb2Home, 'demo-vault', 'hello-world.md'),
+          ts: 123,
+        }));
+      });
+    });
+    await listen(server);
+    const port = (server.address() as AddressInfo).port;
+
+    const provider = createDemoDocumentProvider({
+      url: `ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`,
+      onSessionEvent: (event) => events.push(event),
+    });
+
+    await waitUntil(() => events.some((event) => event.kind === 'persist-failure'), () =>
+      `Timed out waiting for provider session event: ${JSON.stringify(events)}`
+    );
+
     provider.destroy();
   });
 });

--- a/apps/web/src/lib/yjs/demo-document-provider.ts
+++ b/apps/web/src/lib/yjs/demo-document-provider.ts
@@ -2,11 +2,15 @@ import * as decoding from 'lib0/decoding';
 import * as encoding from 'lib0/encoding';
 import * as syncProtocol from 'y-protocols/sync';
 import * as Y from 'yjs';
+import {
+  MESSAGE_SESSION_EVENT,
+  MESSAGE_SYNC,
+  decodeSessionEvent,
+  type DocumentSessionEvent,
+} from '@kb-2/doc-session/protocol';
 
 export const DEMO_DOCUMENT_YJS_PATH = '/api/demo-document/yjs';
 export const DEMO_DOCUMENT_TEXT_NAME = 'markdown';
-
-const messageSync = 0;
 
 export type DemoDocumentProviderStatus =
   | 'connecting'
@@ -24,6 +28,7 @@ export interface DemoDocumentProviderOptions {
   url?: string;
   onStatus?: (status: DemoDocumentProviderStatus) => void;
   onError?: (error: unknown) => void;
+  onSessionEvent?: (event: DocumentSessionEvent) => void;
 }
 
 export function createDemoDocumentProvider(
@@ -40,7 +45,7 @@ export function createDemoDocumentProvider(
   const sendSync = (write: (encoder: encoding.Encoder) => void): void => {
     if (socket.readyState !== WebSocket.OPEN) return;
     const encoder = encoding.createEncoder();
-    encoding.writeVarUint(encoder, messageSync);
+    encoding.writeVarUint(encoder, MESSAGE_SYNC);
     write(encoder);
     socket.send(encoding.toUint8Array(encoder));
   };
@@ -69,9 +74,17 @@ export function createDemoDocumentProvider(
       const decoder = decoding.createDecoder(message);
       const encoder = encoding.createEncoder();
       const messageType = decoding.readVarUint(decoder);
-      if (messageType !== messageSync) return;
+      if (messageType === MESSAGE_SESSION_EVENT) {
+        const event = decodeSessionEvent(decoder);
+        if (event) {
+          options.onSessionEvent?.(event);
+        }
+        return;
+      }
 
-      encoding.writeVarUint(encoder, messageSync);
+      if (messageType !== MESSAGE_SYNC) return;
+
+      encoding.writeVarUint(encoder, MESSAGE_SYNC);
       syncProtocol.readSyncMessage(decoder, encoder, doc, socket);
       if (encoding.length(encoder) > 1) {
         socket.send(encoding.toUint8Array(encoder));

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -5,12 +5,17 @@
     DemoDocumentProviderStatus,
   } from '$lib/yjs/demo-document-provider';
   import { PlaintextEditor, type LivePath, type OrgPerson } from '@kb-2/editor';
-  import { LiveStatusChip } from '@kb-2/ui';
+  import { DocumentSaveBanner, LiveStatusChip } from '@kb-2/ui';
+  import type { DocumentSessionEvent } from '@kb-2/doc-session/protocol';
   import { onMount } from 'svelte';
 
   let provider = $state<DemoDocumentProvider | null>(null);
   let status = $state<DemoDocumentProviderStatus>('connecting');
   let error = $state<string | null>(null);
+  let externalChangeVisible = $state(false);
+  let persistFailureActive = $state(false);
+  let persistRecoveredVisible = $state(false);
+  let recoveryTimer: ReturnType<typeof setTimeout> | undefined;
 
   const livePaths: LivePath[] = [
     { path: 'demo-vault/hello-world.md', noteId: 'demo-document' },
@@ -35,6 +40,33 @@
           : 'Daemon · closed',
   );
 
+  function handleSessionEvent(event: DocumentSessionEvent): void {
+    if (event.kind === 'external-change') {
+      externalChangeVisible = true;
+      return;
+    }
+
+    if (event.kind === 'persist-failure') {
+      persistFailureActive = true;
+      persistRecoveredVisible = false;
+      if (recoveryTimer) {
+        clearTimeout(recoveryTimer);
+        recoveryTimer = undefined;
+      }
+      return;
+    }
+
+    persistFailureActive = false;
+    persistRecoveredVisible = true;
+    if (recoveryTimer) {
+      clearTimeout(recoveryTimer);
+    }
+    recoveryTimer = setTimeout(() => {
+      persistRecoveredVisible = false;
+      recoveryTimer = undefined;
+    }, 3500);
+  }
+
   onMount(() => {
     const nextProvider = createDemoDocumentProvider({
       onStatus: (nextStatus) => {
@@ -43,10 +75,15 @@
       onError: (caught) => {
         error = caught instanceof Error ? caught.message : String(caught);
       },
+      onSessionEvent: handleSessionEvent,
     });
     provider = nextProvider;
 
     return () => {
+      if (recoveryTimer) {
+        clearTimeout(recoveryTimer);
+        recoveryTimer = undefined;
+      }
       nextProvider.destroy();
       provider = null;
     };
@@ -67,6 +104,35 @@
       <LiveStatusChip label={statusLabel} />
     </a>
   </header>
+
+  {#if externalChangeVisible || persistFailureActive || persistRecoveredVisible}
+    <section class="banner-strip" aria-label="Document save notifications">
+      {#if externalChangeVisible}
+        <DocumentSaveBanner
+          variant="external-change"
+          title="File changed outside KB-2"
+          message="This file changed outside KB-2 and was reloaded from disk."
+          ondismiss={() => {
+            externalChangeVisible = false;
+          }}
+        />
+      {/if}
+
+      {#if persistFailureActive}
+        <DocumentSaveBanner
+          variant="persist-failure"
+          title="Changes are NOT saving to disk."
+          message="Keep this tab open. KB-2 will keep retrying until saving recovers."
+        />
+      {:else if persistRecoveredVisible}
+        <DocumentSaveBanner
+          variant="persist-recovered"
+          title="Saving restored"
+          message="KB-2 is saving changes to disk again."
+        />
+      {/if}
+    </section>
+  {/if}
 
   <section class="document-shell" aria-label="Demo Markdown document">
     {#if provider}
@@ -91,7 +157,7 @@
   .editor-page {
     min-height: 100vh;
     display: grid;
-    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-rows: auto auto minmax(0, 1fr);
     background: var(--rd-bg);
     color: var(--rd-ink-2);
     font-family: var(--rd-ui);
@@ -142,6 +208,18 @@
     overflow: hidden;
   }
 
+  .banner-strip {
+    display: grid;
+    gap: 8px;
+    padding: 12px 22px 0;
+    background: var(--rd-bg);
+  }
+
+  .banner-strip :global(.document-save-banner) {
+    width: min(100%, 760px);
+    justify-self: center;
+  }
+
   .document-shell :global(.kb2-editor-shell),
   .loading {
     grid-column: 2;
@@ -189,6 +267,10 @@
     .document-shell {
       grid-template-columns: 12px minmax(0, 1fr) 12px;
       padding-top: 12px;
+    }
+
+    .banner-strip {
+      padding: 10px 12px 0;
     }
   }
 </style>

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -7,9 +7,7 @@ const config = {
   kit: {
     alias: {
       '@kb-2/doc-session/protocol': fileURLToPath(new URL('../../packages/doc-session/src/protocol.ts', import.meta.url)),
-      '@kb-2/doc-session': fileURLToPath(new URL('../../packages/doc-session/src/index.ts', import.meta.url)),
-      '@kb-2/editor': fileURLToPath(new URL('../../packages/editor/src/lib/index.ts', import.meta.url)),
-      '@kb-2/ui': fileURLToPath(new URL('../../packages/ui/src/lib/index.ts', import.meta.url))
+      '@kb-2/doc-session': fileURLToPath(new URL('../../packages/doc-session/src/index.ts', import.meta.url))
     },
     adapter: adapter({
       fallback: 'index.html'

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -1,9 +1,16 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { fileURLToPath } from 'node:url';
 
 const config = {
   preprocess: vitePreprocess(),
   kit: {
+    alias: {
+      '@kb-2/doc-session/protocol': fileURLToPath(new URL('../../packages/doc-session/src/protocol.ts', import.meta.url)),
+      '@kb-2/doc-session': fileURLToPath(new URL('../../packages/doc-session/src/index.ts', import.meta.url)),
+      '@kb-2/editor': fileURLToPath(new URL('../../packages/editor/src/lib/index.ts', import.meta.url)),
+      '@kb-2/ui': fileURLToPath(new URL('../../packages/ui/src/lib/index.ts', import.meta.url))
+    },
     adapter: adapter({
       fallback: 'index.html'
     })

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,11 +1,24 @@
 import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
+import { fileURLToPath } from 'node:url';
 
 const webPort = Number(process.env.KB2_WEB_PORT ?? '5173');
 
 export default defineConfig({
   plugins: [tailwindcss(), sveltekit()],
+  resolve: {
+    alias: [
+      {
+        find: /^@kb-2\/doc-session\/protocol$/,
+        replacement: fileURLToPath(new URL('../../packages/doc-session/src/protocol.ts', import.meta.url))
+      },
+      {
+        find: /^@kb-2\/doc-session$/,
+        replacement: fileURLToPath(new URL('../../packages/doc-session/src/index.ts', import.meta.url))
+      }
+    ]
+  },
   server: {
     host: '127.0.0.1',
     port: webPort,

--- a/packages/doc-session/package.json
+++ b/packages/doc-session/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./protocol": {
+      "types": "./dist/protocol.d.ts",
+      "import": "./dist/protocol.js"
     }
   },
   "files": [

--- a/packages/doc-session/src/index.ts
+++ b/packages/doc-session/src/index.ts
@@ -1,6 +1,7 @@
 export {
   DEFAULT_DEMO_DOCUMENT_CONTENT,
   OneFileDocumentSession,
+  type DocumentSessionEventHandler,
   type DocumentSessionWarning,
   type OneFileDocumentSessionOptions
 } from './session.js';
@@ -9,3 +10,11 @@ export {
   bindYjsWebSocket,
   type YjsWebSocketLike
 } from './websocket.js';
+export {
+  MESSAGE_SESSION_EVENT,
+  MESSAGE_SYNC,
+  decodeSessionEvent,
+  encodeSessionEvent,
+  type DocumentSessionEvent,
+  type DocumentSessionEventKind
+} from './protocol.js';

--- a/packages/doc-session/src/protocol.ts
+++ b/packages/doc-session/src/protocol.ts
@@ -1,0 +1,49 @@
+import * as decoding from 'lib0/decoding';
+import * as encoding from 'lib0/encoding';
+
+export const MESSAGE_SYNC = 0;
+export const MESSAGE_SESSION_EVENT = 1;
+
+export type DocumentSessionEventKind =
+  | 'external-change'
+  | 'persist-failure'
+  | 'persist-recovered';
+
+export interface DocumentSessionEvent {
+  kind: DocumentSessionEventKind;
+  path: string;
+  ts: number;
+}
+
+export function encodeSessionEvent(event: DocumentSessionEvent): Uint8Array {
+  const encoder = encoding.createEncoder();
+  encoding.writeVarUint(encoder, MESSAGE_SESSION_EVENT);
+  encoding.writeVarString(encoder, JSON.stringify(event));
+  return encoding.toUint8Array(encoder);
+}
+
+export function decodeSessionEvent(
+  decoder: decoding.Decoder,
+): DocumentSessionEvent | undefined {
+  const parsed = JSON.parse(decoding.readVarString(decoder)) as Partial<DocumentSessionEvent>;
+
+  if (
+    !isSessionEventKind(parsed.kind) ||
+    typeof parsed.path !== 'string' ||
+    typeof parsed.ts !== 'number'
+  ) {
+    return undefined;
+  }
+
+  return {
+    kind: parsed.kind,
+    path: parsed.path,
+    ts: parsed.ts,
+  };
+}
+
+function isSessionEventKind(kind: unknown): kind is DocumentSessionEventKind {
+  return kind === 'external-change' ||
+    kind === 'persist-failure' ||
+    kind === 'persist-recovered';
+}

--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -1,10 +1,14 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import * as Y from 'yjs';
 
-import { OneFileDocumentSession, type DocumentSessionWarning } from './session.js';
+import {
+  OneFileDocumentSession,
+  type DocumentSessionEvent,
+  type DocumentSessionWarning
+} from './index.js';
 
 describe('OneFileDocumentSession', () => {
   let kb2Home: string;
@@ -65,7 +69,94 @@ describe('OneFileDocumentSession', () => {
     await secondSession.close();
   });
 
-  it('warns on direct filesystem changes and preserves the active session state', async () => {
+  it('reconciles direct filesystem changes into the active session', async () => {
+    const events: DocumentSessionEvent[] = [];
+    await writeFileWithParents(filePath, 'active\n');
+    const session = new OneFileDocumentSession(filePath, {
+      watchDebounceMs: 10,
+      watchPollMs: 50
+    });
+    session.onEvent((event) => events.push(event));
+    await session.open();
+
+    await writeFile(filePath, 'external edit\n', 'utf8');
+
+    await waitUntil(async () => await session.getContent() === 'external edit\n', () =>
+      `Timed out waiting for external reconcile; content=${session.ydoc.getText('markdown').toString()}`
+    );
+
+    expect(events.filter((event) => event.kind === 'external-change')).toHaveLength(1);
+    await session.close();
+  });
+
+  it('does not report its own materializations as external changes', async () => {
+    const events: DocumentSessionEvent[] = [];
+    const session = new OneFileDocumentSession(filePath, {
+      defaultContent: '',
+      watchDebounceMs: 10,
+      watchPollMs: 50
+    });
+    session.onEvent((event) => events.push(event));
+    await session.open();
+
+    session.ydoc.getText('markdown').insert(0, 'own write\n');
+    await session.flush();
+    await new Promise((resolve) => setTimeout(resolve, 120));
+
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('own write\n');
+    expect(events.filter((event) => event.kind === 'external-change')).toHaveLength(0);
+    await session.close();
+  });
+
+  it('coalesces rapid external writes into one reconciliation event', async () => {
+    const events: DocumentSessionEvent[] = [];
+    await writeFileWithParents(filePath, 'start\n');
+    const session = new OneFileDocumentSession(filePath, {
+      watchDebounceMs: 50,
+      watchPollMs: 10_000
+    });
+    session.onEvent((event) => events.push(event));
+    await session.open();
+
+    await writeFile(filePath, 'external 1\n', 'utf8');
+    await writeFile(filePath, 'external 2\n', 'utf8');
+    await writeFile(filePath, 'external final\n', 'utf8');
+
+    await waitUntil(async () => await session.getContent() === 'external final\n', () =>
+      `Timed out waiting for coalesced reconcile; content=${session.ydoc.getText('markdown').toString()}`
+    );
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    expect(events.filter((event) => event.kind === 'external-change')).toHaveLength(1);
+    await session.close();
+  });
+
+  it('broadcasts persistence failure and recovery events while keeping the session alive', async () => {
+    const events: DocumentSessionEvent[] = [];
+    const session = new OneFileDocumentSession(filePath, { defaultContent: '' });
+    session.onEvent((event) => events.push(event));
+    await session.open();
+
+    const vaultDir = dirname(filePath);
+    await chmod(vaultDir, 0o500);
+    session.ydoc.getText('markdown').insert(0, 'unsaved while readonly\n');
+
+    await waitUntil(() => events.some((event) => event.kind === 'persist-failure'), () =>
+      `Timed out waiting for persist-failure; events=${JSON.stringify(events)}`
+    );
+
+    await chmod(vaultDir, 0o700);
+    session.ydoc.getText('markdown').insert(session.ydoc.getText('markdown').length, 'saved after recovery\n');
+
+    await waitUntil(() => events.some((event) => event.kind === 'persist-recovered'), () =>
+      `Timed out waiting for persist-recovered; events=${JSON.stringify(events)}`
+    );
+
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('unsaved while readonly\nsaved after recovery\n');
+    await session.close();
+  });
+
+  it('reconciles direct filesystem changes before materializing a racing session edit', async () => {
     const warnings: DocumentSessionWarning[] = [];
     const session = new OneFileDocumentSession(filePath, {
       defaultContent: 'active\n',
@@ -76,7 +167,8 @@ describe('OneFileDocumentSession', () => {
     await writeFile(filePath, 'external stale edit\n', 'utf8');
     await session.reset('active wins\n');
 
-    await expect(readFile(filePath, 'utf8')).resolves.toBe('active wins\n');
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('external stale edit\n');
+    await expect(session.getContent()).resolves.toBe('external stale edit\n');
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatchObject({
       type: 'external-change-detected',
@@ -89,4 +181,16 @@ describe('OneFileDocumentSession', () => {
 async function writeFileWithParents(pathname: string, content: string): Promise<void> {
   await mkdir(dirname(pathname), { recursive: true });
   await writeFile(pathname, content, 'utf8');
+}
+
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  errorMessage: () => string,
+): Promise<void> {
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(errorMessage());
 }

--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -108,6 +108,24 @@ describe('OneFileDocumentSession', () => {
     await session.close();
   });
 
+  it('does not emit an external-change event when disk and session content already match', async () => {
+    const events: DocumentSessionEvent[] = [];
+    await writeFileWithParents(filePath, 'same content\n');
+    const session = new OneFileDocumentSession(filePath, {
+      watchDebounceMs: 10,
+      watchPollMs: 50
+    });
+    session.onEvent((event) => events.push(event));
+    await session.open();
+
+    await writeFile(filePath, 'same content\n', 'utf8');
+    await new Promise((resolve) => setTimeout(resolve, 120));
+
+    expect(events.filter((event) => event.kind === 'external-change')).toHaveLength(0);
+    await expect(session.getContent()).resolves.toBe('same content\n');
+    await session.close();
+  });
+
   it('coalesces rapid external writes into one reconciliation event', async () => {
     const events: DocumentSessionEvent[] = [];
     await writeFileWithParents(filePath, 'start\n');

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -48,9 +48,11 @@ export class OneFileDocumentSession {
   private opened = false;
   private openPromise: Promise<void> | undefined;
   private lastWrittenHash: string | undefined;
+  private pendingWriteHash: string | undefined;
   private persistRequested = false;
   private persistPromise: Promise<void> | undefined;
   private persistFailed = false;
+  private activePersistFailureEvent: DocumentSessionEvent | undefined;
   private watcher: FSWatcher | undefined;
   private watchDebounceTimer: NodeJS.Timeout | undefined;
   private watchPollTimer: NodeJS.Timeout | undefined;
@@ -103,6 +105,10 @@ export class OneFileDocumentSession {
     return () => {
       this.eventHandlers.delete(handler);
     };
+  }
+
+  getActivePersistFailureEvent(): DocumentSessionEvent | undefined {
+    return this.activePersistFailureEvent;
   }
 
   async reset(content = this.defaultContent): Promise<string> {
@@ -178,9 +184,17 @@ export class OneFileDocumentSession {
       return;
     }
 
-    await atomicWriteFile(this.filePath, content);
-    this.lastWrittenHash = hashContent(content);
-    this.markPersistRecovered();
+    const contentHash = hashContent(content);
+    this.pendingWriteHash = contentHash;
+    try {
+      await atomicWriteFile(this.filePath, content);
+      this.lastWrittenHash = contentHash;
+      this.markPersistRecovered();
+    } finally {
+      if (this.pendingWriteHash === contentHash) {
+        this.pendingWriteHash = undefined;
+      }
+    }
   }
 
   private async readOrCreateFile(): Promise<string> {
@@ -278,7 +292,7 @@ export class OneFileDocumentSession {
     const diskContent = await readOptionalFile(this.filePath);
     const diskHash = diskContent === undefined ? hashContent('') : hashContent(diskContent);
 
-    if (diskHash === this.lastWrittenHash) {
+    if (diskHash === this.lastWrittenHash || diskHash === this.pendingWriteHash) {
       return;
     }
 
@@ -287,17 +301,21 @@ export class OneFileDocumentSession {
 
   private async reconcileExternalContent(content: string, contentHash: string): Promise<void> {
     const current = this.currentContent();
-    if (current !== content) {
-      applyMinimalTextSplice(this.text, current, content, this.doc);
+    if (current === content) {
+      this.lastWrittenHash = contentHash;
+      return;
     }
 
+    applyMinimalTextSplice(this.text, current, content, this.doc);
     this.lastWrittenHash = contentHash;
     this.emitEvent('external-change');
   }
 
   private markPersistFailed(error: unknown): void {
     this.persistFailed = true;
-    this.emitEvent('persist-failure');
+    const event = this.createEvent('persist-failure');
+    this.activePersistFailureEvent = event;
+    this.emitEvent(event);
     console.warn(`KB-2 failed to persist document update for ${this.filePath}; keeping active Yjs session open.`, error);
   }
 
@@ -307,15 +325,22 @@ export class OneFileDocumentSession {
     }
 
     this.persistFailed = false;
+    this.activePersistFailureEvent = undefined;
     this.emitEvent('persist-recovered');
   }
 
-  private emitEvent(kind: DocumentSessionEvent['kind']): void {
-    const event = {
+  private createEvent(kind: DocumentSessionEvent['kind']): DocumentSessionEvent {
+    return {
       kind,
       path: this.filePath,
       ts: Date.now()
-    } satisfies DocumentSessionEvent;
+    };
+  }
+
+  private emitEvent(eventOrKind: DocumentSessionEvent | DocumentSessionEvent['kind']): void {
+    const event = typeof eventOrKind === 'string'
+      ? this.createEvent(eventOrKind)
+      : eventOrKind;
 
     for (const handler of this.eventHandlers) {
       try {

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -1,8 +1,11 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { watch, type FSWatcher } from 'node:fs';
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 import * as Y from 'yjs';
+
+import type { DocumentSessionEvent } from './protocol.js';
 
 export const DEFAULT_DEMO_DOCUMENT_CONTENT = [
   '# Hello KB-2',
@@ -12,6 +15,9 @@ export const DEFAULT_DEMO_DOCUMENT_CONTENT = [
 ].join('\n');
 
 const Y_TEXT_NAME = 'markdown';
+const EXTERNAL_CHANGE_ORIGIN = Symbol('kb2.external-change');
+const WATCH_DEBOUNCE_MS = 150;
+const WATCH_POLL_MS = 2000;
 
 export interface DocumentSessionWarning {
   type: 'external-change-detected';
@@ -23,26 +29,40 @@ export interface DocumentSessionWarning {
 export interface OneFileDocumentSessionOptions {
   defaultContent?: string;
   warn?: (warning: DocumentSessionWarning) => void;
+  watchDebounceMs?: number;
+  watchPollMs?: number;
 }
+
+export type DocumentSessionEventHandler = (event: DocumentSessionEvent) => void;
 
 export class OneFileDocumentSession {
   readonly filePath: string;
 
   private readonly defaultContent: string;
   private readonly warn: (warning: DocumentSessionWarning) => void;
+  private readonly watchDebounceMs: number;
+  private readonly watchPollMs: number;
   private readonly doc = new Y.Doc();
   private readonly text = this.doc.getText(Y_TEXT_NAME);
+  private readonly eventHandlers = new Set<DocumentSessionEventHandler>();
   private opened = false;
   private openPromise: Promise<void> | undefined;
   private lastWrittenHash: string | undefined;
   private persistRequested = false;
   private persistPromise: Promise<void> | undefined;
+  private persistFailed = false;
+  private watcher: FSWatcher | undefined;
+  private watchDebounceTimer: NodeJS.Timeout | undefined;
+  private watchPollTimer: NodeJS.Timeout | undefined;
+  private externalCheckPromise: Promise<void> | undefined;
 
   constructor(filePath: string, options: OneFileDocumentSessionOptions = {}) {
     this.filePath = filePath;
     this.defaultContent = options.defaultContent ?? DEFAULT_DEMO_DOCUMENT_CONTENT;
+    this.watchDebounceMs = options.watchDebounceMs ?? WATCH_DEBOUNCE_MS;
+    this.watchPollMs = options.watchPollMs ?? WATCH_POLL_MS;
     this.warn = options.warn ?? ((warning) => {
-      console.warn(`KB-2 external document change detected at ${warning.filePath}; preserving active Yjs session state.`);
+      console.warn(`KB-2 external document change detected at ${warning.filePath}; reconciling active Yjs session from disk.`);
     });
   }
 
@@ -70,11 +90,19 @@ export class OneFileDocumentSession {
     this.lastWrittenHash = hashContent(content);
     this.doc.on('update', this.handleDocumentUpdate);
     this.opened = true;
+    this.startWatching();
   }
 
   async getContent(): Promise<string> {
     await this.open();
     return this.currentContent();
+  }
+
+  onEvent(handler: DocumentSessionEventHandler): () => void {
+    this.eventHandlers.add(handler);
+    return () => {
+      this.eventHandlers.delete(handler);
+    };
   }
 
   async reset(content = this.defaultContent): Promise<string> {
@@ -98,9 +126,14 @@ export class OneFileDocumentSession {
   async close(): Promise<void> {
     await this.flush();
     this.doc.off('update', this.handleDocumentUpdate);
+    this.stopWatching();
   }
 
-  private readonly handleDocumentUpdate = (): void => {
+  private readonly handleDocumentUpdate = (_update: Uint8Array, origin: unknown): void => {
+    if (origin === EXTERNAL_CHANGE_ORIGIN) {
+      return;
+    }
+
     this.requestPersist().catch((error: unknown) => {
       console.warn(`KB-2 failed to persist document update for ${this.filePath}; keeping active Yjs session open.`, error);
     });
@@ -121,7 +154,11 @@ export class OneFileDocumentSession {
   private async persistLoop(): Promise<void> {
     while (this.persistRequested) {
       this.persistRequested = false;
-      await this.materialize();
+      try {
+        await this.materialize();
+      } catch (error) {
+        this.markPersistFailed(error);
+      }
     }
   }
 
@@ -137,10 +174,13 @@ export class OneFileDocumentSession {
         expectedHash: this.lastWrittenHash,
         actualHash: diskHash
       });
+      await this.reconcileExternalContent(diskContent ?? '', diskHash ?? hashContent(''));
+      return;
     }
 
     await atomicWriteFile(this.filePath, content);
     this.lastWrittenHash = hashContent(content);
+    this.markPersistRecovered();
   }
 
   private async readOrCreateFile(): Promise<string> {
@@ -155,6 +195,135 @@ export class OneFileDocumentSession {
 
   private currentContent(): string {
     return this.text.toString();
+  }
+
+  private startWatching(): void {
+    if (this.watcher) {
+      return;
+    }
+
+    const directory = dirname(this.filePath);
+    const filename = basename(this.filePath);
+
+    this.watcher = watch(directory, (eventType, changedFilename) => {
+      if (eventType !== 'change' && eventType !== 'rename') {
+        return;
+      }
+
+      if (changedFilename && changedFilename.toString() !== filename) {
+        return;
+      }
+
+      this.scheduleExternalCheck();
+    });
+
+    this.watcher.on('error', (error) => {
+      console.warn(`KB-2 file watcher failed for ${this.filePath}; fallback polling remains active.`, error);
+    });
+
+    this.watchPollTimer = setInterval(() => {
+      this.checkForExternalChange().catch((error: unknown) => {
+        console.warn(`KB-2 fallback file poll failed for ${this.filePath}.`, error);
+      });
+    }, this.watchPollMs);
+    this.watchPollTimer.unref?.();
+  }
+
+  private stopWatching(): void {
+    this.watcher?.close();
+    this.watcher = undefined;
+
+    if (this.watchDebounceTimer) {
+      clearTimeout(this.watchDebounceTimer);
+      this.watchDebounceTimer = undefined;
+    }
+
+    if (this.watchPollTimer) {
+      clearInterval(this.watchPollTimer);
+      this.watchPollTimer = undefined;
+    }
+  }
+
+  private scheduleExternalCheck(): void {
+    if (this.watchDebounceTimer) {
+      clearTimeout(this.watchDebounceTimer);
+    }
+
+    this.watchDebounceTimer = setTimeout(() => {
+      this.watchDebounceTimer = undefined;
+      this.checkForExternalChange().catch((error: unknown) => {
+        console.warn(`KB-2 file watcher check failed for ${this.filePath}.`, error);
+      });
+    }, this.watchDebounceMs);
+    this.watchDebounceTimer.unref?.();
+  }
+
+  private async checkForExternalChange(): Promise<void> {
+    if (this.externalCheckPromise) {
+      await this.externalCheckPromise;
+      return;
+    }
+
+    this.externalCheckPromise = this.runExternalChangeCheck().finally(() => {
+      this.externalCheckPromise = undefined;
+    });
+    await this.externalCheckPromise;
+  }
+
+  private async runExternalChangeCheck(): Promise<void> {
+    if (!this.opened || this.lastWrittenHash === undefined) {
+      return;
+    }
+
+    const diskContent = await readOptionalFile(this.filePath);
+    const diskHash = diskContent === undefined ? hashContent('') : hashContent(diskContent);
+
+    if (diskHash === this.lastWrittenHash) {
+      return;
+    }
+
+    await this.reconcileExternalContent(diskContent ?? '', diskHash);
+  }
+
+  private async reconcileExternalContent(content: string, contentHash: string): Promise<void> {
+    const current = this.currentContent();
+    if (current !== content) {
+      applyMinimalTextSplice(this.text, current, content, this.doc);
+    }
+
+    this.lastWrittenHash = contentHash;
+    this.emitEvent('external-change');
+  }
+
+  private markPersistFailed(error: unknown): void {
+    this.persistFailed = true;
+    this.emitEvent('persist-failure');
+    console.warn(`KB-2 failed to persist document update for ${this.filePath}; keeping active Yjs session open.`, error);
+  }
+
+  private markPersistRecovered(): void {
+    if (!this.persistFailed) {
+      return;
+    }
+
+    this.persistFailed = false;
+    this.emitEvent('persist-recovered');
+  }
+
+  private emitEvent(kind: DocumentSessionEvent['kind']): void {
+    const event = {
+      kind,
+      path: this.filePath,
+      ts: Date.now()
+    } satisfies DocumentSessionEvent;
+
+    for (const handler of this.eventHandlers) {
+      try {
+        handler(event);
+      } catch (error) {
+        console.warn(`KB-2 document session event handler failed for ${this.filePath}.`, error);
+      }
+    }
   }
 }
 
@@ -190,4 +359,43 @@ function hashContent(content: string): string {
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && 'code' in error;
+}
+
+function applyMinimalTextSplice(
+  text: Y.Text,
+  current: string,
+  next: string,
+  doc: Y.Doc,
+): void {
+  let prefixLength = 0;
+  const maxPrefixLength = Math.min(current.length, next.length);
+  while (
+    prefixLength < maxPrefixLength &&
+    current.charCodeAt(prefixLength) === next.charCodeAt(prefixLength)
+  ) {
+    prefixLength += 1;
+  }
+
+  let suffixLength = 0;
+  const maxSuffixLength = maxPrefixLength - prefixLength;
+  while (
+    suffixLength < maxSuffixLength &&
+    current.charCodeAt(current.length - suffixLength - 1) ===
+      next.charCodeAt(next.length - suffixLength - 1)
+  ) {
+    suffixLength += 1;
+  }
+
+  const deleteLength = current.length - prefixLength - suffixLength;
+  const inserted = next.slice(prefixLength, next.length - suffixLength);
+
+  doc.transact(() => {
+    if (deleteLength > 0) {
+      text.delete(prefixLength, deleteLength);
+    }
+
+    if (inserted.length > 0) {
+      text.insert(prefixLength, inserted);
+    }
+  }, EXTERNAL_CHANGE_ORIGIN);
 }

--- a/packages/doc-session/src/websocket.test.ts
+++ b/packages/doc-session/src/websocket.test.ts
@@ -158,6 +158,49 @@ describe('Yjs WebSocket session', () => {
     }
   });
 
+  it('replays active persist failure to clients that bind after the failure', async () => {
+    const filePath = join(kb2Home, 'demo-vault', 'hello-world.md');
+    const vaultDir = join(kb2Home, 'demo-vault');
+    const session = new OneFileDocumentSession(filePath, { defaultContent: '' });
+    await session.open();
+
+    const server = createServer();
+    const webSocketServer = new WebSocketServer({ noServer: true });
+    server.on('upgrade', (request, socket, head) => {
+      if (request.url !== DEMO_DOCUMENT_YJS_PATH) {
+        socket.destroy();
+        return;
+      }
+
+      webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
+        void bindYjsWebSocket(session, webSocket);
+      });
+    });
+    await listen(server);
+
+    const port = (server.address() as AddressInfo).port;
+    const clientA = await connectYjsClient(`ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`);
+
+    try {
+      await chmod(vaultDir, 0o500);
+      clientA.text.insert(0, 'unsaved before joiner\n');
+      await waitForSessionEvent([clientA], 'persist-failure');
+
+      const lateClient = await connectYjsClient(`ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`);
+      try {
+        await waitForSessionEvent([lateClient], 'persist-failure');
+      } finally {
+        lateClient.close();
+      }
+    } finally {
+      await chmod(vaultDir, 0o700).catch(() => undefined);
+      clientA.close();
+      await closeWebSocketServer(webSocketServer);
+      await closeServer(server);
+      await session.close();
+    }
+  });
+
   it('closes malformed sync frames without crashing the session', async () => {
     const filePath = join(kb2Home, 'demo-vault', 'hello-world.md');
     const session = new OneFileDocumentSession(filePath, { defaultContent: '' });

--- a/packages/doc-session/src/websocket.test.ts
+++ b/packages/doc-session/src/websocket.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -110,6 +110,52 @@ describe('Yjs WebSocket session', () => {
     await closeWebSocketServer(webSocketServer);
     await closeServer(server);
     await session.close();
+  });
+
+  it('broadcasts persist failure and recovery events to every client', async () => {
+    const filePath = join(kb2Home, 'demo-vault', 'hello-world.md');
+    const vaultDir = join(kb2Home, 'demo-vault');
+    const session = new OneFileDocumentSession(filePath, { defaultContent: '' });
+    await session.open();
+
+    const server = createServer();
+    const webSocketServer = new WebSocketServer({ noServer: true });
+    server.on('upgrade', (request, socket, head) => {
+      if (request.url !== DEMO_DOCUMENT_YJS_PATH) {
+        socket.destroy();
+        return;
+      }
+
+      webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
+        void bindYjsWebSocket(session, webSocket);
+      });
+    });
+    await listen(server);
+
+    const port = (server.address() as AddressInfo).port;
+    const clientA = await connectYjsClient(`ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`);
+    const clientB = await connectYjsClient(`ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`);
+
+    try {
+      await chmod(vaultDir, 0o500);
+      clientA.text.insert(0, 'unsaved while readonly\n');
+      await waitForSessionEvent([clientA, clientB], 'persist-failure');
+
+      await chmod(vaultDir, 0o700);
+      clientA.text.insert(clientA.text.length, 'saved after recovery\n');
+      await waitForSessionEvent([clientA, clientB], 'persist-recovered');
+
+      await waitForDiskContent(filePath, (content) =>
+        content === 'unsaved while readonly\nsaved after recovery\n'
+      );
+    } finally {
+      await chmod(vaultDir, 0o700).catch(() => undefined);
+      clientA.close();
+      clientB.close();
+      await closeWebSocketServer(webSocketServer);
+      await closeServer(server);
+      await session.close();
+    }
   });
 
   it('closes malformed sync frames without crashing the session', async () => {
@@ -279,6 +325,15 @@ async function waitForSessionEvent(
 ): Promise<void> {
   await waitUntil(() => clients.every((client) => client.events.some((event) => event.kind === kind)), () =>
     `Timed out waiting for ${kind}: ${clients.map((client) => JSON.stringify(client.events)).join(' | ')}`
+  );
+}
+
+async function waitForDiskContent(
+  filePath: string,
+  predicate: (content: string) => boolean,
+): Promise<void> {
+  await waitUntil(async () => predicate(await readFile(filePath, 'utf8')), () =>
+    `Timed out waiting for disk content at ${filePath}`
   );
 }
 

--- a/packages/doc-session/src/websocket.test.ts
+++ b/packages/doc-session/src/websocket.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,10 +10,14 @@ import { WebSocket, WebSocketServer } from 'ws';
 import * as syncProtocol from 'y-protocols/sync';
 import * as Y from 'yjs';
 
-import { OneFileDocumentSession } from './session.js';
+import {
+  MESSAGE_SESSION_EVENT,
+  MESSAGE_SYNC,
+  OneFileDocumentSession,
+  decodeSessionEvent,
+  type DocumentSessionEvent
+} from './index.js';
 import { DEMO_DOCUMENT_YJS_PATH, bindYjsWebSocket } from './websocket.js';
-
-const messageSync = 0;
 
 describe('Yjs WebSocket session', () => {
   let kb2Home: string;
@@ -67,6 +71,47 @@ describe('Yjs WebSocket session', () => {
     await session.close();
   });
 
+  it('reconciles external file changes and broadcasts the event to every client', async () => {
+    const filePath = join(kb2Home, 'demo-vault', 'hello-world.md');
+    const session = new OneFileDocumentSession(filePath, {
+      defaultContent: 'initial\n',
+      watchDebounceMs: 10,
+      watchPollMs: 50
+    });
+    await session.open();
+
+    const server = createServer();
+    const webSocketServer = new WebSocketServer({ noServer: true });
+    server.on('upgrade', (request, socket, head) => {
+      if (request.url !== DEMO_DOCUMENT_YJS_PATH) {
+        socket.destroy();
+        return;
+      }
+
+      webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
+        void bindYjsWebSocket(session, webSocket);
+      });
+    });
+    await listen(server);
+
+    const port = (server.address() as AddressInfo).port;
+    const clientA = await connectYjsClient(`ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`);
+    const clientB = await connectYjsClient(`ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`);
+
+    await waitForSharedContent([clientA, clientB], (content) => content === 'initial\n');
+
+    await writeFile(filePath, 'changed outside\n', 'utf8');
+
+    await waitForSharedContent([clientA, clientB], (content) => content === 'changed outside\n');
+    await waitForSessionEvent([clientA, clientB], 'external-change');
+
+    clientA.close();
+    clientB.close();
+    await closeWebSocketServer(webSocketServer);
+    await closeServer(server);
+    await session.close();
+  });
+
   it('closes malformed sync frames without crashing the session', async () => {
     const filePath = join(kb2Home, 'demo-vault', 'hello-world.md');
     const session = new OneFileDocumentSession(filePath, { defaultContent: '' });
@@ -110,12 +155,14 @@ describe('Yjs WebSocket session', () => {
 interface YjsClient {
   doc: Y.Doc;
   text: Y.Text;
+  events: DocumentSessionEvent[];
   close: () => void;
 }
 
 async function connectYjsClient(url: string): Promise<YjsClient> {
   const doc = new Y.Doc();
   const text = doc.getText('markdown');
+  const events: DocumentSessionEvent[] = [];
   const socket = new WebSocket(url);
   socket.binaryType = 'arraybuffer';
 
@@ -135,11 +182,19 @@ async function connectYjsClient(url: string): Promise<YjsClient> {
     const encoder = encoding.createEncoder();
     const messageType = decoding.readVarUint(decoder);
 
-    if (messageType !== messageSync) {
+    if (messageType === MESSAGE_SESSION_EVENT) {
+      const event = decodeSessionEvent(decoder);
+      if (event) {
+        events.push(event);
+      }
       return;
     }
 
-    encoding.writeVarUint(encoder, messageSync);
+    if (messageType !== MESSAGE_SYNC) {
+      return;
+    }
+
+    encoding.writeVarUint(encoder, MESSAGE_SYNC);
     syncProtocol.readSyncMessage(decoder, encoder, doc, socket);
     if (encoding.length(encoder) > 1) {
       socket.send(encoding.toUint8Array(encoder));
@@ -158,13 +213,14 @@ async function connectYjsClient(url: string): Promise<YjsClient> {
   return {
     doc,
     text,
+    events,
     close: () => socket.close()
   };
 }
 
 function sendSync(socket: WebSocket, write: (encoder: encoding.Encoder) => void): void {
   const encoder = encoding.createEncoder();
-  encoding.writeVarUint(encoder, messageSync);
+  encoding.writeVarUint(encoder, MESSAGE_SYNC);
   write(encoder);
   socket.send(encoding.toUint8Array(encoder));
 }
@@ -215,6 +271,27 @@ async function waitForSharedContent(
       client.doc.on('update', onUpdate);
     }
   });
+}
+
+async function waitForSessionEvent(
+  clients: YjsClient[],
+  kind: DocumentSessionEvent['kind'],
+): Promise<void> {
+  await waitUntil(() => clients.every((client) => client.events.some((event) => event.kind === kind)), () =>
+    `Timed out waiting for ${kind}: ${clients.map((client) => JSON.stringify(client.events)).join(' | ')}`
+  );
+}
+
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  errorMessage: () => string,
+): Promise<void> {
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(errorMessage());
 }
 
 function listen(server: Server): Promise<void> {

--- a/packages/doc-session/src/websocket.ts
+++ b/packages/doc-session/src/websocket.ts
@@ -88,6 +88,11 @@ export async function bindYjsWebSocket(
     sendBytes(socket, encodeSessionEvent(event));
   });
 
+  const activePersistFailure = session.getActivePersistFailureEvent();
+  if (activePersistFailure) {
+    sendBytes(socket, encodeSessionEvent(activePersistFailure));
+  }
+
   sendSync(socket, (encoder) => {
     syncProtocol.writeSyncStep1(encoder, session.ydoc);
   });

--- a/packages/doc-session/src/websocket.ts
+++ b/packages/doc-session/src/websocket.ts
@@ -3,10 +3,10 @@ import * as encoding from 'lib0/encoding';
 import * as syncProtocol from 'y-protocols/sync';
 
 import type { OneFileDocumentSession } from './session.js';
+import { MESSAGE_SYNC, encodeSessionEvent } from './protocol.js';
 
 export const DEMO_DOCUMENT_YJS_PATH = '/api/demo-document/yjs';
 
-const messageSync = 0;
 const socketOpen = 1;
 
 export interface YjsWebSocketLike {
@@ -34,6 +34,7 @@ export async function bindYjsWebSocket(
     resolveClosed = resolve;
     rejectClosed = reject;
   });
+  let unsubscribeSessionEvents: () => void = () => {};
 
   const updateHandler = (update: Uint8Array, origin: unknown) => {
     if (origin === socket) {
@@ -51,6 +52,7 @@ export async function bindYjsWebSocket(
     }
 
     cleanupStarted = true;
+    unsubscribeSessionEvents();
     session.ydoc.off('update', updateHandler);
     session.flush().then(resolveClosed, rejectClosed);
   };
@@ -66,11 +68,11 @@ export async function bindYjsWebSocket(
       const encoder = encoding.createEncoder();
       const messageType = decoding.readVarUint(decoder);
 
-      if (messageType !== messageSync) {
+      if (messageType !== MESSAGE_SYNC) {
         return;
       }
 
-      encoding.writeVarUint(encoder, messageSync);
+      encoding.writeVarUint(encoder, MESSAGE_SYNC);
       syncProtocol.readSyncMessage(decoder, encoder, session.ydoc, socket);
 
       if (encoding.length(encoder) > 1) {
@@ -81,30 +83,38 @@ export async function bindYjsWebSocket(
     }
   });
 
-  socket.on('close', cleanup);
-  socket.on('error', cleanup);
   session.ydoc.on('update', updateHandler);
+  unsubscribeSessionEvents = session.onEvent((event) => {
+    sendBytes(socket, encodeSessionEvent(event));
+  });
 
   sendSync(socket, (encoder) => {
     syncProtocol.writeSyncStep1(encoder, session.ydoc);
   });
+
+  socket.on('close', cleanup);
+  socket.on('error', cleanup);
 
   return { closed };
 }
 
 function sendSync(socket: YjsWebSocketLike, write: (encoder: encoding.Encoder) => void): void {
   const encoder = encoding.createEncoder();
-  encoding.writeVarUint(encoder, messageSync);
+  encoding.writeVarUint(encoder, MESSAGE_SYNC);
   write(encoder);
   sendEncoded(socket, encoder);
 }
 
 function sendEncoded(socket: YjsWebSocketLike, encoder: encoding.Encoder): void {
+  sendBytes(socket, encoding.toUint8Array(encoder));
+}
+
+function sendBytes(socket: YjsWebSocketLike, bytes: Uint8Array): void {
   if (socket.readyState !== socketOpen) {
     return;
   }
 
-  socket.send(encoding.toUint8Array(encoder));
+  socket.send(bytes);
 }
 
 function toUint8Array(data: unknown): Uint8Array | undefined {

--- a/packages/editor/src/lib/PlaintextEditor.undo.test.ts
+++ b/packages/editor/src/lib/PlaintextEditor.undo.test.ts
@@ -109,6 +109,27 @@ describe('PlaintextEditor undo gate (substrate contract)', () => {
     expect(ytext.toJSON()).toBe('AGENT: hello');
   });
 
+  it('preserves a remote external-change transaction when user undo runs', () => {
+    // The daemon reconciles external disk writes through Yjs and clients
+    // receive them as remote socket-origin updates. The editor's undo
+    // stack tracks only local user origin, so Ctrl-Z must leave that
+    // external content intact.
+    const { doc, ytext, undoManager } = setup('hello');
+    const remoteExternalChangeOrigin = { source: 'external-change-socket' };
+    doc.transact(() => {
+      ytext.insert(ytext.length, ' from disk');
+    }, remoteExternalChangeOrigin);
+    doc.transact(() => {
+      ytext.insert(ytext.length, '!');
+    }, PLAINTEXT_USER_ORIGIN);
+
+    expect(ytext.toJSON()).toBe('hello from disk!');
+    undoManager.undo();
+    expect(ytext.toJSON()).toBe('hello from disk');
+    undoManager.undo();
+    expect(ytext.toJSON()).toBe('hello from disk');
+  });
+
   it('redoes a previously undone user edit', () => {
     const { doc, ytext, undoManager } = setup('hello');
     doc.transact(() => {

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -23,6 +23,11 @@ export { default as DialogShell } from './dialogs/DialogShell.svelte';
 export { default as Panel } from './layout/Panel.svelte';
 export { default as LocalStatusShell } from './layout/LocalStatusShell.svelte';
 export type { DaemonStatus, HealthResponse } from './layout/LocalStatusShell.svelte';
+export { default as DocumentSaveBanner } from './notifications/DocumentSaveBanner.svelte';
+export type {
+  DocumentSaveBannerProps,
+  DocumentSaveBannerVariant,
+} from './notifications/DocumentSaveBanner.svelte';
 export {
   accentForId,
   accentHex,

--- a/packages/ui/src/lib/notifications/DocumentSaveBanner.stories.ts
+++ b/packages/ui/src/lib/notifications/DocumentSaveBanner.stories.ts
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import DocumentSaveBanner, {
+  type DocumentSaveBannerProps,
+} from './DocumentSaveBanner.svelte';
+
+const noop = () => undefined;
+
+const fixtures = {
+  externalChangeNotice: {
+    variant: 'external-change',
+    title: 'Document changed elsewhere',
+    message: 'A teammate saved a newer version while this document was open.',
+    actionLabel: 'Review changes',
+    onaction: noop,
+    ondismiss: noop,
+  },
+  persistFailureAlarm: {
+    variant: 'persist-failure',
+    title: 'Changes are not saving',
+    message: 'Keep this tab open. KB-2 will retry automatically when storage responds.',
+  },
+  persistRecoveredConfirmation: {
+    variant: 'persist-recovered',
+    title: 'Saving restored',
+    message: 'All pending edits have been written to the knowledge base.',
+  },
+} satisfies Record<string, DocumentSaveBannerProps>;
+
+const meta = {
+  title: 'App/Notifications/Document Save Banner',
+  component: DocumentSaveBanner,
+  parameters: { layout: 'centered' },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['external-change', 'persist-failure', 'persist-recovered'],
+    },
+  },
+} satisfies Meta<typeof DocumentSaveBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ExternalChangeNotice: Story = {
+  args: fixtures.externalChangeNotice,
+};
+
+export const PersistFailureAlarm: Story = {
+  args: fixtures.persistFailureAlarm,
+};
+
+export const PersistRecoveredConfirmation: Story = {
+  args: fixtures.persistRecoveredConfirmation,
+};

--- a/packages/ui/src/lib/notifications/DocumentSaveBanner.svelte
+++ b/packages/ui/src/lib/notifications/DocumentSaveBanner.svelte
@@ -1,0 +1,192 @@
+<script lang="ts" module>
+  import type { IconName } from '../primitives/types';
+
+  export type DocumentSaveBannerVariant =
+    | 'external-change'
+    | 'persist-failure'
+    | 'persist-recovered';
+
+  export interface DocumentSaveBannerProps {
+    variant: DocumentSaveBannerVariant;
+    title?: string;
+    message?: string;
+    actionLabel?: string;
+    onaction?: (event: MouseEvent) => void;
+    ondismiss?: (event: MouseEvent) => void;
+    dismissLabel?: string;
+    class?: string;
+  }
+
+  interface VariantConfig {
+    title: string;
+    message: string;
+    icon: IconName;
+    role: 'alert' | 'status';
+    ariaLive: 'assertive' | 'polite';
+  }
+
+  const variantConfig: Record<DocumentSaveBannerVariant, VariantConfig> = {
+    'external-change': {
+      title: 'Document changed elsewhere',
+      message: 'A newer version is available. Review it before continuing to edit.',
+      icon: 'refresh',
+      role: 'status',
+      ariaLive: 'polite',
+    },
+    'persist-failure': {
+      title: 'Changes are not saving',
+      message: 'Your edits are still in this session, but KB-2 cannot persist them right now.',
+      icon: 'bell',
+      role: 'alert',
+      ariaLive: 'assertive',
+    },
+    'persist-recovered': {
+      title: 'Saving restored',
+      message: 'KB-2 is persisting changes again.',
+      icon: 'cloud',
+      role: 'status',
+      ariaLive: 'polite',
+    },
+  };
+</script>
+
+<script lang="ts">
+  import { Button } from '../button';
+  import Icon from '../primitives/Icon.svelte';
+  import IconButton from '../primitives/IconButton.svelte';
+  import { cn } from '../utils';
+
+  let {
+    variant,
+    title,
+    message,
+    actionLabel,
+    onaction,
+    ondismiss,
+    dismissLabel = 'Dismiss save notification',
+    class: className = '',
+  }: DocumentSaveBannerProps = $props();
+
+  const config = $derived(variantConfig[variant]);
+  const heading = $derived(title ?? config.title);
+  const body = $derived(message ?? config.message);
+  const hasAction = $derived(Boolean(actionLabel && onaction));
+</script>
+
+<section
+  class={cn('document-save-banner', `variant-${variant}`, className)}
+  role={config.role}
+  aria-live={config.ariaLive}
+>
+  <span class="icon-cell" aria-hidden="true">
+    <Icon name={config.icon} size={18} weight="regular" />
+  </span>
+
+  <div class="copy">
+    <h2>{heading}</h2>
+    <p>{body}</p>
+  </div>
+
+  {#if hasAction}
+    <Button variant="outline" size="sm" onclick={onaction}>{actionLabel}</Button>
+  {/if}
+
+  {#if ondismiss}
+    <IconButton size="sm" variant="quiet" title={dismissLabel} ariaLabel={dismissLabel} onclick={ondismiss}>
+      <Icon name="x" size={15} weight="regular" />
+    </IconButton>
+  {/if}
+</section>
+
+<style>
+  .document-save-banner {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    border: 1px solid var(--banner-border);
+    border-radius: 8px;
+    background: var(--banner-bg);
+    color: var(--rd-ink-1);
+    padding: 10px 12px;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  }
+
+  .icon-cell {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    border-radius: 7px;
+    background: var(--banner-icon-bg);
+    color: var(--banner-accent);
+  }
+
+  .copy {
+    min-width: 0;
+  }
+
+  h2,
+  p {
+    margin: 0;
+    font-family: var(--rd-ui);
+  }
+
+  h2 {
+    color: var(--rd-ink-1);
+    font-size: 13px;
+    font-weight: 650;
+    line-height: 1.25;
+  }
+
+  p {
+    margin-top: 2px;
+    color: var(--rd-ink-3);
+    font-size: 12px;
+    line-height: 1.35;
+  }
+
+  :global(.document-save-banner .kb2-button) {
+    background: color-mix(in srgb, var(--banner-accent) 8%, var(--rd-panel));
+    color: var(--rd-ink-2);
+  }
+
+  :global(.document-save-banner .kb2-button:hover) {
+    background: color-mix(in srgb, var(--banner-accent) 14%, var(--rd-panel));
+  }
+
+  .variant-external-change {
+    --banner-accent: var(--rd-sky);
+    --banner-bg: color-mix(in srgb, var(--rd-sky-bg) 32%, var(--rd-panel));
+    --banner-border: color-mix(in srgb, var(--rd-sky) 28%, var(--rd-rule));
+    --banner-icon-bg: color-mix(in srgb, var(--rd-sky-bg) 70%, var(--rd-panel));
+  }
+
+  .variant-persist-failure {
+    --banner-accent: var(--destructive);
+    --banner-bg: color-mix(in srgb, var(--destructive) 8%, var(--rd-panel));
+    --banner-border: color-mix(in srgb, var(--destructive) 30%, var(--rd-rule));
+    --banner-icon-bg: color-mix(in srgb, var(--destructive) 12%, var(--rd-panel));
+  }
+
+  .variant-persist-recovered {
+    --banner-accent: var(--rd-live-on);
+    --banner-bg: color-mix(in srgb, var(--rd-live-bg) 42%, var(--rd-panel));
+    --banner-border: color-mix(in srgb, var(--rd-live) 32%, var(--rd-rule));
+    --banner-icon-bg: color-mix(in srgb, var(--rd-live-bg) 72%, var(--rd-panel));
+  }
+
+  @media (max-width: 560px) {
+    .document-save-banner {
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      align-items: start;
+    }
+
+    :global(.document-save-banner .kb2-button) {
+      grid-column: 2 / -1;
+      justify-self: start;
+    }
+  }
+</style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@fontsource/source-serif-4':
         specifier: 5.2.9
         version: 5.2.9
+      '@kb-2/doc-session':
+        specifier: workspace:*
+        version: link:../../packages/doc-session
       '@kb-2/editor':
         specifier: workspace:*
         version: link:../../packages/editor
@@ -133,9 +136,6 @@ importers:
         specifier: 13.6.31
         version: 13.6.31
     devDependencies:
-      '@kb-2/doc-session':
-        specifier: workspace:*
-        version: link:../../packages/doc-session
       '@sveltejs/adapter-static':
         specifier: 'catalog:'
         version: 3.0.10(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.55.5)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.55.5)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)))

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "moduleResolution": "NodeNext",
     "paths": {
       "@kb-2/doc-session": ["./packages/doc-session/src/index.ts"],
+      "@kb-2/doc-session/protocol": ["./packages/doc-session/src/protocol.ts"],
       "@kb-2/editor": ["./packages/editor/src/lib/index.ts"],
       "@kb-2/ui": ["./packages/ui/src/lib/index.ts"]
     },


### PR DESCRIPTION
## Summary

- Detect external writes to the managed Markdown file with fs.watch, hash checks, debounce, and fallback polling.
- Reconcile confirmed disk changes into the active Y.Text session and broadcast typed session events over the existing WebSocket.
- Surface external-change, persist-failure, and persist-recovered events in the web app with props-driven UI package banners and dedicated stories.
- Add direct coverage for own-write suppression, external reconciliation, all-client event broadcast, persist failure/recovery, joiner failure replay, no-op external-change suppression, and undo isolation.

## Review fixes

- New clients now receive the active `persist-failure` event immediately when binding to a session that is already failing to persist, so the warning remains persistent across reload/join.
- External-change emission is now guarded on an actual content delta, and watcher checks suppress the hash of an in-flight daemon materialization to avoid own-write race false positives.
- External file-deletion semantics remain intentionally deferred per commander instruction.

## Verification

- pnpm install
- pnpm --filter @kb-2/doc-session test
- pnpm --filter @kb-2/doc-session typecheck
- pnpm --filter @kb-2/editor test
- pnpm check
- Real Chrome/CDP manual verification on temp KB2_HOME=/tmp/kb2-chunk006-UsOJBV, daemon port 7393, web port 5193:
  - two tabs both showed live content update after `echo >> demo-vault/hello-world.md`
  - two tabs both showed `This file changed outside KB-2 and was reloaded from disk.`
  - chmod read-only on the temp demo vault, then browser typing, showed `Changes are NOT saving to disk.` in both tabs
  - chmod restored, then browser typing, showed `Saving restored` in both tabs and the alarm cleared
  - final disk content contained the external edit, readonly-period typed text, and recovery typed text

## Notes

- Verification used only temp KB2_HOME and isolated ports; the user's live 7382 daemon and real ~/.kb2 were not used.
- The implementation intentionally does not add reconnect/offline/read-only mode, file tree support, MCP, or a general vault watcher.
- A worktree recovery occurred during implementation; /Users/yohsuzuki/Development/Metatheory/kb-2 was restored clean to main@46bf283, and final work continued only in /Users/yohsuzuki/.codex/worktrees/1f91/kb-2.