### PR TITLE
Graduate tunnel-protocol From the Cloud-002 Relay Spike

### DIFF
--- a/packages/tunnel-protocol/package.json
+++ b/packages/tunnel-protocol/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@kb-2/tunnel-protocol",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "vitest": "4.1.8"
+  }
+}

--- a/packages/tunnel-protocol/project.json
+++ b/packages/tunnel-protocol/project.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "tunnel-protocol",
+  "sourceRoot": "packages/tunnel-protocol/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/tunnel-protocol build"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/tunnel-protocol test"
+      }
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/tunnel-protocol typecheck"
+      }
+    }
+  }
+}

--- a/packages/tunnel-protocol/src/index.test.ts
+++ b/packages/tunnel-protocol/src/index.test.ts
@@ -1,0 +1,21 @@
+import {
+  TUNNEL_PROTOCOL_VERSION,
+  decodeTunnelMessage,
+  encodeTunnelMessage
+} from "./index.js";
+
+it("round-trips an HTTP response envelope", () => {
+  const message = {
+    type: "http.response",
+    id: "req-1",
+    status: 200,
+    headers: { "content-type": "text/plain" },
+    bodyB64: "b2s="
+  } as const;
+
+  expect(decodeTunnelMessage(encodeTunnelMessage(message))).toEqual(message);
+});
+
+it("carries the spike protocol version", () => {
+  expect(TUNNEL_PROTOCOL_VERSION).toBe(1);
+});

--- a/packages/tunnel-protocol/src/index.ts
+++ b/packages/tunnel-protocol/src/index.ts
@@ -1,0 +1,84 @@
+export const TUNNEL_PROTOCOL_VERSION = 1 as const;
+
+export type TunnelProtocolVersion = typeof TUNNEL_PROTOCOL_VERSION;
+
+export type TunnelRole = "control" | "dialback";
+
+export type TunnelControlClientHello = {
+  type: "control.hello";
+  version: TunnelProtocolVersion;
+  token: string;
+};
+
+export type TunnelControlServerReady = {
+  type: "control.ready";
+  version: TunnelProtocolVersion;
+};
+
+export type TunnelControlServerError = {
+  type: "control.error";
+  code: "unauthorized" | "unsupported-version" | "bad-message" | "relay-error";
+  message: string;
+};
+
+export type TunnelHttpRequestEnvelope = {
+  type: "http.request";
+  id: string;
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  bodyB64: string | null;
+};
+
+export type TunnelHttpResponseEnvelope = {
+  type: "http.response";
+  id: string;
+  status: number;
+  headers: Record<string, string>;
+  bodyB64: string | null;
+};
+
+export type TunnelWebSocketOpenEnvelope = {
+  type: "ws.open";
+  streamId: string;
+  path: string;
+  headers: Record<string, string>;
+};
+
+export type TunnelWebSocketDialbackHello = {
+  type: "ws.dialback.hello";
+  version: TunnelProtocolVersion;
+  token: string;
+  streamId: string;
+};
+
+export type TunnelControlClientMessage =
+  | TunnelControlClientHello
+  | TunnelHttpResponseEnvelope;
+
+export type TunnelControlServerMessage =
+  | TunnelControlServerReady
+  | TunnelControlServerError
+  | TunnelHttpRequestEnvelope
+  | TunnelWebSocketOpenEnvelope;
+
+export type TunnelDialbackClientMessage = TunnelWebSocketDialbackHello;
+
+export type TunnelJsonMessage =
+  | TunnelControlClientMessage
+  | TunnelControlServerMessage
+  | TunnelDialbackClientMessage;
+
+export function encodeTunnelMessage(message: TunnelJsonMessage): string {
+  return JSON.stringify(message);
+}
+
+export function decodeTunnelMessage(data: string): TunnelJsonMessage {
+  const parsed: unknown = JSON.parse(data);
+
+  if (!parsed || typeof parsed !== "object" || !("type" in parsed)) {
+    throw new Error("Tunnel message must be an object with a type");
+  }
+
+  return parsed as TunnelJsonMessage;
+}

--- a/packages/tunnel-protocol/tsconfig.build.json
+++ b/packages/tunnel-protocol/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": []
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/tunnel-protocol/tsconfig.json
+++ b/packages/tunnel-protocol/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/tunnel-protocol/vitest.config.ts
+++ b/packages/tunnel-protocol/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node"
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,12 @@ importers:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/tunnel-protocol:
+    devDependencies:
+      vitest:
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/ui:
     dependencies:
       clsx:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,6 +7,7 @@
       "@kb-2/doc-session": ["./packages/doc-session/src/index.ts"],
       "@kb-2/doc-session/protocol": ["./packages/doc-session/src/protocol.ts"],
       "@kb-2/editor": ["./packages/editor/src/lib/index.ts"],
+      "@kb-2/tunnel-protocol": ["./packages/tunnel-protocol/src/index.ts"],
       "@kb-2/ui": ["./packages/ui/src/lib/index.ts"]
     },
     "strict": true,


### PR DESCRIPTION
Adds `packages/tunnel-protocol` (control/dial-back envelope types + handshake, with tests) from the proven `cloud-002-spike` branch, plus its tsconfig path wiring. The spike's findings: kb-1-cloud `docs/spikes/cloud-002-relay-findings.md` (GO verdict, edge-verified). The spike client stays on the spike branch; the real daemon-side client arrives with the relay prototype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)