### PR TITLE
KB-2 Chunk 006.5: Fast-Diff Reconcile and Quiet Merge

### DIFF
--- a/apps/web/src/lib/yjs/demo-document-provider.test.ts
+++ b/apps/web/src/lib/yjs/demo-document-provider.test.ts
@@ -115,7 +115,7 @@ describe('demo document provider', () => {
 
       webSocketServer!.handleUpgrade(request, socket, head, (webSocket) => {
         webSocket.send(encodeSessionEvent({
-          kind: 'persist-failure',
+          kind: 'external-merge',
           path: join(kb2Home, 'demo-vault', 'hello-world.md'),
           ts: 123,
         }));
@@ -129,7 +129,7 @@ describe('demo document provider', () => {
       onSessionEvent: (event) => events.push(event),
     });
 
-    await waitUntil(() => events.some((event) => event.kind === 'persist-failure'), () =>
+    await waitUntil(() => events.some((event) => event.kind === 'external-merge'), () =>
       `Timed out waiting for provider session event: ${JSON.stringify(events)}`
     );
 

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -12,9 +12,11 @@
   let provider = $state<DemoDocumentProvider | null>(null);
   let status = $state<DemoDocumentProviderStatus>('connecting');
   let error = $state<string | null>(null);
+  let externalMergeVisible = $state(false);
   let externalChangeVisible = $state(false);
   let persistFailureActive = $state(false);
   let persistRecoveredVisible = $state(false);
+  let externalMergeTimer: ReturnType<typeof setTimeout> | undefined;
   let recoveryTimer: ReturnType<typeof setTimeout> | undefined;
 
   const livePaths: LivePath[] = [
@@ -41,8 +43,25 @@
   );
 
   function handleSessionEvent(event: DocumentSessionEvent): void {
+    if (event.kind === 'external-merge') {
+      externalMergeVisible = true;
+      if (externalMergeTimer) {
+        clearTimeout(externalMergeTimer);
+      }
+      externalMergeTimer = setTimeout(() => {
+        externalMergeVisible = false;
+        externalMergeTimer = undefined;
+      }, 4000);
+      return;
+    }
+
     if (event.kind === 'external-change') {
       externalChangeVisible = true;
+      externalMergeVisible = false;
+      if (externalMergeTimer) {
+        clearTimeout(externalMergeTimer);
+        externalMergeTimer = undefined;
+      }
       return;
     }
 
@@ -80,6 +99,10 @@
     provider = nextProvider;
 
     return () => {
+      if (externalMergeTimer) {
+        clearTimeout(externalMergeTimer);
+        externalMergeTimer = undefined;
+      }
       if (recoveryTimer) {
         clearTimeout(recoveryTimer);
         recoveryTimer = undefined;
@@ -105,8 +128,23 @@
     </a>
   </header>
 
-  {#if externalChangeVisible || persistFailureActive || persistRecoveredVisible}
+  {#if externalMergeVisible || externalChangeVisible || persistFailureActive || persistRecoveredVisible}
     <section class="banner-strip" aria-label="Document save notifications">
+      {#if externalMergeVisible}
+        <DocumentSaveBanner
+          variant="external-merge"
+          title="External edit merged"
+          message="Merged an edit made outside KB-2."
+          ondismiss={() => {
+            externalMergeVisible = false;
+            if (externalMergeTimer) {
+              clearTimeout(externalMergeTimer);
+              externalMergeTimer = undefined;
+            }
+          }}
+        />
+      {/if}
+
       {#if externalChangeVisible}
         <DocumentSaveBanner
           variant="external-change"

--- a/packages/doc-session/package.json
+++ b/packages/doc-session/package.json
@@ -24,13 +24,14 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "fast-diff": "1.3.0",
     "lib0": "0.2.117",
     "y-protocols": "1.0.7",
     "yjs": "13.6.31"
   },
   "devDependencies": {
+    "@types/ws": "8.18.1",
     "vitest": "4.1.8",
-    "ws": "8.21.0",
-    "@types/ws": "8.18.1"
+    "ws": "8.21.0"
   }
 }

--- a/packages/doc-session/src/protocol.ts
+++ b/packages/doc-session/src/protocol.ts
@@ -5,6 +5,7 @@ export const MESSAGE_SYNC = 0;
 export const MESSAGE_SESSION_EVENT = 1;
 
 export type DocumentSessionEventKind =
+  | 'external-merge'
   | 'external-change'
   | 'persist-failure'
   | 'persist-recovered';
@@ -43,7 +44,8 @@ export function decodeSessionEvent(
 }
 
 function isSessionEventKind(kind: unknown): kind is DocumentSessionEventKind {
-  return kind === 'external-change' ||
+  return kind === 'external-merge' ||
+    kind === 'external-change' ||
     kind === 'persist-failure' ||
     kind === 'persist-recovered';
 }

--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 
 import * as Y from 'yjs';
 
+import { createFastDiffYTextDelta } from './session.js';
 import {
   OneFileDocumentSession,
   type DocumentSessionEvent,
@@ -21,6 +22,55 @@ describe('OneFileDocumentSession', () => {
 
   afterEach(async () => {
     await rm(kb2Home, { force: true, recursive: true });
+  });
+
+  it('maps fast-diff output to a Y.Text delta that reproduces randomized disk content exactly', () => {
+    const cases = [
+      ['', ''],
+      ['', 'created\n'],
+      ['deleted\n', ''],
+      ['same\n', 'same\n'],
+      ['a😀b', 'a😃b'],
+      ['😀 at start', 'prefix 😀 at start'],
+      ['end 🧪', 'end 🧪 suffix'],
+      ['repeat\nrepeat\nrepeat\n', 'repeat\nchanged\nrepeat\n'],
+      ['multi\nline\nsource\n', 'multi\n🧪 line\ntarget\n'],
+    ];
+
+    for (let seed = 1; seed <= 160; seed += 1) {
+      cases.push([randomDocument(seed), randomDocument(seed * 7919)]);
+    }
+
+    for (const [source, target] of cases) {
+      const doc = new Y.Doc();
+      const text = doc.getText('markdown');
+      text.insert(0, source);
+
+      doc.transact(() => {
+        text.applyDelta(createFastDiffYTextDelta(source, target));
+      });
+
+      expect(text.toString()).toBe(target);
+    }
+  });
+
+  it('applies surrogate-pair boundary edits without corrupting the document', () => {
+    const source = 'alpha 😀 omega';
+    const cases = [
+      'alpha 🧪 omega',
+      'alpha 😀 inserted omega',
+      'alpha inserted 😀 omega',
+      'alpha omega',
+    ];
+
+    for (const target of cases) {
+      const doc = new Y.Doc();
+      const text = doc.getText('markdown');
+      text.insert(0, source);
+      text.applyDelta(createFastDiffYTextDelta(source, target));
+
+      expect(text.toString()).toBe(target);
+    }
   });
 
   it('creates the configured file when it is missing', async () => {
@@ -69,7 +119,7 @@ describe('OneFileDocumentSession', () => {
     await secondSession.close();
   });
 
-  it('reconciles direct filesystem changes into the active session', async () => {
+  it('quietly merges direct filesystem changes into an idle active session', async () => {
     const events: DocumentSessionEvent[] = [];
     await writeFileWithParents(filePath, 'active\n');
     const session = new OneFileDocumentSession(filePath, {
@@ -85,7 +135,7 @@ describe('OneFileDocumentSession', () => {
       `Timed out waiting for external reconcile; content=${session.ydoc.getText('markdown').toString()}`
     );
 
-    expect(events.filter((event) => event.kind === 'external-change')).toHaveLength(1);
+    expect(eventKinds(events)).toEqual(['external-merge']);
     await session.close();
   });
 
@@ -104,7 +154,7 @@ describe('OneFileDocumentSession', () => {
     await new Promise((resolve) => setTimeout(resolve, 120));
 
     await expect(readFile(filePath, 'utf8')).resolves.toBe('own write\n');
-    expect(events.filter((event) => event.kind === 'external-change')).toHaveLength(0);
+    expect(events.filter((event) => event.kind === 'external-change' || event.kind === 'external-merge')).toHaveLength(0);
     await session.close();
   });
 
@@ -121,7 +171,7 @@ describe('OneFileDocumentSession', () => {
     await writeFile(filePath, 'same content\n', 'utf8');
     await new Promise((resolve) => setTimeout(resolve, 120));
 
-    expect(events.filter((event) => event.kind === 'external-change')).toHaveLength(0);
+    expect(events.filter((event) => event.kind === 'external-change' || event.kind === 'external-merge')).toHaveLength(0);
     await expect(session.getContent()).resolves.toBe('same content\n');
     await session.close();
   });
@@ -145,7 +195,62 @@ describe('OneFileDocumentSession', () => {
     );
     await new Promise((resolve) => setTimeout(resolve, 80));
 
-    expect(events.filter((event) => event.kind === 'external-change')).toHaveLength(1);
+    expect(eventKinds(events)).toEqual(['external-merge']);
+    await session.close();
+  });
+
+  it('keeps the loud external-change event when the backing file is truncated', async () => {
+    const events: DocumentSessionEvent[] = [];
+    await writeFileWithParents(filePath, 'nonempty\n');
+    const session = new OneFileDocumentSession(filePath, {
+      watchDebounceMs: 10,
+      watchPollMs: 50
+    });
+    session.onEvent((event) => events.push(event));
+    await session.open();
+
+    await writeFile(filePath, '', 'utf8');
+
+    await waitUntil(async () => await session.getContent() === '', () =>
+      `Timed out waiting for truncation reconcile; content=${session.ydoc.getText('markdown').toString()}`
+    );
+
+    expect(eventKinds(events)).toEqual(['external-change']);
+    await session.close();
+  });
+
+  it('persists a client update that arrives after an idle external merge', async () => {
+    const events: DocumentSessionEvent[] = [];
+    const session = new OneFileDocumentSession(filePath, {
+      defaultContent: 'base\n',
+      watchDebounceMs: 10,
+      watchPollMs: 50
+    });
+    session.onEvent((event) => events.push(event));
+    await session.open();
+
+    const clientDoc = new Y.Doc();
+    Y.applyUpdate(clientDoc, Y.encodeStateAsUpdate(session.ydoc), session);
+    clientDoc.getText('markdown').insert(clientDoc.getText('markdown').length, 'client edit\n');
+    const inFlightUpdate = Y.encodeStateAsUpdate(clientDoc, Y.encodeStateVector(session.ydoc));
+
+    await writeFile(filePath, 'external edit\n', 'utf8');
+    await waitUntil(async () => await session.getContent() === 'external edit\n', () =>
+      `Timed out waiting for idle external merge; content=${session.ydoc.getText('markdown').toString()}`
+    );
+
+    Y.applyUpdate(session.ydoc, inFlightUpdate, clientDoc);
+    await session.flush();
+
+    await waitUntil(async () => {
+      const content = await readFile(filePath, 'utf8');
+      return content.includes('external edit\n') && content.includes('client edit\n');
+    }, () => `Timed out waiting for external and client edits to persist; content=${session.ydoc.getText('markdown').toString()}`);
+
+    expect(eventKinds(events)).toEqual(['external-merge']);
+    const finalContent = await readFile(filePath, 'utf8');
+    expect(finalContent).toContain('external edit\n');
+    expect(finalContent).toContain('client edit\n');
     await session.close();
   });
 
@@ -175,11 +280,13 @@ describe('OneFileDocumentSession', () => {
   });
 
   it('reconciles direct filesystem changes before materializing a racing session edit', async () => {
+    const events: DocumentSessionEvent[] = [];
     const warnings: DocumentSessionWarning[] = [];
     const session = new OneFileDocumentSession(filePath, {
       defaultContent: 'active\n',
       warn: (warning) => warnings.push(warning)
     });
+    session.onEvent((event) => events.push(event));
     await session.open();
 
     await writeFile(filePath, 'external stale edit\n', 'utf8');
@@ -192,9 +299,32 @@ describe('OneFileDocumentSession', () => {
       type: 'external-change-detected',
       filePath
     });
+    expect(events.some((event) => event.kind === 'external-change')).toBe(true);
     await session.close();
   });
 });
+
+function eventKinds(events: DocumentSessionEvent[]): DocumentSessionEvent['kind'][] {
+  return events.map((event) => event.kind);
+}
+
+function randomDocument(seed: number): string {
+  const alphabet = ['a', 'b', 'c', ' ', '\n', '# ', '- ', '😀', '😃', '🧪', '𝌆'];
+  let state = seed;
+  const length = nextRandomInt(0, 80);
+  let content = '';
+
+  for (let index = 0; index < length; index += 1) {
+    content += alphabet[nextRandomInt(0, alphabet.length - 1)];
+  }
+
+  return content;
+
+  function nextRandomInt(min: number, max: number): number {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return min + (state % (max - min + 1));
+  }
+}
 
 async function writeFileWithParents(pathname: string, content: string): Promise<void> {
   await mkdir(dirname(pathname), { recursive: true });

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -3,6 +3,7 @@ import { watch, type FSWatcher } from 'node:fs';
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 
+import diff from 'fast-diff';
 import * as Y from 'yjs';
 
 import type { DocumentSessionEvent } from './protocol.js';
@@ -48,6 +49,7 @@ export class OneFileDocumentSession {
   private opened = false;
   private openPromise: Promise<void> | undefined;
   private lastWrittenHash: string | undefined;
+  private lastWrittenContent: string | undefined;
   private pendingWriteHash: string | undefined;
   private persistRequested = false;
   private persistPromise: Promise<void> | undefined;
@@ -90,6 +92,7 @@ export class OneFileDocumentSession {
     const content = await this.readOrCreateFile();
     this.text.insert(0, content);
     this.lastWrittenHash = hashContent(content);
+    this.lastWrittenContent = content;
     this.doc.on('update', this.handleDocumentUpdate);
     this.opened = true;
     this.startWatching();
@@ -180,7 +183,7 @@ export class OneFileDocumentSession {
         expectedHash: this.lastWrittenHash,
         actualHash: diskHash
       });
-      await this.reconcileExternalContent(diskContent ?? '', diskHash ?? hashContent(''));
+      await this.reconcileExternalContent(diskContent ?? '', diskHash ?? hashContent(''), diskContent === undefined);
       return;
     }
 
@@ -189,6 +192,7 @@ export class OneFileDocumentSession {
     try {
       await atomicWriteFile(this.filePath, content);
       this.lastWrittenHash = contentHash;
+      this.lastWrittenContent = content;
       this.markPersistRecovered();
     } finally {
       if (this.pendingWriteHash === contentHash) {
@@ -296,19 +300,34 @@ export class OneFileDocumentSession {
       return;
     }
 
-    await this.reconcileExternalContent(diskContent ?? '', diskHash);
+    await this.reconcileExternalContent(diskContent ?? '', diskHash, diskContent === undefined);
   }
 
-  private async reconcileExternalContent(content: string, contentHash: string): Promise<void> {
+  private async reconcileExternalContent(
+    content: string,
+    contentHash: string,
+    missingFromDisk: boolean,
+  ): Promise<void> {
     const current = this.currentContent();
     if (current === content) {
       this.lastWrittenHash = contentHash;
+      this.lastWrittenContent = content;
       return;
     }
 
-    applyMinimalTextSplice(this.text, current, content, this.doc);
+    const truncatedToEmpty = current.length > 0 && (missingFromDisk || content.length === 0);
+    const eventKind: DocumentSessionEvent['kind'] =
+      !truncatedToEmpty && current === this.lastWrittenContent
+        ? 'external-merge'
+        : 'external-change';
+
+    this.doc.transact(() => {
+      this.text.applyDelta(createFastDiffYTextDelta(current, content));
+    }, EXTERNAL_CHANGE_ORIGIN);
     this.lastWrittenHash = contentHash;
-    this.emitEvent('external-change');
+    // Mirrors the last materialized string; revisit resident memory cost before multi-file sessions.
+    this.lastWrittenContent = content;
+    this.emitEvent(eventKind);
   }
 
   private markPersistFailed(error: unknown): void {
@@ -386,41 +405,21 @@ function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && 'code' in error;
 }
 
-function applyMinimalTextSplice(
-  text: Y.Text,
-  current: string,
-  next: string,
-  doc: Y.Doc,
-): void {
-  let prefixLength = 0;
-  const maxPrefixLength = Math.min(current.length, next.length);
-  while (
-    prefixLength < maxPrefixLength &&
-    current.charCodeAt(prefixLength) === next.charCodeAt(prefixLength)
-  ) {
-    prefixLength += 1;
-  }
+export type YTextDeltaOperation =
+  | { retain: number }
+  | { insert: string }
+  | { delete: number };
 
-  let suffixLength = 0;
-  const maxSuffixLength = maxPrefixLength - prefixLength;
-  while (
-    suffixLength < maxSuffixLength &&
-    current.charCodeAt(current.length - suffixLength - 1) ===
-      next.charCodeAt(next.length - suffixLength - 1)
-  ) {
-    suffixLength += 1;
-  }
-
-  const deleteLength = current.length - prefixLength - suffixLength;
-  const inserted = next.slice(prefixLength, next.length - suffixLength);
-
-  doc.transact(() => {
-    if (deleteLength > 0) {
-      text.delete(prefixLength, deleteLength);
+export function createFastDiffYTextDelta(current: string, next: string): YTextDeltaOperation[] {
+  return diff(current, next).map(([operation, value]) => {
+    if (operation === diff.EQUAL) {
+      return { retain: value.length };
     }
 
-    if (inserted.length > 0) {
-      text.insert(prefixLength, inserted);
+    if (operation === diff.INSERT) {
+      return { insert: value };
     }
-  }, EXTERNAL_CHANGE_ORIGIN);
+
+    return { delete: value.length };
+  });
 }

--- a/packages/doc-session/src/websocket.test.ts
+++ b/packages/doc-session/src/websocket.test.ts
@@ -71,7 +71,7 @@ describe('Yjs WebSocket session', () => {
     await session.close();
   });
 
-  it('reconciles external file changes and broadcasts the event to every client', async () => {
+  it('reconciles idle external file changes and broadcasts the quiet merge event to every client', async () => {
     const filePath = join(kb2Home, 'demo-vault', 'hello-world.md');
     const session = new OneFileDocumentSession(filePath, {
       defaultContent: 'initial\n',
@@ -103,7 +103,7 @@ describe('Yjs WebSocket session', () => {
     await writeFile(filePath, 'changed outside\n', 'utf8');
 
     await waitForSharedContent([clientA, clientB], (content) => content === 'changed outside\n');
-    await waitForSessionEvent([clientA, clientB], 'external-change');
+    await waitForSessionEvent([clientA, clientB], 'external-merge');
 
     clientA.close();
     clientB.close();

--- a/packages/ui/src/lib/notifications/DocumentSaveBanner.stories.ts
+++ b/packages/ui/src/lib/notifications/DocumentSaveBanner.stories.ts
@@ -6,6 +6,12 @@ import DocumentSaveBanner, {
 const noop = () => undefined;
 
 const fixtures = {
+  externalMergeNotice: {
+    variant: 'external-merge',
+    title: 'External edit merged',
+    message: 'Merged an edit made outside KB-2.',
+    ondismiss: noop,
+  },
   externalChangeNotice: {
     variant: 'external-change',
     title: 'Document changed elsewhere',
@@ -33,7 +39,7 @@ const meta = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['external-change', 'persist-failure', 'persist-recovered'],
+      options: ['external-merge', 'external-change', 'persist-failure', 'persist-recovered'],
     },
   },
 } satisfies Meta<typeof DocumentSaveBanner>;
@@ -43,6 +49,10 @@ type Story = StoryObj<typeof meta>;
 
 export const ExternalChangeNotice: Story = {
   args: fixtures.externalChangeNotice,
+};
+
+export const ExternalMergeNotice: Story = {
+  args: fixtures.externalMergeNotice,
 };
 
 export const PersistFailureAlarm: Story = {

--- a/packages/ui/src/lib/notifications/DocumentSaveBanner.svelte
+++ b/packages/ui/src/lib/notifications/DocumentSaveBanner.svelte
@@ -2,6 +2,7 @@
   import type { IconName } from '../primitives/types';
 
   export type DocumentSaveBannerVariant =
+    | 'external-merge'
     | 'external-change'
     | 'persist-failure'
     | 'persist-recovered';
@@ -26,6 +27,13 @@
   }
 
   const variantConfig: Record<DocumentSaveBannerVariant, VariantConfig> = {
+    'external-merge': {
+      title: 'External edit merged',
+      message: 'Merged an edit made outside KB-2.',
+      icon: 'refresh',
+      role: 'status',
+      ariaLive: 'polite',
+    },
     'external-change': {
       title: 'Document changed elsewhere',
       message: 'A newer version is available. Review it before continuing to edit.',
@@ -162,6 +170,13 @@
     --banner-bg: color-mix(in srgb, var(--rd-sky-bg) 32%, var(--rd-panel));
     --banner-border: color-mix(in srgb, var(--rd-sky) 28%, var(--rd-rule));
     --banner-icon-bg: color-mix(in srgb, var(--rd-sky-bg) 70%, var(--rd-panel));
+  }
+
+  .variant-external-merge {
+    --banner-accent: var(--rd-live);
+    --banner-bg: color-mix(in srgb, var(--rd-live-bg) 34%, var(--rd-panel));
+    --banner-border: color-mix(in srgb, var(--rd-live) 24%, var(--rd-rule));
+    --banner-icon-bg: color-mix(in srgb, var(--rd-live-bg) 70%, var(--rd-panel));
   }
 
   .variant-persist-failure {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
 
   packages/doc-session:
     dependencies:
+      fast-diff:
+        specifier: 1.3.0
+        version: 1.3.0
       lib0:
         specifier: 0.2.117
         version: 0.2.117
@@ -1686,6 +1689,9 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3800,6 +3806,8 @@ snapshots:
       '@types/estree': 1.0.9
 
   expect-type@1.3.0: {}
+
+  fast-diff@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Replace the hand-rolled `applyMinimalTextSplice` path with exact-pinned `fast-diff` mapped directly to `Y.Text.applyDelta`.
- Track `lastWrittenContent` so idle external edits emit quiet `external-merge`, while raced edits and truncation keep the loud `external-change` path.
- Add the quiet banner variant, Storybook fixture, provider/protocol plumbing, and focused reconcile coverage.

## Verification
- `pnpm --filter @kb-2/doc-session test`
- `pnpm --filter @kb-2/doc-session typecheck`
- `pnpm check`
- Fresh Engineer audit: no findings; focused doc-session tests passed.
- Real Chrome two-tab verification on temp `KB2_HOME=/tmp/kb2-fast-diff-browser-Csk0f5`, private daemon port `7482`, private web port `5273`:
  - idle external edit converged in both tabs and showed quiet `Merged an edit made outside KB-2.` notice, then auto-dismissed;
  - rapid typing race showed loud `File changed outside KB-2` banner in both tabs;
  - truncation showed loud banner in both tabs and emptied editor content.

## Notes
- Graphite submit was unavailable because this renamed repo is not currently synced with Graphite, so this PR was opened via GitHub CLI.
- `pnpm check` still reports the pre-existing Svelte warning in `PlaintextEditor.svelte` about nested class declaration; no errors.