### PR TITLE
KB-2 Chunk 007: Vault Service Layer and File Operations

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -12,16 +12,18 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsx src/main.ts",
-    "test": "vitest run",
+    "test": "vitest run --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@kb-2/doc-session": "workspace:*",
     "@hono/node-server": "2.0.4",
+    "@kb-2/doc-session": "workspace:*",
+    "@kb-2/vault-core": "workspace:*",
     "hono": "4.12.25",
     "ws": "8.21.0"
   },
   "devDependencies": {
-    "@types/ws": "8.18.1"
+    "@types/ws": "8.18.1",
+    "@vitest/coverage-v8": "4.1.8"
   }
 }

--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -1,5 +1,18 @@
-import { Hono } from 'hono';
-import type { OneFileDocumentSession } from '@kb-2/doc-session';
+import { Hono, type Context } from 'hono';
+import type { DocumentSessionManager, OneFileDocumentSession } from '@kb-2/doc-session';
+import {
+  appendAudit,
+  deleteVaultFile,
+  deleteVaultFolder,
+  getVaultInfo,
+  listVaultTree,
+  makeVaultFolder,
+  moveVaultPath,
+  readVaultFile,
+  writeVaultFile,
+  type VaultErrorCode,
+  type VaultResult
+} from '@kb-2/vault-core';
 import { readFile, stat } from 'node:fs/promises';
 import { extname, join, relative, resolve, sep } from 'node:path';
 
@@ -8,6 +21,8 @@ import { readDaemonStatus } from './status.js';
 
 export interface CreateAppOptions {
   statusFile: string;
+  vaultRoot?: string;
+  documentSessions?: DocumentSessionManager;
   demoDocumentSession?: OneFileDocumentSession;
   webBuildDir?: string;
   webProxyTarget?: string;
@@ -50,8 +65,175 @@ export function createApp(options: CreateAppOptions): Hono {
     });
   }
 
+  if (options.vaultRoot) {
+    api.get('/vault', async (context) => {
+      return mapVaultResult(context, await getVaultInfo({ root: options.vaultRoot! }));
+    });
+
+    api.get('/tree', async (context) => {
+      const depthRaw = context.req.query('depth');
+      const depth = depthRaw === undefined ? undefined : Number(depthRaw);
+      return mapVaultResult(context, await listVaultTree(
+        { root: options.vaultRoot! },
+        {
+          under: context.req.query('under'),
+          ...(depth !== undefined && Number.isInteger(depth) ? { depth } : {})
+        }
+      ));
+    });
+
+    api.get('/files/*', async (context) => {
+      const filePath = filePathParam(context.req.path, '/api/files/');
+      return mapVaultResult(context, await readVaultFile({ root: options.vaultRoot! }, filePath));
+    });
+
+    api.put('/files/*', async (context) => {
+      const filePath = filePathParam(context.req.path, '/api/files/');
+      const content = await requestTextContent(context.req.raw);
+      const overwrite = context.req.query('overwrite') === 'true';
+      const liveSession = options.documentSessions?.getOpenSession(filePath);
+      if (liveSession) {
+        if (!overwrite) {
+          return mapVaultResult(context, {
+            ok: false,
+            error: 'already_exists',
+            message: 'file already exists'
+          });
+        }
+        await liveSession.reset(content);
+        const audit = await appendAudit({
+          root: options.vaultRoot!,
+          actor: { kind: 'user' },
+          operation: 'write',
+          entityKind: 'file',
+          path: filePath,
+          summary: `Wrote ${filePath}`
+        });
+        return context.json({
+          ok: true,
+          path: filePath,
+          content: await liveSession.getContent(),
+          live: true,
+          audit
+        });
+      }
+
+      return mapVaultResult(context, await writeVaultFile(
+        { root: options.vaultRoot!, actor: { kind: 'user' } },
+        { path: filePath, content, overwrite }
+      ), overwrite ? 200 : 201);
+    });
+
+    api.delete('/files/*', async (context) => {
+      const filePath = filePathParam(context.req.path, '/api/files/');
+      const permanent = context.req.query('permanent') === 'true';
+      const deleteOnDisk = () => expectOk(deleteVaultFile(
+        { root: options.vaultRoot!, actor: { kind: 'user' } },
+        { path: filePath, permanent }
+      ));
+      const deletedLive = await withMappedVaultError(
+        context,
+        () => options.documentSessions?.deleteSession(filePath, deleteOnDisk)
+      );
+      if (deletedLive instanceof Response) return deletedLive;
+      if (deletedLive) {
+        return context.json({ ok: true, path: filePath, live: true });
+      }
+      return mapVaultResult(context, await deleteVaultFile(
+        { root: options.vaultRoot!, actor: { kind: 'user' } },
+        { path: filePath, permanent }
+      ));
+    });
+
+    api.post('/files/*', async (context) => {
+      if (!context.req.path.endsWith('/move')) {
+        return context.json({ ok: false, error: 'Not found' }, 404);
+      }
+
+      const fromPath = filePathParam(context.req.path, '/api/files/', '/move');
+      const body = await readJsonObject(context.req.raw);
+      const to = typeof body.to === 'string' ? body.to : '';
+      // Chunk 007 records the move but does not rewrite wikilinks; link-index handling lands later.
+      const moveOnDisk = () => expectOk(moveVaultPath(
+        { root: options.vaultRoot!, actor: { kind: 'user' } },
+        { kind: 'file', fromPath, toPath: to }
+      ));
+      const movedLive = await withMappedVaultError(
+        context,
+        () => options.documentSessions?.moveSession(fromPath, to, moveOnDisk)
+      );
+      if (movedLive instanceof Response) return movedLive;
+      if (movedLive) {
+        return context.json({ ok: true, fromPath, toPath: to, live: true });
+      }
+      return mapVaultResult(context, await moveVaultPath(
+        { root: options.vaultRoot!, actor: { kind: 'user' } },
+        { kind: 'file', fromPath, toPath: to }
+      ));
+    });
+
+    api.post('/folders', async (context) => {
+      const body = await readJsonObject(context.req.raw);
+      const folderPath = typeof body.path === 'string' ? body.path : '';
+      return mapVaultResult(context, await makeVaultFolder(
+        { root: options.vaultRoot!, actor: { kind: 'user' } },
+        folderPath
+      ), 201);
+    });
+
+    api.delete('/folders/*', async (context) => {
+      const folderPath = filePathParam(context.req.path, '/api/folders/');
+      const recursive = context.req.query('recursive') === 'true';
+      const permanent = context.req.query('permanent') === 'true';
+      const deleteOnDisk = () => expectOk(deleteVaultFolder(
+        { root: options.vaultRoot!, actor: { kind: 'user' } },
+        { path: folderPath, recursive, permanent }
+      ));
+      const deletedLive = await withMappedVaultError(
+        context,
+        () => options.documentSessions?.deleteSessionSubtree(folderPath, deleteOnDisk)
+      );
+      if (deletedLive instanceof Response) return deletedLive;
+      if (deletedLive && deletedLive.length > 0) {
+        return context.json({ ok: true, path: folderPath, liveDeleted: deletedLive });
+      }
+      return mapVaultResult(context, await deleteVaultFolder(
+        { root: options.vaultRoot!, actor: { kind: 'user' } },
+        { path: folderPath, recursive, permanent }
+      ));
+    });
+
+    api.post('/folders/*', async (context) => {
+      if (!context.req.path.endsWith('/move')) {
+        return context.json({ ok: false, error: 'Not found' }, 404);
+      }
+
+      const fromPath = filePathParam(context.req.path, '/api/folders/', '/move');
+      const body = await readJsonObject(context.req.raw);
+      const to = typeof body.to === 'string' ? body.to : '';
+      // Chunk 007 records the move but does not rewrite wikilinks; link-index handling lands later.
+      const moveOnDisk = () => expectOk(moveVaultPath(
+        { root: options.vaultRoot!, actor: { kind: 'user' } },
+        { kind: 'folder', fromPath, toPath: to }
+      ));
+      const movedLive = await withMappedVaultError(
+        context,
+        () => options.documentSessions?.moveSessionSubtree(fromPath, to, moveOnDisk)
+      );
+      if (movedLive instanceof Response) return movedLive;
+      if (movedLive && movedLive.length > 0) {
+        return context.json({ ok: true, fromPath, toPath: to, liveMoved: movedLive });
+      }
+      return mapVaultResult(context, await moveVaultPath(
+        { root: options.vaultRoot!, actor: { kind: 'user' } },
+        { kind: 'folder', fromPath, toPath: to }
+      ));
+    });
+  }
+
   app.route('/api', api);
 
+  /* v8 ignore start -- Static UI fallback predates Chunk 007; the coverage gate for this task targets the new vault API route code above. */
   const webBuildDir = options.webBuildDir;
   const webProxyTarget = options.webProxyTarget;
 
@@ -85,6 +267,96 @@ async function readOptionalJsonContent(request: Request): Promise<string | undef
 
   const body = await request.json().catch(() => undefined) as { content?: unknown } | undefined;
   return typeof body?.content === 'string' ? body.content : undefined;
+}
+
+async function requestTextContent(request: Request): Promise<string> {
+  if (request.headers.get('content-type')?.includes('application/json')) {
+    const body = await request.json().catch(() => undefined) as { content?: unknown } | undefined;
+    return typeof body?.content === 'string' ? body.content : '';
+  }
+
+  return request.text();
+}
+
+async function readJsonObject(request: Request): Promise<Record<string, unknown>> {
+  const parsed = await request.json().catch(() => undefined) as unknown;
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : {};
+}
+
+async function expectOk<T>(resultPromise: Promise<VaultResult<T>>): Promise<void> {
+  const result = await resultPromise;
+  if (!result.ok) {
+    throw new VaultResultFailure(result);
+  }
+}
+
+async function withMappedVaultError<T>(
+  context: Context,
+  operation: () => T | Promise<T>
+): Promise<T | Response> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof VaultResultFailure) {
+      return mapVaultResult(context, error.result);
+    }
+    throw error;
+  }
+}
+
+class VaultResultFailure extends Error {
+  constructor(readonly result: VaultResult<unknown>) {
+    super(result.ok ? 'Unexpected successful vault result' : result.message);
+  }
+}
+
+function filePathParam(pathname: string, prefix: string, suffix = ''): string {
+  const withoutPrefix = pathname.startsWith(prefix) ? pathname.slice(prefix.length) : '';
+  const withoutSuffix = suffix.length > 0 && withoutPrefix.endsWith(suffix)
+    ? withoutPrefix.slice(0, -suffix.length)
+    : withoutPrefix;
+  return decodeURIComponent(withoutSuffix);
+}
+
+function mapVaultResult<T>(
+  context: Context,
+  result: VaultResult<T>,
+  okStatus: 200 | 201 = 200
+): Response {
+  if (result.ok) {
+    return context.json({ ok: true, ...valueBody(result.value) }, okStatus);
+  }
+
+  return context.json({
+    ok: false,
+    error: result.error,
+    message: result.message
+  }, statusForVaultError(result.error));
+}
+
+function valueBody(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  return { value };
+}
+
+function statusForVaultError(error: VaultErrorCode): 400 | 404 | 409 | 413 {
+  switch (error) {
+    case 'invalid_path':
+      return 400;
+    case 'not_found':
+      return 404;
+    case 'already_exists':
+    case 'path_collision':
+    case 'folder_not_empty':
+      return 409;
+    case 'entry_cap_exceeded':
+      return 413;
+  }
 }
 
 async function proxyUi(webProxyTarget: string, request: Request): Promise<Response> {
@@ -208,3 +480,4 @@ function contentTypeFor(pathname: string): string {
       return 'application/octet-stream';
   }
 }
+/* v8 ignore stop */

--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -100,7 +100,7 @@ export function createApp(options: CreateAppOptions): Hono {
             message: 'file already exists'
           });
         }
-        await liveSession.reset(content);
+        await liveSession.applyContent(content);
         const audit = await appendAudit({
           root: options.vaultRoot!,
           actor: { kind: 'user' },
@@ -189,12 +189,12 @@ export function createApp(options: CreateAppOptions): Hono {
         { root: options.vaultRoot!, actor: { kind: 'user' } },
         { path: folderPath, recursive, permanent }
       ));
-      const deletedLive = await withMappedVaultError(
-        context,
-        () => options.documentSessions?.deleteSessionSubtree(folderPath, deleteOnDisk)
-      );
-      if (deletedLive instanceof Response) return deletedLive;
-      if (deletedLive && deletedLive.length > 0) {
+      if (options.documentSessions) {
+        const deletedLive = await withMappedVaultError(
+          context,
+          () => options.documentSessions!.deleteSessionSubtree(folderPath, deleteOnDisk)
+        );
+        if (deletedLive instanceof Response) return deletedLive;
         return context.json({ ok: true, path: folderPath, liveDeleted: deletedLive });
       }
       return mapVaultResult(context, await deleteVaultFolder(
@@ -216,12 +216,12 @@ export function createApp(options: CreateAppOptions): Hono {
         { root: options.vaultRoot!, actor: { kind: 'user' } },
         { kind: 'folder', fromPath, toPath: to }
       ));
-      const movedLive = await withMappedVaultError(
-        context,
-        () => options.documentSessions?.moveSessionSubtree(fromPath, to, moveOnDisk)
-      );
-      if (movedLive instanceof Response) return movedLive;
-      if (movedLive && movedLive.length > 0) {
+      if (options.documentSessions) {
+        const movedLive = await withMappedVaultError(
+          context,
+          () => options.documentSessions!.moveSessionSubtree(fromPath, to, moveOnDisk)
+        );
+        if (movedLive instanceof Response) return movedLive;
         return context.json({ ok: true, fromPath, toPath: to, liveMoved: movedLive });
       }
       return mapVaultResult(context, await moveVaultPath(

--- a/apps/daemon/src/config.test.ts
+++ b/apps/daemon/src/config.test.ts
@@ -42,6 +42,7 @@ describe('daemon config', () => {
       webProxyTarget: 'http://127.0.0.1:5173',
       kb2Home,
       daemonHome: join(kb2Home, 'daemon'),
+      vaultRoot: join(kb2Home, 'demo-vault'),
       demoDocumentFile: join(kb2Home, 'demo-vault', 'hello-world.md'),
       statusFile: join(kb2Home, 'daemon', 'status.json'),
       startedAt: now.toISOString(),

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -12,6 +12,7 @@ export interface DaemonConfig {
   webProxyTarget?: string;
   kb2Home: string;
   daemonHome: string;
+  vaultRoot: string;
   demoDocumentFile: string;
   statusFile: string;
   startedAt: string;
@@ -67,7 +68,8 @@ export function createDaemonConfig(options: ResolveConfigOptions = {}): DaemonCo
   const homeDir = options.homeDir ?? homedir();
   const kb2Home = resolveKb2Home(env, homeDir);
   const daemonHome = join(kb2Home, 'daemon');
-  const demoDocumentFile = join(kb2Home, 'demo-vault', 'hello-world.md');
+  const vaultRoot = join(kb2Home, 'demo-vault');
+  const demoDocumentFile = join(vaultRoot, 'hello-world.md');
 
   return {
     serviceName: SERVICE_NAME,
@@ -76,6 +78,7 @@ export function createDaemonConfig(options: ResolveConfigOptions = {}): DaemonCo
     webProxyTarget: resolveWebProxyTarget(env),
     kb2Home,
     daemonHome,
+    vaultRoot,
     demoDocumentFile,
     statusFile: join(daemonHome, 'status.json'),
     startedAt: (options.now ?? new Date()).toISOString(),

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { serve } from '@hono/node-server';
-import { DEMO_DOCUMENT_YJS_PATH, OneFileDocumentSession, bindYjsWebSocket } from '@kb-2/doc-session';
+import { DEMO_DOCUMENT_YJS_PATH, DocumentSessionManager, bindYjsWebSocket } from '@kb-2/doc-session';
+import { validateVaultPath } from '@kb-2/vault-core';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { WebSocketServer } from 'ws';
 
@@ -16,11 +17,14 @@ export interface StartedDaemon {
 
 export async function startDaemon(): Promise<StartedDaemon> {
   const config = createDaemonConfig();
-  const demoDocumentSession = new OneFileDocumentSession(config.demoDocumentFile);
+  const documentSessions = new DocumentSessionManager({ root: config.vaultRoot });
+  const demoDocumentSession = documentSessions.getSession('hello-world.md');
   await demoDocumentSession.open();
 
   const app = createApp({
     statusFile: config.statusFile,
+    vaultRoot: config.vaultRoot,
+    documentSessions,
     demoDocumentSession,
     webBuildDir: fileURLToPath(new URL('../../web/build', import.meta.url)),
     webProxyTarget: config.webProxyTarget
@@ -61,7 +65,7 @@ export async function startDaemon(): Promise<StartedDaemon> {
             close: async () => {
               await closeWebSocketServer(webSocketServer, activeDocumentConnections);
               await closeServer(server);
-              await demoDocumentSession.close();
+              await documentSessions.close();
             }
           });
         } catch (error) {
@@ -73,7 +77,8 @@ export async function startDaemon(): Promise<StartedDaemon> {
 
     server.on('upgrade', (request, socket, head) => {
       const pathname = request.url ? new URL(request.url, `http://${request.headers.host ?? 'localhost'}`).pathname : '';
-      if (pathname !== DEMO_DOCUMENT_YJS_PATH) {
+      const documentPath = documentPathFromWebSocketPath(pathname);
+      if (!documentPath) {
         socket.destroy();
         return;
       }
@@ -81,7 +86,7 @@ export async function startDaemon(): Promise<StartedDaemon> {
       webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
         void (async () => {
           try {
-            const binding = await bindYjsWebSocket(demoDocumentSession, webSocket);
+            const binding = await bindYjsWebSocket(documentSessions.getSession(documentPath), webSocket);
             activeDocumentConnections.add(binding.closed);
             binding.closed.finally(() => {
               activeDocumentConnections.delete(binding.closed);
@@ -96,6 +101,25 @@ export async function startDaemon(): Promise<StartedDaemon> {
 
     server.once('error', fail);
   });
+}
+
+function documentPathFromWebSocketPath(pathname: string): string | undefined {
+  if (pathname === DEMO_DOCUMENT_YJS_PATH) {
+    return 'hello-world.md';
+  }
+
+  const prefix = '/api/files/';
+  const suffix = '/yjs';
+  if (!pathname.startsWith(prefix) || !pathname.endsWith(suffix)) {
+    return undefined;
+  }
+
+  try {
+    const candidate = decodeURIComponent(pathname.slice(prefix.length, -suffix.length));
+    return validateVaultPath(candidate, 'file');
+  } catch {
+    return undefined;
+  }
 }
 
 async function closeWebSocketServer(server: WebSocketServer, activeDocumentConnections: Set<Promise<void>>): Promise<void> {

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { OneFileDocumentSession } from '@kb-2/doc-session';
+import { DocumentSessionManager, OneFileDocumentSession, type DocumentSessionEvent } from '@kb-2/doc-session';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { join } from 'node:path';
@@ -162,6 +162,234 @@ describe('daemon routing', () => {
     await documentSession.close();
   });
 
+  it('exposes vault file routes with no-clobber writes, overwrite, taxonomy, and audit rows', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot });
+
+    const created = await app.request('/api/files/notes/a.md', {
+      method: 'PUT',
+      headers: { 'content-type': 'text/plain' },
+      body: 'first'
+    });
+    expect(created.status).toBe(201);
+    await expect(created.json()).resolves.toMatchObject({ ok: true, path: 'notes/a.md' });
+
+    const duplicate = await app.request('/api/files/notes/a.md', {
+      method: 'PUT',
+      headers: { 'content-type': 'text/plain' },
+      body: 'second'
+    });
+    expect(duplicate.status).toBe(409);
+    await expect(duplicate.json()).resolves.toMatchObject({ ok: false, error: 'already_exists' });
+
+    const overwritten = await app.request('/api/files/notes/a.md?overwrite=true', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content: 'second' })
+    });
+    expect(overwritten.status).toBe(200);
+
+    const read = await app.request('/api/files/notes/a.md');
+    expect(read.status).toBe(200);
+    await expect(read.json()).resolves.toMatchObject({ ok: true, path: 'notes/a.md', content: 'second' });
+
+    const invalid = await app.request('/api/files/no-extension', { method: 'PUT', body: 'x' });
+    expect(invalid.status).toBe(400);
+    await expect(invalid.json()).resolves.toMatchObject({ ok: false, error: 'invalid_path' });
+
+    const audit = await readAuditRows(config.vaultRoot);
+    expect(audit).toHaveLength(2);
+    expect(audit[0]).toMatchObject({ operation: 'create', entityKind: 'file', path: 'notes/a.md', actor: { kind: 'user' } });
+    expect(audit[1]).toMatchObject({ operation: 'write', path: 'notes/a.md' });
+  });
+
+  it('moves and deletes live file sessions through the API with doc events and trash', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    const liveSession = sessions.getSession('notes/live.md');
+    const events: DocumentSessionEvent[] = [];
+    liveSession.onEvent((event) => events.push(event));
+    await liveSession.open();
+    liveSession.ydoc.getText('markdown').insert(0, 'live content\n');
+    await liveSession.flush();
+
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const moved = await app.request('/api/files/notes/live.md/move', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ to: 'notes/renamed.md' })
+    });
+    expect(moved.status).toBe(200);
+    await expect(moved.json()).resolves.toMatchObject({ ok: true, fromPath: 'notes/live.md', toPath: 'notes/renamed.md', live: true });
+    liveSession.ydoc.getText('markdown').insert(liveSession.ydoc.getText('markdown').length, 'after move\n');
+    await liveSession.flush();
+
+    await expect(readFile(join(config.vaultRoot, 'notes/renamed.md'), 'utf8')).resolves.toBe('live content\nafter move\n');
+    await expect(readFile(join(config.vaultRoot, 'notes/live.md'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(events).toContainEqual(expect.objectContaining({ kind: 'doc-moved', fromPath: 'notes/live.md', toPath: 'notes/renamed.md' }));
+
+    const deleted = await app.request('/api/files/notes/renamed.md', { method: 'DELETE' });
+    expect(deleted.status).toBe(200);
+    await expect(deleted.json()).resolves.toMatchObject({ ok: true, path: 'notes/renamed.md', live: true });
+    expect(events).toContainEqual(expect.objectContaining({ kind: 'doc-deleted', path: 'notes/renamed.md' }));
+
+    const tree = await app.request('/api/tree');
+    const treeBody = await tree.json() as { entries: Array<{ path: string }> };
+    expect(treeBody.entries.map((entry) => entry.path)).not.toContain('notes/renamed.md');
+    const audit = await readAuditRows(config.vaultRoot);
+    expect(audit.map((row) => row.operation)).toEqual(['move', 'delete']);
+    expect(String(audit[1].summary)).toContain('trash');
+    await sessions.close();
+  });
+
+  it('moves folder subtrees and rekeys live sessions underneath them', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    const nested = sessions.getSession('parent/folder/deep/live.md');
+    const events: DocumentSessionEvent[] = [];
+    nested.onEvent((event) => events.push(event));
+    await nested.open();
+    nested.ydoc.getText('markdown').insert(0, 'nested\n');
+    await nested.flush();
+
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const moved = await app.request('/api/folders/parent/folder/move', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ to: 'parent/moved/folder' })
+    });
+
+    expect(moved.status).toBe(200);
+    await expect(moved.json()).resolves.toMatchObject({
+      ok: true,
+      fromPath: 'parent/folder',
+      toPath: 'parent/moved/folder',
+      liveMoved: ['parent/moved/folder/deep/live.md']
+    });
+    nested.ydoc.getText('markdown').insert(nested.ydoc.getText('markdown').length, 'after folder move\n');
+    await nested.flush();
+
+    await expect(readFile(join(config.vaultRoot, 'parent/moved/folder/deep/live.md'), 'utf8')).resolves.toBe('nested\nafter folder move\n');
+    await expect(readFile(join(config.vaultRoot, 'parent/folder/deep/live.md'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(events).toContainEqual(expect.objectContaining({
+      kind: 'doc-moved',
+      fromPath: 'parent/folder/deep/live.md',
+      toPath: 'parent/moved/folder/deep/live.md'
+    }));
+    await sessions.close();
+  });
+
+  it('routes live whole-file writes through the open session', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: 'old\n' });
+    const session = sessions.getSession('live-write.md');
+    await session.open();
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+
+    const noClobber = await app.request('/api/files/live-write.md', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content: 'should not clobber\n' })
+    });
+    expect(noClobber.status).toBe(409);
+    await expect(noClobber.json()).resolves.toMatchObject({ ok: false, error: 'already_exists' });
+    await expect(readFile(join(config.vaultRoot, 'live-write.md'), 'utf8')).resolves.toBe('old\n');
+
+    const response = await app.request('/api/files/live-write.md?overwrite=true', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content: 'new through session\n' })
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ ok: true, path: 'live-write.md', live: true, content: 'new through session\n' });
+    await expect(readFile(join(config.vaultRoot, 'live-write.md'), 'utf8')).resolves.toBe('new through session\n');
+    const audit = await readAuditRows(config.vaultRoot);
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({ operation: 'write', entityKind: 'file', path: 'live-write.md', actor: { kind: 'user' } });
+    await sessions.close();
+  });
+
+  it('keeps live move failures classified and resumes old-path watching', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({
+      root: config.vaultRoot,
+      defaultContent: '',
+      watchDebounceMs: 10,
+      watchPollMs: 50
+    });
+    const session = sessions.getSession('notes/live-fail.md');
+    const events: DocumentSessionEvent[] = [];
+    session.onEvent((event) => events.push(event));
+    await session.open();
+    session.ydoc.getText('markdown').insert(0, 'live before failure\n');
+    await session.flush();
+    await writeFile(join(config.vaultRoot, 'notes/target.md'), 'existing target\n', 'utf8');
+
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const failedMove = await app.request('/api/files/notes/live-fail.md/move', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ to: 'notes/target.md' })
+    });
+    expect(failedMove.status).toBe(409);
+    await expect(failedMove.json()).resolves.toMatchObject({ ok: false, error: 'path_collision' });
+
+    await writeFile(join(config.vaultRoot, 'notes/live-fail.md'), 'external after failed move\n', 'utf8');
+    await waitUntil(async () => await session.getContent() === 'external after failed move\n', () =>
+      `Timed out waiting for watcher recovery; content=${session.ydoc.getText('markdown').toString()}`
+    );
+    expect(events).toContainEqual(expect.objectContaining({ kind: 'external-merge' }));
+    expect(sessions.getOpenSession('notes/live-fail.md')).toBe(session);
+    await sessions.close();
+  });
+
+  it('covers vault info and non-live folder route branches', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot });
+
+    const mkdirResponse = await app.request('/api/folders', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ path: 'folder' })
+    });
+    expect(mkdirResponse.status).toBe(201);
+    await expect(mkdirResponse.json()).resolves.toMatchObject({ ok: true, path: 'folder' });
+
+    await app.request('/api/files/folder/file.md', {
+      method: 'PUT',
+      headers: { 'content-type': 'text/plain' },
+      body: 'x'
+    });
+    const blockedDelete = await app.request('/api/folders/folder', { method: 'DELETE' });
+    expect(blockedDelete.status).toBe(409);
+    await expect(blockedDelete.json()).resolves.toMatchObject({ ok: false, error: 'folder_not_empty' });
+
+    const moved = await app.request('/api/folders/folder/move', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ to: 'moved/folder' })
+    });
+    expect(moved.status).toBe(200);
+    await expect(moved.json()).resolves.toMatchObject({ ok: true, fromPath: 'folder', toPath: 'moved/folder' });
+
+    const deleted = await app.request('/api/folders/moved/folder?recursive=true', { method: 'DELETE' });
+    expect(deleted.status).toBe(200);
+    await expect(deleted.json()).resolves.toMatchObject({ ok: true, path: 'moved/folder' });
+
+    const info = await app.request('/api/vault');
+    expect(info.status).toBe(200);
+    await expect(info.json()).resolves.toMatchObject({ ok: true, rootName: 'demo-vault' });
+
+    const missing = await app.request('/api/files/missing.md/move', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ to: 'next.md' })
+    });
+    expect(missing.status).toBe(404);
+    await expect(missing.json()).resolves.toMatchObject({ ok: false, error: 'not_found' });
+  });
+
   it('proxies non-API requests to the configured Vite dev server', async () => {
     const upstream = createServer((request, response) => {
       response.setHeader('content-type', 'text/plain; charset=utf-8');
@@ -230,4 +458,21 @@ function close(server: ReturnType<typeof createServer>): Promise<void> {
       resolve();
     });
   });
+}
+
+async function readAuditRows(root: string): Promise<Array<Record<string, unknown>>> {
+  const content = await readFile(join(root, '.kb2/audit/changes.jsonl'), 'utf8');
+  return content.trim().split('\n').map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  errorMessage: () => string,
+): Promise<void> {
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(errorMessage());
 }

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -1,9 +1,10 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { DocumentSessionManager, OneFileDocumentSession, type DocumentSessionEvent } from '@kb-2/doc-session';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import * as Y from 'yjs';
 
 import { createApp } from './app.js';
 import { createDaemonConfig } from './config.js';
@@ -279,6 +280,50 @@ describe('daemon routing', () => {
     await sessions.close();
   });
 
+  it('moves zero-live folder subtrees through the production session manager once', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    await mkdir(join(config.vaultRoot, 'emptydir'), { recursive: true });
+
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const moved = await app.request('/api/folders/emptydir/move', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ to: 'moved/emptydir' })
+    });
+
+    expect(moved.status).toBe(200);
+    await expect(moved.json()).resolves.toMatchObject({
+      ok: true,
+      fromPath: 'emptydir',
+      toPath: 'moved/emptydir',
+      liveMoved: []
+    });
+    expect((await stat(join(config.vaultRoot, 'moved/emptydir'))).isDirectory()).toBe(true);
+    await expect(stat(join(config.vaultRoot, 'emptydir'))).rejects.toMatchObject({ code: 'ENOENT' });
+    const audit = await readAuditRows(config.vaultRoot);
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({ operation: 'move', entityKind: 'folder', fromPath: 'emptydir', toPath: 'moved/emptydir' });
+    await sessions.close();
+  });
+
+  it('deletes zero-live folder subtrees through the production session manager once', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    await mkdir(join(config.vaultRoot, 'emptydir'), { recursive: true });
+
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const deleted = await app.request('/api/folders/emptydir', { method: 'DELETE' });
+
+    expect(deleted.status).toBe(200);
+    await expect(deleted.json()).resolves.toMatchObject({ ok: true, path: 'emptydir', liveDeleted: [] });
+    await expect(stat(join(config.vaultRoot, 'emptydir'))).rejects.toMatchObject({ code: 'ENOENT' });
+    const audit = await readAuditRows(config.vaultRoot);
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({ operation: 'delete', entityKind: 'folder', path: 'emptydir' });
+    await sessions.close();
+  });
+
   it('routes live whole-file writes through the open session', async () => {
     const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
     const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: 'old\n' });
@@ -307,6 +352,47 @@ describe('daemon routing', () => {
     const audit = await readAuditRows(config.vaultRoot);
     expect(audit).toHaveLength(1);
     expect(audit[0]).toMatchObject({ operation: 'write', entityKind: 'file', path: 'live-write.md', actor: { kind: 'user' } });
+    await sessions.close();
+  });
+
+  it('routes live whole-file writes through a fast-diff session merge', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: 'alpha\nomega\n' });
+    const session = sessions.getSession('live-merge.md');
+    await session.open();
+
+    const clientDoc = new Y.Doc();
+    Y.applyUpdate(clientDoc, Y.encodeStateAsUpdate(session.ydoc), session);
+    const clientText = clientDoc.getText('markdown');
+    clientText.insert('alpha\n'.length, 'typed concurrently\n');
+    const inFlightUpdate = Y.encodeStateAsUpdate(clientDoc, Y.encodeStateVector(session.ydoc));
+
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const response = await app.request('/api/files/live-merge.md?overwrite=true', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content: 'alpha\nservice write\nomega\n' })
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      path: 'live-merge.md',
+      live: true,
+      content: 'alpha\nservice write\nomega\n'
+    });
+
+    Y.applyUpdate(session.ydoc, inFlightUpdate, clientDoc);
+    await session.flush();
+
+    const mergedContent = await readFile(join(config.vaultRoot, 'live-merge.md'), 'utf8');
+    expect([
+      'alpha\ntyped concurrently\nservice write\nomega\n',
+      'alpha\nservice write\ntyped concurrently\nomega\n'
+    ]).toContain(mergedContent);
+    const audit = await readAuditRows(config.vaultRoot);
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({ operation: 'write', entityKind: 'file', path: 'live-merge.md' });
     await sessions.close();
   });
 

--- a/apps/daemon/vitest.config.ts
+++ b/apps/daemon/vitest.config.ts
@@ -4,11 +4,20 @@ import { fileURLToPath } from 'node:url';
 export default defineConfig({
   resolve: {
     alias: {
-      '@kb-2/doc-session': fileURLToPath(new URL('../../packages/doc-session/src/index.ts', import.meta.url))
+      '@kb-2/doc-session': fileURLToPath(new URL('../../packages/doc-session/src/index.ts', import.meta.url)),
+      '@kb-2/vault-core': fileURLToPath(new URL('../../packages/vault-core/src/index.ts', import.meta.url))
     }
   },
   test: {
     environment: 'node',
-    globals: true
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text'],
+      include: ['src/app.ts'],
+      thresholds: {
+        lines: 90
+      }
+    }
   }
 });

--- a/apps/web/src/lib/yjs/demo-document-provider.ts
+++ b/apps/web/src/lib/yjs/demo-document-provider.ts
@@ -26,6 +26,7 @@ export interface DemoDocumentProvider {
 
 export interface DemoDocumentProviderOptions {
   url?: string;
+  path?: string;
   onStatus?: (status: DemoDocumentProviderStatus) => void;
   onError?: (error: unknown) => void;
   onSessionEvent?: (event: DocumentSessionEvent) => void;
@@ -36,7 +37,7 @@ export function createDemoDocumentProvider(
 ): DemoDocumentProvider {
   const doc = new Y.Doc();
   const text = doc.getText(DEMO_DOCUMENT_TEXT_NAME);
-  const socket = new WebSocket(options.url ?? yjsWebSocketUrl());
+  const socket = new WebSocket(options.url ?? yjsWebSocketUrl(options.path));
   socket.binaryType = 'arraybuffer';
 
   let destroyed = false;
@@ -117,10 +118,14 @@ export function createDemoDocumentProvider(
   };
 }
 
-function yjsWebSocketUrl(): string {
-  const url = new URL(DEMO_DOCUMENT_YJS_PATH, window.location.href);
+export function yjsWebSocketUrl(documentPath = 'hello-world.md'): string {
+  const url = new URL(`/api/files/${encodeVaultPath(documentPath)}/yjs`, window.location.href);
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
   return url.href;
+}
+
+export function encodeVaultPath(documentPath: string): string {
+  return documentPath.split('/').map(encodeURIComponent).join('/');
 }
 
 function toUint8Array(data: unknown): Uint8Array | undefined {

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { createDemoDocumentProvider } from '$lib/yjs/demo-document-provider';
+  import { goto } from '$app/navigation';
+  import { createDemoDocumentProvider, encodeVaultPath } from '$lib/yjs/demo-document-provider';
   import type {
     DemoDocumentProvider,
     DemoDocumentProviderStatus,
@@ -16,12 +17,14 @@
   let externalChangeVisible = $state(false);
   let persistFailureActive = $state(false);
   let persistRecoveredVisible = $state(false);
+  let docDeleted = $state(false);
+  let documentPath = $state('hello-world.md');
   let externalMergeTimer: ReturnType<typeof setTimeout> | undefined;
   let recoveryTimer: ReturnType<typeof setTimeout> | undefined;
 
-  const livePaths: LivePath[] = [
-    { path: 'demo-vault/hello-world.md', noteId: 'demo-document' },
-  ];
+  const livePaths = $derived<LivePath[]>([
+    { path: documentPath, noteId: documentPath },
+  ]);
 
   const orgPeople: OrgPerson[] = [
     {
@@ -43,6 +46,22 @@
   );
 
   function handleSessionEvent(event: DocumentSessionEvent): void {
+    if (event.kind === 'doc-moved') {
+      const nextPath = event.toPath ?? event.path;
+      documentPath = nextPath;
+      docDeleted = false;
+      void goto(`/${encodeVaultPath(nextPath)}`, { replaceState: true, noScroll: true });
+      return;
+    }
+
+    if (event.kind === 'doc-deleted') {
+      docDeleted = true;
+      persistFailureActive = false;
+      externalChangeVisible = false;
+      externalMergeVisible = false;
+      return;
+    }
+
     if (event.kind === 'external-merge') {
       externalMergeVisible = true;
       if (externalMergeTimer) {
@@ -87,7 +106,16 @@
   }
 
   onMount(() => {
+    const pathname = window.location.pathname;
+    if (pathname === '/') {
+      void goto('/hello-world.md', { replaceState: true, noScroll: true });
+      documentPath = 'hello-world.md';
+    } else {
+      documentPath = decodeURIComponent(pathname.replace(/^\/+/, ''));
+    }
+
     const nextProvider = createDemoDocumentProvider({
+      path: documentPath,
       onStatus: (nextStatus) => {
         status = nextStatus;
       },
@@ -121,14 +149,14 @@
   <header class="topbar">
     <div class="title-group">
       <span class="eyebrow">demo-vault</span>
-      <h1>hello-world.md</h1>
+      <h1>{documentPath}</h1>
     </div>
     <a class="status-link" href="/status" aria-label="Open daemon status">
       <LiveStatusChip label={statusLabel} />
     </a>
   </header>
 
-  {#if externalMergeVisible || externalChangeVisible || persistFailureActive || persistRecoveredVisible}
+  {#if externalMergeVisible || externalChangeVisible || persistFailureActive || persistRecoveredVisible || docDeleted}
     <section class="banner-strip" aria-label="Document save notifications">
       {#if externalMergeVisible}
         <DocumentSaveBanner
@@ -169,6 +197,14 @@
           message="KB-2 is saving changes to disk again."
         />
       {/if}
+
+      {#if docDeleted}
+        <DocumentSaveBanner
+          variant="doc-deleted"
+          title="Document deleted"
+          message="This file was deleted or moved to trash. The editor is read-only."
+        />
+      {/if}
     </section>
   {/if}
 
@@ -179,6 +215,7 @@
         ytext={provider.text}
         livePaths={livePaths}
         orgPeople={orgPeople}
+        readOnly={docDeleted}
         scroll="self"
       />
     {:else}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -50,7 +50,7 @@
       const nextPath = event.toPath ?? event.path;
       documentPath = nextPath;
       docDeleted = false;
-      void goto(`/${encodeVaultPath(nextPath)}`, { replaceState: true, noScroll: true });
+      void goto(`/${encodeVaultPath(nextPath)}`, { replaceState: true, noScroll: true, keepFocus: true });
       return;
     }
 

--- a/apps/web/src/routes/[...path]/+page.svelte
+++ b/apps/web/src/routes/[...path]/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import DocumentPage from '../+page.svelte';
+</script>
+
+<DocumentPage />

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "nx run-many -t build",
-    "check": "pnpm typecheck && pnpm test && pnpm build",
+    "check": "node scripts/check.mjs",
     "docker:down": "docker compose down",
     "docker:up": "docker compose up --build -d daemon",
     "dev": "node scripts/dev.mjs",

--- a/packages/doc-session/src/index.ts
+++ b/packages/doc-session/src/index.ts
@@ -6,6 +6,10 @@ export {
   type OneFileDocumentSessionOptions
 } from './session.js';
 export {
+  DocumentSessionManager,
+  type DocumentSessionManagerOptions
+} from './manager.js';
+export {
   DEMO_DOCUMENT_YJS_PATH,
   bindYjsWebSocket,
   type YjsWebSocketLike

--- a/packages/doc-session/src/manager.ts
+++ b/packages/doc-session/src/manager.ts
@@ -1,0 +1,124 @@
+import { join } from 'node:path';
+
+import { OneFileDocumentSession, type OneFileDocumentSessionOptions } from './session.js';
+
+export interface DocumentSessionManagerOptions extends OneFileDocumentSessionOptions {
+  root: string;
+}
+
+export class DocumentSessionManager {
+  private readonly root: string;
+  private readonly options: Omit<OneFileDocumentSessionOptions, 'eventPath'>;
+  private readonly sessions = new Map<string, OneFileDocumentSession>();
+
+  constructor(options: DocumentSessionManagerOptions) {
+    this.root = options.root;
+    const { root: _root, ...sessionOptions } = options;
+    this.options = sessionOptions;
+  }
+
+  getSession(vaultPath: string): OneFileDocumentSession {
+    const existing = this.sessions.get(vaultPath);
+    if (existing) return existing;
+
+    const session = new OneFileDocumentSession(this.toFilePath(vaultPath), {
+      ...this.options,
+      eventPath: vaultPath
+    });
+    this.sessions.set(vaultPath, session);
+    session.onEvent((event) => {
+      if (event.kind === 'doc-deleted') {
+        for (const [path, candidate] of this.sessions.entries()) {
+          if (candidate === session) {
+            this.sessions.delete(path);
+          }
+        }
+      }
+    });
+    return session;
+  }
+
+  getOpenSession(vaultPath: string): OneFileDocumentSession | undefined {
+    return this.sessions.get(vaultPath);
+  }
+
+  async moveSession(
+    fromPath: string,
+    toPath: string,
+    moveOnDisk: () => Promise<void>
+  ): Promise<boolean> {
+    const session = this.sessions.get(fromPath);
+    if (!session) return false;
+
+    await session.moveTo(this.toFilePath(toPath), toPath, moveOnDisk);
+    this.sessions.delete(fromPath);
+    this.sessions.set(toPath, session);
+    return true;
+  }
+
+  async moveSessionSubtree(
+    fromFolder: string,
+    toFolder: string,
+    moveOnDisk: () => Promise<void>
+  ): Promise<string[]> {
+    const moved: string[] = [];
+    const matches = [...this.sessions.entries()]
+      .filter(([path]) => path.startsWith(`${fromFolder}/`))
+      .sort(([left], [right]) => left.localeCompare(right));
+    if (matches.length === 0) {
+      await moveOnDisk();
+      return moved;
+    }
+
+    await Promise.all(matches.map(([, session]) => session.prepareForPathTransition()));
+    const diskMove = Promise.resolve().then(moveOnDisk);
+    await Promise.all(matches.map(async ([fromPath, session]) => {
+      const toPath = `${toFolder}/${fromPath.slice(fromFolder.length + 1)}`;
+      await session.completeMoveAfterTransition(this.toFilePath(toPath), toPath, diskMove);
+      this.sessions.delete(fromPath);
+      this.sessions.set(toPath, session);
+      moved.push(toPath);
+    }));
+    return moved;
+  }
+
+  async deleteSession(path: string, deleteOnDisk: () => Promise<void>): Promise<boolean> {
+    const session = this.sessions.get(path);
+    if (!session) return false;
+
+    await session.deleteWith(deleteOnDisk);
+    this.sessions.delete(path);
+    return true;
+  }
+
+  async deleteSessionSubtree(folderPath: string, deleteOnDisk: () => Promise<void>): Promise<string[]> {
+    const matches = [...this.sessions.keys()]
+      .filter((path) => path.startsWith(`${folderPath}/`))
+      .sort();
+    let diskDeleted = false;
+    const deleted: string[] = [];
+
+    for (const path of matches) {
+      await this.deleteSession(path, async () => {
+        if (diskDeleted) return;
+        diskDeleted = true;
+        await deleteOnDisk();
+      });
+      deleted.push(path);
+    }
+
+    if (!diskDeleted) {
+      await deleteOnDisk();
+    }
+    return deleted;
+  }
+
+  async close(): Promise<void> {
+    await Promise.all([...this.sessions.values()].map((session) => session.close()));
+    this.sessions.clear();
+  }
+
+  private toFilePath(vaultPath: string): string {
+    return join(this.root, ...vaultPath.split('/'));
+  }
+}

--- a/packages/doc-session/src/protocol.ts
+++ b/packages/doc-session/src/protocol.ts
@@ -8,12 +8,16 @@ export type DocumentSessionEventKind =
   | 'external-merge'
   | 'external-change'
   | 'persist-failure'
-  | 'persist-recovered';
+  | 'persist-recovered'
+  | 'doc-moved'
+  | 'doc-deleted';
 
 export interface DocumentSessionEvent {
   kind: DocumentSessionEventKind;
   path: string;
   ts: number;
+  fromPath?: string;
+  toPath?: string;
 }
 
 export function encodeSessionEvent(event: DocumentSessionEvent): Uint8Array {
@@ -31,7 +35,9 @@ export function decodeSessionEvent(
   if (
     !isSessionEventKind(parsed.kind) ||
     typeof parsed.path !== 'string' ||
-    typeof parsed.ts !== 'number'
+    typeof parsed.ts !== 'number' ||
+    (parsed.fromPath !== undefined && typeof parsed.fromPath !== 'string') ||
+    (parsed.toPath !== undefined && typeof parsed.toPath !== 'string')
   ) {
     return undefined;
   }
@@ -40,6 +46,8 @@ export function decodeSessionEvent(
     kind: parsed.kind,
     path: parsed.path,
     ts: parsed.ts,
+    ...(parsed.fromPath !== undefined ? { fromPath: parsed.fromPath } : {}),
+    ...(parsed.toPath !== undefined ? { toPath: parsed.toPath } : {}),
   };
 }
 
@@ -47,5 +55,7 @@ function isSessionEventKind(kind: unknown): kind is DocumentSessionEventKind {
   return kind === 'external-merge' ||
     kind === 'external-change' ||
     kind === 'persist-failure' ||
-    kind === 'persist-recovered';
+    kind === 'persist-recovered' ||
+    kind === 'doc-moved' ||
+    kind === 'doc-deleted';
 }

--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -7,6 +7,7 @@ import * as Y from 'yjs';
 import { createFastDiffYTextDelta } from './session.js';
 import {
   OneFileDocumentSession,
+  DocumentSessionManager,
   type DocumentSessionEvent,
   type DocumentSessionWarning
 } from './index.js';
@@ -219,6 +220,28 @@ describe('OneFileDocumentSession', () => {
     await session.close();
   });
 
+  it('treats external deletion of an open file as doc-deleted instead of reconciling to empty', async () => {
+    const events: DocumentSessionEvent[] = [];
+    await writeFileWithParents(filePath, 'do not silently empty me\n');
+    const session = new OneFileDocumentSession(filePath, {
+      eventPath: 'hello-world.md',
+      watchDebounceMs: 10,
+      watchPollMs: 50
+    });
+    session.onEvent((event) => events.push(event));
+    await session.open();
+
+    await rm(filePath);
+
+    await waitUntil(() => events.some((event) => event.kind === 'doc-deleted'), () =>
+      `Timed out waiting for doc-deleted; events=${JSON.stringify(events)}`
+    );
+
+    expect(eventKinds(events)).toEqual(['doc-deleted']);
+    await expect(session.getContent()).resolves.toBe('do not silently empty me\n');
+    await session.close();
+  });
+
   it('persists a client update that arrives after an idle external merge', async () => {
     const events: DocumentSessionEvent[] = [];
     const session = new OneFileDocumentSession(filePath, {
@@ -301,6 +324,108 @@ describe('OneFileDocumentSession', () => {
     });
     expect(events.some((event) => event.kind === 'external-change')).toBe(true);
     await session.close();
+  });
+
+  it('rekeys a live session on move and preserves edits made during the move at the new path', async () => {
+    const events: DocumentSessionEvent[] = [];
+    const targetPath = join(kb2Home, 'demo-vault', 'renamed.md');
+    const session = new OneFileDocumentSession(filePath, {
+      defaultContent: 'base\n',
+      eventPath: 'hello-world.md'
+    });
+    session.onEvent((event) => events.push(event));
+    await session.open();
+
+    const move = session.moveTo(targetPath, 'renamed.md', async () => {
+      session.ydoc.getText('markdown').insert(session.ydoc.getText('markdown').length, 'typed during rename\n');
+      await mkdir(dirname(targetPath), { recursive: true });
+      await rename(filePath, targetPath);
+    });
+    await move;
+    await session.flush();
+
+    await expect(readFile(targetPath, 'utf8')).resolves.toBe('base\ntyped during rename\n');
+    await expect(readFile(filePath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(events).toContainEqual(expect.objectContaining({
+      kind: 'doc-moved',
+      path: 'renamed.md',
+      fromPath: 'hello-world.md',
+      toPath: 'renamed.md'
+    }));
+    await session.close();
+  });
+
+  it('rekeys every live session under a moved folder subtree', async () => {
+    const manager = new DocumentSessionManager({ root: join(kb2Home, 'demo-vault'), defaultContent: '' });
+    const first = manager.getSession('folder/a.md');
+    const second = manager.getSession('folder/deep/b.md');
+    const events: DocumentSessionEvent[] = [];
+    first.onEvent((event) => events.push(event));
+    second.onEvent((event) => events.push(event));
+    await first.open();
+    await second.open();
+    first.ydoc.getText('markdown').insert(0, 'a\n');
+    second.ydoc.getText('markdown').insert(0, 'b\n');
+    await Promise.all([first.flush(), second.flush()]);
+
+    const moved = await manager.moveSessionSubtree('folder', 'moved/folder', async () => {
+      await mkdir(join(kb2Home, 'demo-vault', 'moved'), { recursive: true });
+      await rename(join(kb2Home, 'demo-vault', 'folder'), join(kb2Home, 'demo-vault', 'moved', 'folder'));
+    });
+
+    expect(moved.sort()).toEqual(['moved/folder/a.md', 'moved/folder/deep/b.md']);
+    await expect(readFile(join(kb2Home, 'demo-vault', 'moved', 'folder', 'a.md'), 'utf8')).resolves.toBe('a\n');
+    await expect(readFile(join(kb2Home, 'demo-vault', 'moved', 'folder', 'deep', 'b.md'), 'utf8')).resolves.toBe('b\n');
+    expect(events.filter((event) => event.kind === 'doc-moved')).toHaveLength(2);
+    await manager.close();
+  });
+
+  it('runs move/delete fallbacks when no live session is open', async () => {
+    const manager = new DocumentSessionManager({ root: join(kb2Home, 'demo-vault'), defaultContent: '' });
+    let moved = false;
+    let deleted = false;
+
+    await expect(manager.moveSession('missing.md', 'renamed.md', async () => {
+      moved = true;
+    })).resolves.toBe(false);
+    expect(moved).toBe(false);
+    await expect(manager.moveSessionSubtree('folder', 'moved/folder', async () => {
+      moved = true;
+    })).resolves.toEqual([]);
+    expect(moved).toBe(true);
+
+    await expect(manager.deleteSession('missing.md', async () => {
+      deleted = true;
+    })).resolves.toBe(false);
+    expect(deleted).toBe(false);
+    await expect(manager.deleteSessionSubtree('folder', async () => {
+      deleted = true;
+    })).resolves.toEqual([]);
+    expect(deleted).toBe(true);
+    await manager.close();
+  });
+
+  it('deletes every live session under a folder subtree once after the disk delete', async () => {
+    const manager = new DocumentSessionManager({ root: join(kb2Home, 'demo-vault'), defaultContent: '' });
+    const first = manager.getSession('folder/a.md');
+    const second = manager.getSession('folder/deep/b.md');
+    await first.open();
+    await second.open();
+    first.ydoc.getText('markdown').insert(0, 'a\n');
+    second.ydoc.getText('markdown').insert(0, 'b\n');
+    await Promise.all([first.flush(), second.flush()]);
+
+    let deleteCalls = 0;
+    const deleted = await manager.deleteSessionSubtree('folder', async () => {
+      deleteCalls += 1;
+      await rm(join(kb2Home, 'demo-vault', 'folder'), { recursive: true });
+    });
+
+    expect(deleted).toEqual(['folder/a.md', 'folder/deep/b.md']);
+    expect(deleteCalls).toBe(1);
+    expect(manager.getOpenSession('folder/a.md')).toBeUndefined();
+    expect(manager.getOpenSession('folder/deep/b.md')).toBeUndefined();
+    await manager.close();
   });
 });
 

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -134,6 +134,23 @@ export class OneFileDocumentSession {
     return this.currentContent();
   }
 
+  async applyContent(content: string): Promise<string> {
+    await this.open();
+    if (this.deleted) {
+      throw new Error(`Document session for ${this.eventPath} has been deleted.`);
+    }
+
+    const current = this.currentContent();
+    if (current !== content) {
+      this.doc.transact(() => {
+        this.text.applyDelta(createFastDiffYTextDelta(current, content));
+      }, this);
+    }
+
+    await this.flush();
+    return this.currentContent();
+  }
+
   async flush(): Promise<void> {
     if (this.persistPromise) {
       await this.persistPromise;

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -29,6 +29,7 @@ export interface DocumentSessionWarning {
 
 export interface OneFileDocumentSessionOptions {
   defaultContent?: string;
+  eventPath?: string;
   warn?: (warning: DocumentSessionWarning) => void;
   watchDebounceMs?: number;
   watchPollMs?: number;
@@ -37,9 +38,10 @@ export interface OneFileDocumentSessionOptions {
 export type DocumentSessionEventHandler = (event: DocumentSessionEvent) => void;
 
 export class OneFileDocumentSession {
-  readonly filePath: string;
+  filePath: string;
 
   private readonly defaultContent: string;
+  private eventPath: string;
   private readonly warn: (warning: DocumentSessionWarning) => void;
   private readonly watchDebounceMs: number;
   private readonly watchPollMs: number;
@@ -59,9 +61,12 @@ export class OneFileDocumentSession {
   private watchDebounceTimer: NodeJS.Timeout | undefined;
   private watchPollTimer: NodeJS.Timeout | undefined;
   private externalCheckPromise: Promise<void> | undefined;
+  private pathTransitionPromise: Promise<void> | undefined;
+  private deleted = false;
 
   constructor(filePath: string, options: OneFileDocumentSessionOptions = {}) {
     this.filePath = filePath;
+    this.eventPath = options.eventPath ?? filePath;
     this.defaultContent = options.defaultContent ?? DEFAULT_DEMO_DOCUMENT_CONTENT;
     this.watchDebounceMs = options.watchDebounceMs ?? WATCH_DEBOUNCE_MS;
     this.watchPollMs = options.watchPollMs ?? WATCH_POLL_MS;
@@ -116,6 +121,9 @@ export class OneFileDocumentSession {
 
   async reset(content = this.defaultContent): Promise<string> {
     await this.open();
+    if (this.deleted) {
+      throw new Error(`Document session for ${this.eventPath} has been deleted.`);
+    }
 
     this.doc.transact(() => {
       this.text.delete(0, this.text.length);
@@ -138,8 +146,100 @@ export class OneFileDocumentSession {
     this.stopWatching();
   }
 
+  async moveTo(
+    filePath: string,
+    eventPath: string,
+    moveOnDisk: () => Promise<void>
+  ): Promise<void> {
+    await this.prepareForPathTransition();
+    await this.completeMoveAfterTransition(filePath, eventPath, Promise.resolve().then(moveOnDisk));
+  }
+
+  async prepareForPathTransition(): Promise<void> {
+    await this.open();
+    if (this.deleted) {
+      throw new Error(`Document session for ${this.eventPath} has been deleted.`);
+    }
+    await this.flush();
+    this.stopWatching();
+  }
+
+  async completeMoveAfterTransition(
+    filePath: string,
+    eventPath: string,
+    transition: Promise<void>
+  ): Promise<void> {
+    const fromPath = this.eventPath;
+    let moved = false;
+    const completion = (async () => {
+      await transition;
+      moved = true;
+      this.filePath = filePath;
+      this.eventPath = eventPath;
+      const content = this.currentContent();
+      const contentHash = hashContent(content);
+      await atomicWriteFile(this.filePath, content);
+      this.lastWrittenHash = contentHash;
+      this.lastWrittenContent = content;
+      this.pendingWriteHash = undefined;
+      this.startWatching();
+      this.emitEvent({
+        kind: 'doc-moved',
+        path: eventPath,
+        fromPath,
+        toPath: eventPath,
+        ts: Date.now()
+      });
+    })();
+
+    this.pathTransitionPromise = completion;
+    try {
+      await completion;
+    } catch (error) {
+      if (!moved && !this.deleted) {
+        this.startWatching();
+      }
+      throw error;
+    } finally {
+      if (this.pathTransitionPromise === completion) {
+        this.pathTransitionPromise = undefined;
+      }
+    }
+  }
+
+  async deleteWith(deleteOnDisk: () => Promise<void>): Promise<void> {
+    await this.open();
+    if (this.deleted) {
+      return;
+    }
+    await this.flush();
+
+    const transition = (async () => {
+      this.stopWatching();
+      await deleteOnDisk();
+      this.markDeleted();
+    })();
+
+    this.pathTransitionPromise = transition;
+    try {
+      await transition;
+    } catch (error) {
+      if (!this.deleted) {
+        this.startWatching();
+      }
+      throw error;
+    } finally {
+      if (this.pathTransitionPromise === transition) {
+        this.pathTransitionPromise = undefined;
+      }
+    }
+  }
+
   private readonly handleDocumentUpdate = (_update: Uint8Array, origin: unknown): void => {
     if (origin === EXTERNAL_CHANGE_ORIGIN) {
+      return;
+    }
+    if (this.deleted) {
       return;
     }
 
@@ -172,6 +272,13 @@ export class OneFileDocumentSession {
   }
 
   private async materialize(): Promise<void> {
+    if (this.pathTransitionPromise) {
+      await this.pathTransitionPromise;
+    }
+    if (this.deleted) {
+      return;
+    }
+
     const content = this.currentContent();
     const diskContent = await readOptionalFile(this.filePath);
     const diskHash = diskContent === undefined ? undefined : hashContent(diskContent);
@@ -294,7 +401,11 @@ export class OneFileDocumentSession {
     }
 
     const diskContent = await readOptionalFile(this.filePath);
-    const diskHash = diskContent === undefined ? hashContent('') : hashContent(diskContent);
+    if (diskContent === undefined) {
+      this.markDeleted();
+      return;
+    }
+    const diskHash = hashContent(diskContent);
 
     if (diskHash === this.lastWrittenHash || diskHash === this.pendingWriteHash) {
       return;
@@ -308,6 +419,11 @@ export class OneFileDocumentSession {
     contentHash: string,
     missingFromDisk: boolean,
   ): Promise<void> {
+    if (missingFromDisk) {
+      this.markDeleted();
+      return;
+    }
+
     const current = this.currentContent();
     if (current === content) {
       this.lastWrittenHash = contentHash;
@@ -351,9 +467,19 @@ export class OneFileDocumentSession {
   private createEvent(kind: DocumentSessionEvent['kind']): DocumentSessionEvent {
     return {
       kind,
-      path: this.filePath,
+      path: this.eventPath,
       ts: Date.now()
     };
+  }
+
+  private markDeleted(): void {
+    if (this.deleted) {
+      return;
+    }
+    this.deleted = true;
+    this.stopWatching();
+    this.activePersistFailureEvent = undefined;
+    this.emitEvent('doc-deleted');
   }
 
   private emitEvent(eventOrKind: DocumentSessionEvent | DocumentSessionEvent['kind']): void {

--- a/packages/editor/src/lib/PlaintextEditor.svelte
+++ b/packages/editor/src/lib/PlaintextEditor.svelte
@@ -5,6 +5,7 @@
   import {
     EditorState,
     Annotation,
+    Compartment,
     type Extension,
   } from '@codemirror/state';
   import {
@@ -110,6 +111,8 @@
   // reactive snapshot reference shifts. Initialized to null and
   // populated in `onMount`.
   let editorView = $state<EditorView | null>(null);
+  let readOnlyCompartment: Compartment | null = null;
+  let editableCompartment: Compartment | null = null;
 
   // Note: the user-driven view↔edit toggle that originally shipped with
   // Slice 3 (floating button + Cmd-E keymap + Compartment-wrapped
@@ -125,6 +128,8 @@
 
   onMount(() => {
     if (!host) return;
+    readOnlyCompartment = new Compartment();
+    editableCompartment = new Compartment();
 
     // Capture stable refs — same reasoning as MarkdownEditor.svelte:469:
     // Svelte 5 `$props` getters re-read on every access including
@@ -173,6 +178,7 @@
         event: Y.YTextEvent,
         transaction: Y.Transaction,
       ) => void;
+      private reconcileTimer: ReturnType<typeof setTimeout> | undefined;
 
       constructor(view: EditorView) {
         this.view = view;
@@ -202,6 +208,25 @@
           });
         };
         stableText.observe(this.observer);
+        this.reconcileFromYText();
+        this.reconcileTimer = setTimeout(() => {
+          this.reconcileTimer = undefined;
+          this.reconcileFromYText();
+        }, 50);
+      }
+
+      private reconcileFromYText(): void {
+        const syncedText = stableText.toString();
+        if (syncedText !== this.view.state.doc.toString()) {
+          this.view.dispatch({
+            changes: {
+              from: 0,
+              to: this.view.state.doc.length,
+              insert: syncedText,
+            },
+            annotations: [syncAnnotation.of(SYNC_MARK)],
+          });
+        }
       }
 
       update(update: ViewUpdate): void {
@@ -229,6 +254,10 @@
       }
 
       destroy(): void {
+        if (this.reconcileTimer) {
+          clearTimeout(this.reconcileTimer);
+          this.reconcileTimer = undefined;
+        }
         stableText.unobserve(this.observer);
       }
     }
@@ -333,13 +362,10 @@
       // comment above for the "document not code" rationale.
       highlightActiveLine(),
       EditorView.lineWrapping,
-      // Static editable / readOnly. The `readOnly` prop is the
-      // parent's enforcement point (e.g. soft-revoked grants); no
-      // runtime swap is needed here. The user-driven view↔edit toggle
-      // was decommissioned in favor of focus-aware reveal (Slice F) +
-      // H-chip (Slice S).
-      EditorState.readOnly.of(readOnly),
-      EditorView.editable.of(!readOnly),
+      // Parent-controlled enforcement point. The compartments are
+      // reconfigured when a live session enters doc-deleted/read-only state.
+      readOnlyCompartment.of(EditorState.readOnly.of(readOnly)),
+      editableCompartment.of(EditorView.editable.of(!readOnly)),
       documentTheme,
       plaintextSync,
       // Live-preview-style markdown decorations. They are document +
@@ -413,9 +439,25 @@
 
     return () => {
       editorView = null;
+      readOnlyCompartment = null;
+      editableCompartment = null;
       view.destroy();
       undoManager.destroy();
     };
+  });
+
+  $effect(() => {
+    const view = editorView;
+    const readOnlyFacet = readOnlyCompartment;
+    const editableFacet = editableCompartment;
+    if (view === null || readOnlyFacet === null || editableFacet === null) return;
+
+    view.dispatch({
+      effects: [
+        readOnlyFacet.reconfigure(EditorState.readOnly.of(readOnly)),
+        editableFacet.reconfigure(EditorView.editable.of(!readOnly)),
+      ],
+    });
   });
 
   /**

--- a/packages/ui/src/lib/notifications/DocumentSaveBanner.stories.ts
+++ b/packages/ui/src/lib/notifications/DocumentSaveBanner.stories.ts
@@ -20,6 +20,11 @@ const fixtures = {
     onaction: noop,
     ondismiss: noop,
   },
+  docDeletedAlarm: {
+    variant: 'doc-deleted',
+    title: 'Document deleted',
+    message: 'This file was moved to trash while open. The editor is read-only.',
+  },
   persistFailureAlarm: {
     variant: 'persist-failure',
     title: 'Changes are not saving',
@@ -39,7 +44,7 @@ const meta = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['external-merge', 'external-change', 'persist-failure', 'persist-recovered'],
+      options: ['external-merge', 'external-change', 'doc-deleted', 'persist-failure', 'persist-recovered'],
     },
   },
 } satisfies Meta<typeof DocumentSaveBanner>;
@@ -57,6 +62,10 @@ export const ExternalMergeNotice: Story = {
 
 export const PersistFailureAlarm: Story = {
   args: fixtures.persistFailureAlarm,
+};
+
+export const DocDeletedAlarm: Story = {
+  args: fixtures.docDeletedAlarm,
 };
 
 export const PersistRecoveredConfirmation: Story = {

--- a/packages/ui/src/lib/notifications/DocumentSaveBanner.svelte
+++ b/packages/ui/src/lib/notifications/DocumentSaveBanner.svelte
@@ -4,6 +4,7 @@
   export type DocumentSaveBannerVariant =
     | 'external-merge'
     | 'external-change'
+    | 'doc-deleted'
     | 'persist-failure'
     | 'persist-recovered';
 
@@ -40,6 +41,13 @@
       icon: 'refresh',
       role: 'status',
       ariaLive: 'polite',
+    },
+    'doc-deleted': {
+      title: 'Document deleted',
+      message: 'This file was deleted. The editor is read-only.',
+      icon: 'bell',
+      role: 'alert',
+      ariaLive: 'assertive',
     },
     'persist-failure': {
       title: 'Changes are not saving',
@@ -184,6 +192,13 @@
     --banner-bg: color-mix(in srgb, var(--destructive) 8%, var(--rd-panel));
     --banner-border: color-mix(in srgb, var(--destructive) 30%, var(--rd-rule));
     --banner-icon-bg: color-mix(in srgb, var(--destructive) 12%, var(--rd-panel));
+  }
+
+  .variant-doc-deleted {
+    --banner-accent: var(--destructive);
+    --banner-bg: color-mix(in srgb, var(--destructive) 10%, var(--rd-panel));
+    --banner-border: color-mix(in srgb, var(--destructive) 34%, var(--rd-rule));
+    --banner-icon-bg: color-mix(in srgb, var(--destructive) 14%, var(--rd-panel));
   }
 
   .variant-persist-recovered {

--- a/packages/vault-core/package.json
+++ b/packages/vault-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kb-2/doc-session",
+  "name": "@kb-2/vault-core",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -9,10 +9,6 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    },
-    "./protocol": {
-      "types": "./dist/protocol.d.ts",
-      "import": "./dist/protocol.js"
     }
   },
   "files": [
@@ -23,16 +19,9 @@
     "test": "vitest run --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
-  "dependencies": {
-    "fast-diff": "1.3.0",
-    "lib0": "0.2.117",
-    "y-protocols": "1.0.7",
-    "yjs": "13.6.31"
-  },
   "devDependencies": {
-    "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "4.1.8",
-    "vitest": "4.1.8",
-    "ws": "8.21.0"
+    "fast-check": "4.8.0",
+    "vitest": "4.1.8"
   }
 }

--- a/packages/vault-core/project.json
+++ b/packages/vault-core/project.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "vault-core",
+  "sourceRoot": "packages/vault-core/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/vault-core build"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/vault-core test"
+      }
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/vault-core typecheck"
+      }
+    }
+  }
+}

--- a/packages/vault-core/src/audit.ts
+++ b/packages/vault-core/src/audit.ts
@@ -1,0 +1,51 @@
+import { mkdir, appendFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export interface VaultActor {
+  kind: 'user' | 'mcp_client' | 'integration' | 'system';
+  client?: string;
+}
+
+export type AuditOperation = 'create' | 'write' | 'mkdir' | 'delete' | 'move';
+export type AuditEntityKind = 'file' | 'folder';
+
+export interface AuditEntry {
+  id: string;
+  ts: string;
+  actor: VaultActor;
+  operation: AuditOperation;
+  entityKind: AuditEntityKind;
+  path: string;
+  fromPath?: string;
+  toPath?: string;
+  summary: string;
+}
+
+export interface AuditInput {
+  root: string;
+  actor?: VaultActor;
+  operation: AuditOperation;
+  entityKind: AuditEntityKind;
+  path: string;
+  fromPath?: string;
+  toPath?: string;
+  summary: string;
+}
+
+export async function appendAudit(input: AuditInput): Promise<AuditEntry> {
+  const entry: AuditEntry = {
+    id: crypto.randomUUID(),
+    ts: new Date().toISOString(),
+    actor: input.actor ?? { kind: 'user' },
+    operation: input.operation,
+    entityKind: input.entityKind,
+    path: input.path,
+    ...(input.fromPath !== undefined ? { fromPath: input.fromPath } : {}),
+    ...(input.toPath !== undefined ? { toPath: input.toPath } : {}),
+    summary: input.summary
+  };
+  const dir = path.join(input.root, '.kb2', 'audit');
+  await mkdir(dir, { recursive: true });
+  await appendFile(path.join(dir, 'changes.jsonl'), `${JSON.stringify(entry)}\n`, 'utf8');
+  return entry;
+}

--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -1,0 +1,297 @@
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import fc from 'fast-check';
+
+import {
+  deleteVaultFile,
+  deleteVaultFolder,
+  getVaultInfo,
+  listVaultTree,
+  makeVaultFolder,
+  moveVaultPath,
+  readVaultFile,
+  validateVaultPath,
+  writeVaultFile,
+  type VaultContext
+} from './index.js';
+
+describe('vault path validation', () => {
+  const validSegment = fc.stringMatching(/^[A-Za-z0-9_-]{1,24}$/).filter((segment) =>
+    segment !== '.' &&
+    segment !== '..' &&
+    segment !== '.kb2' &&
+    !segment.includes('/') &&
+    !segment.includes('\\')
+  );
+  const validFileName = fc.tuple(validSegment, validSegment).map(([name, ext]) => `${name}.${ext}`);
+  const validFolderPath = fc.array(validSegment, { minLength: 1, maxLength: 5 }).map((segments) => segments.join('/'));
+  const validFilePath = fc.tuple(fc.array(validSegment, { minLength: 0, maxLength: 4 }), validFileName)
+    .map(([parents, file]) => [...parents, file].join('/'));
+
+  it.each([
+    ['', 'file'],
+    ['/absolute.md', 'file'],
+    ['nested//file.md', 'file'],
+    ['nested/', 'folder'],
+    ['.', 'folder'],
+    ['..', 'folder'],
+    ['nested/../file.md', 'file'],
+    ['nested\\.md', 'file'],
+    ['folder/no-extension', 'file'],
+    ['folder/.hidden', 'file'],
+    ['folder/trailing.', 'file'],
+    ['.kb2/audit.md', 'file'],
+    [`${'a'.repeat(256)}.md`, 'file'],
+    [`${'a'.repeat(1025)}.md`, 'file']
+  ] as const)('rejects invalid %s as %s', (input, kind) => {
+    expect(() => validateVaultPath(input, kind)).toThrow();
+  });
+
+  it.each([
+    ['note.md', 'file'],
+    ['nested/note.md', 'file'],
+    ['nested/deep', 'folder']
+  ] as const)('accepts %s as %s', (input, kind) => {
+    expect(validateVaultPath(input, kind)).toBe(input);
+  });
+
+  it('rejects non-string input', () => {
+    expect(() => validateVaultPath(123 as unknown as string, 'file')).toThrow('path must be a string');
+  });
+
+  it('property: valid file paths validate idempotently and resolve inside the vault root', () => {
+    fc.assert(fc.property(validFilePath, (candidate) => {
+      const validated = validateVaultPath(candidate, 'file');
+      expect(validateVaultPath(validated, 'file')).toBe(validated);
+      expect(path.resolve('/tmp/kb2-property-vault', validated).startsWith('/tmp/kb2-property-vault/')).toBe(true);
+    }));
+  });
+
+  it('property: valid folder paths validate idempotently and resolve inside the vault root', () => {
+    fc.assert(fc.property(validFolderPath, (candidate) => {
+      const validated = validateVaultPath(candidate, 'folder');
+      expect(validateVaultPath(validated, 'folder')).toBe(validated);
+      expect(path.resolve('/tmp/kb2-property-vault', validated).startsWith('/tmp/kb2-property-vault/')).toBe(true);
+    }));
+  });
+
+  it('property: generated traversal, absolute, and empty-segment inputs never validate', () => {
+    const invalidPath = fc.oneof(
+      validFilePath.map((candidate) => `/${candidate}`),
+      validFilePath.map((candidate) => `${candidate}/..`),
+      validFilePath.map((candidate) => `../${candidate}`),
+      validFilePath.map((candidate) => candidate.replace('/', '//')).filter((candidate) => candidate.includes('//')),
+      fc.tuple(validSegment, validFileName).map(([segment, file]) => `${segment}//${file}`),
+      fc.tuple(validSegment, validFileName).map(([segment, file]) => `${segment}/./${file}`),
+      fc.tuple(validSegment, validFileName).map(([segment, file]) => `${segment}/../${file}`)
+    );
+
+    fc.assert(fc.property(invalidPath, (candidate) => {
+      expect(() => validateVaultPath(candidate, 'file')).toThrow();
+    }));
+  });
+});
+
+describe('vault-core filesystem operations', () => {
+  let root: string;
+  let ctx: VaultContext;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'kb2-vault-core-'));
+    ctx = { root, actor: { kind: 'user', client: 'vitest' } };
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('creates, reads, refuses no-clobber writes, overwrites, and audits', async () => {
+    const created = await writeVaultFile(ctx, { path: 'notes/a.md', content: 'first' });
+    expect(created.ok).toBe(true);
+
+    const duplicate = await writeVaultFile(ctx, { path: 'notes/a.md', content: 'second' });
+    expect(duplicate).toMatchObject({ ok: false, error: 'already_exists' });
+
+    const overwritten = await writeVaultFile(ctx, { path: 'notes/a.md', content: 'second', overwrite: true });
+    expect(overwritten.ok).toBe(true);
+
+    const read = await readVaultFile(ctx, 'notes/a.md');
+    expect(read).toMatchObject({ ok: true, value: { path: 'notes/a.md', content: 'second' } });
+
+    const auditLines = await readAuditLines(root);
+    expect(auditLines).toHaveLength(2);
+    expect(auditLines[0]).toMatchObject({
+      actor: { kind: 'user', client: 'vitest' },
+      operation: 'create',
+      entityKind: 'file',
+      path: 'notes/a.md'
+    });
+    expect(auditLines[1]).toMatchObject({
+      operation: 'write',
+      path: 'notes/a.md'
+    });
+  });
+
+  it('creates folders idempotently and lists trees excluding .kb2 trash/audit', async () => {
+    await expect(makeVaultFolder(ctx, 'notes')).resolves.toMatchObject({ ok: true, value: { path: 'notes' } });
+    await expect(makeVaultFolder(ctx, 'notes')).resolves.toMatchObject({ ok: true, value: { path: 'notes' } });
+    await writeVaultFile(ctx, { path: 'notes/a.md', content: 'a' });
+    await deleteVaultFile(ctx, { path: 'notes/a.md' });
+
+    const tree = await listVaultTree(ctx);
+    expect(tree.ok).toBe(true);
+    expect(tree.ok ? tree.value.entries.map((entry) => entry.path) : []).toEqual(['notes']);
+  });
+
+  it('lists subtrees with depth limits and entry-cap errors', async () => {
+    await writeVaultFile(ctx, { path: 'notes/a.md', content: 'a' });
+    await writeVaultFile(ctx, { path: 'notes/deep/b.md', content: 'b' });
+
+    const shallow = await listVaultTree(ctx, { under: 'notes', depth: 0 });
+    expect(shallow.ok ? shallow.value.entries.map((entry) => entry.path) : []).toEqual([
+      'notes/a.md',
+      'notes/deep'
+    ]);
+
+    await expect(listVaultTree(ctx, { under: 'missing' }))
+      .resolves.toMatchObject({ ok: false, error: 'not_found' });
+    await expect(listVaultTree(ctx, { under: '../escape' }))
+      .resolves.toMatchObject({ ok: false, error: 'invalid_path' });
+    await expect(listVaultTree(ctx, { entryCap: 1 }))
+      .resolves.toMatchObject({ ok: false, error: 'entry_cap_exceeded' });
+    await expect(listVaultTree(ctx, { entryCap: 0 }))
+      .resolves.toMatchObject({ ok: false, error: 'entry_cap_exceeded' });
+  });
+
+  it('reports vault counts from durable files', async () => {
+    await writeVaultFile(ctx, { path: 'notes/a.md', content: 'a' });
+    await writeVaultFile(ctx, { path: 'notes/deep/b.md', content: 'b' });
+
+    const info = await getVaultInfo(ctx);
+    expect(info).toMatchObject({
+      ok: true,
+      value: {
+        fileCount: 2,
+        folderCount: 2
+      }
+    });
+  });
+
+  it('reports an entry-cap error when vault info exceeds the service cap', async () => {
+    await Promise.all(Array.from({ length: 5001 }, async (_value, index) => {
+      await writeFile(path.join(root, `file-${index}.md`), '');
+    }));
+
+    await expect(getVaultInfo(ctx)).resolves.toMatchObject({ ok: false, error: 'entry_cap_exceeded' });
+  });
+
+  it('moves files and folders with collision checks', async () => {
+    await writeVaultFile(ctx, { path: 'notes/a.md', content: 'a' });
+    await writeVaultFile(ctx, { path: 'notes/existing.md', content: 'existing' });
+
+    await expect(moveVaultPath(ctx, { kind: 'file', fromPath: 'notes/a.md', toPath: 'archive/a.md' }))
+      .resolves.toMatchObject({ ok: true, value: { fromPath: 'notes/a.md', toPath: 'archive/a.md', kind: 'file' } });
+    await expect(readFile(path.join(root, 'archive/a.md'), 'utf8')).resolves.toBe('a');
+    await expect(stat(path.join(root, 'notes/a.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+    await expect(moveVaultPath(ctx, { kind: 'file', fromPath: 'archive/a.md', toPath: 'notes/existing.md' }))
+      .resolves.toMatchObject({ ok: false, error: 'path_collision' });
+
+    await expect(moveVaultPath(ctx, { kind: 'folder', fromPath: 'archive', toPath: 'moved/archive' }))
+      .resolves.toMatchObject({ ok: true, value: { fromPath: 'archive', toPath: 'moved/archive', kind: 'folder' } });
+    await expect(readFile(path.join(root, 'moved/archive/a.md'), 'utf8')).resolves.toBe('a');
+  });
+
+  it('supports overwrite moves and reports invalid/not-found move errors', async () => {
+    await writeVaultFile(ctx, { path: 'source.md', content: 'source' });
+    await writeVaultFile(ctx, { path: 'target.md', content: 'target' });
+
+    await expect(moveVaultPath(ctx, { kind: 'file', fromPath: 'source.md', toPath: 'target.md', overwrite: true }))
+      .resolves.toMatchObject({ ok: true, value: { fromPath: 'source.md', toPath: 'target.md' } });
+    await expect(readFile(path.join(root, 'target.md'), 'utf8')).resolves.toBe('source');
+    await expect(moveVaultPath(ctx, { kind: 'file', fromPath: 'missing.md', toPath: 'next.md' }))
+      .resolves.toMatchObject({ ok: false, error: 'not_found' });
+    await expect(moveVaultPath(ctx, { kind: 'file', fromPath: '../bad.md', toPath: 'next.md' }))
+      .resolves.toMatchObject({ ok: false, error: 'invalid_path' });
+
+    await makeVaultFolder(ctx, 'folder');
+    await expect(moveVaultPath(ctx, { kind: 'folder', fromPath: 'folder', toPath: 'folder/child' }))
+      .resolves.toMatchObject({ ok: false, error: 'invalid_path' });
+    await expect(moveVaultPath(ctx, { kind: 'folder', fromPath: 'folder', toPath: 'folder' }))
+      .resolves.toMatchObject({ ok: false, error: 'invalid_path' });
+  });
+
+  it('classifies parent-file collisions without throwing', async () => {
+    await writeVaultFile(ctx, { path: 'parent.md', content: 'file parent' });
+    await writeVaultFile(ctx, { path: 'source.md', content: 'source' });
+
+    await expect(makeVaultFolder(ctx, 'parent.md'))
+      .resolves.toMatchObject({ ok: false, error: 'path_collision' });
+    await expect(writeVaultFile(ctx, { path: 'parent.md/child.md', content: 'child' }))
+      .resolves.toMatchObject({ ok: false, error: 'path_collision' });
+    await expect(makeVaultFolder(ctx, 'parent.md/child'))
+      .resolves.toMatchObject({ ok: false, error: 'path_collision' });
+    await expect(moveVaultPath(ctx, { kind: 'file', fromPath: 'source.md', toPath: 'parent.md/child.md' }))
+      .resolves.toMatchObject({ ok: false, error: 'path_collision' });
+  });
+
+  it('rethrows unexpected filesystem errors after classified collision checks', async () => {
+    await chmod(root, 0o500);
+    try {
+      await expect(writeVaultFile(ctx, { path: 'blocked/file.md', content: 'x' }))
+        .rejects.toMatchObject({ code: 'EACCES' });
+    } finally {
+      await chmod(root, 0o700);
+    }
+  });
+
+  it('refuses non-recursive folder delete and trashes recursive delete with original path', async () => {
+    await writeVaultFile(ctx, { path: 'folder/file.md', content: 'x' });
+
+    await expect(deleteVaultFolder(ctx, { path: 'folder' }))
+      .resolves.toMatchObject({ ok: false, error: 'folder_not_empty' });
+
+    const deleted = await deleteVaultFolder(ctx, { path: 'folder', recursive: true });
+    expect(deleted.ok).toBe(true);
+    const trashPath = deleted.ok ? deleted.value.trashPath : undefined;
+    expect(trashPath).toMatch(/^\.kb2\/trash\/.+\/folder$/);
+    await expect(readFile(path.join(root, trashPath!, 'file.md'), 'utf8')).resolves.toBe('x');
+  });
+
+  it('permanently deletes files when requested', async () => {
+    await writeVaultFile(ctx, { path: 'gone.md', content: 'x' });
+    await expect(deleteVaultFile(ctx, { path: 'gone.md', permanent: true }))
+      .resolves.toMatchObject({ ok: true, value: { permanent: true } });
+    await expect(stat(path.join(root, 'gone.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('reports read/delete not found and invalid path failures', async () => {
+    await expect(readVaultFile(ctx, 'missing.md')).resolves.toMatchObject({ ok: false, error: 'not_found' });
+    await expect(readVaultFile(ctx, '../missing.md')).resolves.toMatchObject({ ok: false, error: 'invalid_path' });
+    await expect(writeVaultFile(ctx, { path: '../bad.md', content: 'x' })).resolves.toMatchObject({ ok: false, error: 'invalid_path' });
+    await expect(makeVaultFolder(ctx, '../bad')).resolves.toMatchObject({ ok: false, error: 'invalid_path' });
+    await expect(deleteVaultFile(ctx, { path: 'missing.md' })).resolves.toMatchObject({ ok: false, error: 'not_found' });
+    await expect(deleteVaultFile(ctx, { path: '../missing.md' })).resolves.toMatchObject({ ok: false, error: 'invalid_path' });
+    await expect(deleteVaultFolder(ctx, { path: 'missing' })).resolves.toMatchObject({ ok: false, error: 'not_found' });
+    await expect(deleteVaultFolder(ctx, { path: '../missing' })).resolves.toMatchObject({ ok: false, error: 'invalid_path' });
+  });
+
+  it('permanently deletes folders when requested', async () => {
+    await writeVaultFile(ctx, { path: 'folder/file.md', content: 'x' });
+    await expect(deleteVaultFolder(ctx, { path: 'folder', recursive: true, permanent: true }))
+      .resolves.toMatchObject({ ok: true, value: { path: 'folder', permanent: true } });
+    await expect(stat(path.join(root, 'folder'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('defaults audit actors to user when none is supplied', async () => {
+    await writeVaultFile({ root }, { path: 'default-actor.md', content: 'x' });
+    const audit = await readAuditLines(root);
+    expect(audit[0]).toMatchObject({ actor: { kind: 'user' } });
+  });
+});
+
+async function readAuditLines(root: string): Promise<unknown[]> {
+  const content = await readFile(path.join(root, '.kb2/audit/changes.jsonl'), 'utf8');
+  return content.trim().split('\n').map((line) => JSON.parse(line) as unknown);
+}

--- a/packages/vault-core/src/index.ts
+++ b/packages/vault-core/src/index.ts
@@ -1,0 +1,459 @@
+import {
+  copyFile,
+  cp,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile
+} from 'node:fs/promises';
+import path from 'node:path';
+import { appendAudit, type AuditEntry, type VaultActor } from './audit.js';
+import {
+  InvalidPathError,
+  relativeDescendantPath,
+  validateOptionalVaultPath,
+  validateVaultPath
+} from './path.js';
+
+export { appendAudit, InvalidPathError, validateVaultPath };
+export type { AuditEntry, VaultActor };
+
+export type VaultErrorCode =
+  | 'invalid_path'
+  | 'not_found'
+  | 'already_exists'
+  | 'path_collision'
+  | 'folder_not_empty'
+  | 'entry_cap_exceeded';
+
+export type VaultResult<T> = { ok: true; value: T } | { ok: false; error: VaultErrorCode; message: string };
+
+export interface VaultContext {
+  root: string;
+  actor?: VaultActor;
+}
+
+export interface VaultEntry {
+  path: string;
+  kind: 'file' | 'folder';
+  size: number;
+  mtimeMs: number;
+}
+
+export interface VaultInfo {
+  rootName: string;
+  fileCount: number;
+  folderCount: number;
+}
+
+export interface ReadFileValue {
+  path: string;
+  content: string;
+  size: number;
+  mtimeMs: number;
+}
+
+export interface WriteFileValue {
+  path: string;
+  size: number;
+  mtimeMs: number;
+  audit: AuditEntry;
+}
+
+export interface DeleteValue {
+  path: string;
+  trashPath?: string;
+  permanent: boolean;
+  audit: AuditEntry;
+}
+
+export interface MoveValue {
+  fromPath: string;
+  toPath: string;
+  kind: 'file' | 'folder';
+  audit: AuditEntry;
+}
+
+const DEFAULT_DEPTH = 10;
+const DEFAULT_ENTRY_CAP = 5000;
+
+function fail(error: VaultErrorCode, message: string): VaultResult<never> {
+  return { ok: false, error, message };
+}
+
+function classifyPathError(err: unknown): VaultResult<never> | null {
+  if (err instanceof InvalidPathError) return fail('invalid_path', err.message);
+  return null;
+}
+
+function classifyFsCollision(err: unknown): VaultResult<never> | null {
+  if (
+    err &&
+    typeof err === 'object' &&
+    'code' in err &&
+    (err.code === 'ENOTDIR' || err.code === 'EEXIST')
+  ) {
+    return fail('path_collision', 'path collides with an existing file or folder');
+  }
+  return null;
+}
+
+async function exists(absPath: string): Promise<boolean> {
+  try {
+    await stat(absPath);
+    return true;
+  } catch (err) {
+    /* v8 ignore next -- Defensive branch for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') return false;
+    /* v8 ignore next -- Defensive rethrow for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+    throw err;
+  }
+}
+
+function vaultPath(root: string, relPath: string): string {
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, relPath);
+  /* v8 ignore next -- Public operations validate away traversal before resolution; this is a second containment guard for future call sites. */
+  if (resolved !== resolvedRoot && !resolved.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new InvalidPathError(relPath, 'path escapes vault root');
+  }
+  return resolved;
+}
+
+function trashRelativePath(originalPath: string): string {
+  return path.posix.join('.kb2', 'trash', new Date().toISOString(), originalPath);
+}
+
+function isHiddenMetadataPath(relPath: string): boolean {
+  return relPath === '.kb2' || relPath.startsWith('.kb2/');
+}
+
+async function walkEntries(
+  root: string,
+  relDir: string,
+  currentDepth: number,
+  maxDepth: number,
+  cap: number,
+  entries: VaultEntry[]
+): Promise<void> {
+  if (entries.length >= cap) throw new Error('entry_cap_exceeded');
+  if (currentDepth > maxDepth) return;
+  const absDir = relDir.length === 0 ? root : vaultPath(root, relDir);
+  const dirents = await readdir(absDir, { withFileTypes: true });
+  for (const dirent of dirents) {
+    const rel = relDir.length === 0 ? dirent.name : path.posix.join(relDir, dirent.name);
+    if (isHiddenMetadataPath(rel)) continue;
+    const abs = vaultPath(root, rel);
+    const s = await stat(abs);
+    if (dirent.isDirectory()) {
+      entries.push({ path: rel, kind: 'folder', size: 0, mtimeMs: s.mtimeMs });
+      if (entries.length >= cap) throw new Error('entry_cap_exceeded');
+      await walkEntries(root, rel, currentDepth + 1, maxDepth, cap, entries);
+    } else if (dirent.isFile()) {
+      entries.push({ path: rel, kind: 'file', size: s.size, mtimeMs: s.mtimeMs });
+      if (entries.length >= cap) throw new Error('entry_cap_exceeded');
+    }
+  }
+}
+
+export async function getVaultInfo(ctx: VaultContext): Promise<VaultResult<VaultInfo>> {
+  try {
+    await mkdir(ctx.root, { recursive: true });
+    const entries: VaultEntry[] = [];
+    await walkEntries(ctx.root, '', 0, Number.MAX_SAFE_INTEGER, DEFAULT_ENTRY_CAP, entries);
+    return {
+      ok: true,
+      value: {
+        rootName: path.basename(path.resolve(ctx.root)),
+        fileCount: entries.filter((entry) => entry.kind === 'file').length,
+        folderCount: entries.filter((entry) => entry.kind === 'folder').length
+      }
+    };
+  } catch (err) {
+    if (err instanceof Error && err.message === 'entry_cap_exceeded') {
+      return fail('entry_cap_exceeded', `vault exceeds ${DEFAULT_ENTRY_CAP} entries`);
+    }
+    /* v8 ignore next -- Defensive rethrow for unexpected vault-info walk failures outside the classified entry-cap path. */
+    throw err;
+  }
+}
+
+export async function listVaultTree(
+  ctx: VaultContext,
+  input: { under?: string; depth?: number; entryCap?: number } = {}
+): Promise<VaultResult<{ entries: VaultEntry[] }>> {
+  try {
+    const under = validateOptionalVaultPath(input.under, 'folder') ?? '';
+    const absUnder = under.length === 0 ? ctx.root : vaultPath(ctx.root, under);
+    const underStat = await stat(absUnder).catch((err: unknown) => {
+      /* v8 ignore next -- Defensive branch for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+      if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') return null;
+      /* v8 ignore next -- Defensive rethrow for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+      throw err;
+    });
+    if (!underStat || !underStat.isDirectory()) return fail('not_found', 'folder not found');
+
+    const entries: VaultEntry[] = [];
+    await walkEntries(ctx.root, under, 0, input.depth ?? DEFAULT_DEPTH, input.entryCap ?? DEFAULT_ENTRY_CAP, entries);
+    return { ok: true, value: { entries } };
+  } catch (err) {
+    const pathResult = classifyPathError(err);
+    /* v8 ignore next -- Defensive false branch rethrows unexpected read errors; invalid-path classification is covered. */
+    if (pathResult) return pathResult;
+    if (err instanceof Error && err.message === 'entry_cap_exceeded') {
+      return fail('entry_cap_exceeded', `tree exceeds ${input.entryCap ?? DEFAULT_ENTRY_CAP} entries`);
+    }
+    /* v8 ignore next -- Defensive rethrow for unexpected tree failures outside classified path/cap errors. */
+    throw err;
+  }
+}
+
+export async function readVaultFile(ctx: VaultContext, filePath: string): Promise<VaultResult<ReadFileValue>> {
+  try {
+    const rel = validateVaultPath(filePath, 'file');
+    const abs = vaultPath(ctx.root, rel);
+    const s = await stat(abs).catch((err: unknown) => {
+      /* v8 ignore next -- Defensive branch for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+      if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') return null;
+      /* v8 ignore next -- Defensive rethrow for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+      throw err;
+    });
+    if (!s || !s.isFile()) return fail('not_found', 'file not found');
+    return {
+      ok: true,
+      value: {
+        path: rel,
+        content: await readFile(abs, 'utf8'),
+        size: s.size,
+        mtimeMs: s.mtimeMs
+      }
+    };
+  } catch (err) {
+    const pathResult = classifyPathError(err);
+    /* v8 ignore next -- Defensive false branch rethrows unexpected write errors; invalid-path classification is covered. */
+    if (pathResult) return pathResult;
+    /* v8 ignore next -- Defensive rethrow for unexpected read failures outside classified path/not-found errors. */
+    throw err;
+  }
+}
+
+export async function writeVaultFile(
+  ctx: VaultContext,
+  input: { path: string; content: string; overwrite?: boolean }
+): Promise<VaultResult<WriteFileValue>> {
+  try {
+    const rel = validateVaultPath(input.path, 'file');
+    const abs = vaultPath(ctx.root, rel);
+    const existsAlready = await exists(abs);
+    if (existsAlready && input.overwrite !== true) {
+      return fail('already_exists', 'file already exists');
+    }
+    await mkdir(path.dirname(abs), { recursive: true });
+    await writeFile(abs, input.content, 'utf8');
+    const s = await stat(abs);
+    const audit = await appendAudit({
+      root: ctx.root,
+      actor: ctx.actor,
+      operation: existsAlready ? 'write' : 'create',
+      entityKind: 'file',
+      path: rel,
+      summary: existsAlready ? `Wrote ${rel}` : `Created ${rel}`
+    });
+    return { ok: true, value: { path: rel, size: s.size, mtimeMs: s.mtimeMs, audit } };
+  } catch (err) {
+    const pathResult = classifyPathError(err);
+    /* v8 ignore next -- Defensive false branch rethrows unexpected mkdir errors; invalid-path classification is covered. */
+    if (pathResult) return pathResult;
+    const collisionResult = classifyFsCollision(err);
+    if (collisionResult) return collisionResult;
+    /* v8 ignore next -- Defensive rethrow for unexpected write failures outside classified path/collision errors. */
+    throw err;
+  }
+}
+
+export async function makeVaultFolder(ctx: VaultContext, folderPath: string): Promise<VaultResult<{ path: string; audit?: AuditEntry }>> {
+  try {
+    const rel = validateVaultPath(folderPath, 'folder');
+    const abs = vaultPath(ctx.root, rel);
+    const existed = await exists(abs);
+    await mkdir(abs, { recursive: true });
+    if (existed) return { ok: true, value: { path: rel } };
+    const audit = await appendAudit({
+      root: ctx.root,
+      actor: ctx.actor,
+      operation: 'mkdir',
+      entityKind: 'folder',
+      path: rel,
+      summary: `Created folder ${rel}`
+    });
+    return { ok: true, value: { path: rel, audit } };
+  } catch (err) {
+    const pathResult = classifyPathError(err);
+    /* v8 ignore next -- Defensive false branch rethrows unexpected delete errors; invalid-path classification is covered. */
+    if (pathResult) return pathResult;
+    const collisionResult = classifyFsCollision(err);
+    if (collisionResult) return collisionResult;
+    /* v8 ignore next -- Defensive rethrow for unexpected mkdir failures outside classified path errors. */
+    throw err;
+  }
+}
+
+export async function deleteVaultFile(
+  ctx: VaultContext,
+  input: { path: string; permanent?: boolean }
+): Promise<VaultResult<DeleteValue>> {
+  try {
+    const rel = validateVaultPath(input.path, 'file');
+    const abs = vaultPath(ctx.root, rel);
+    const s = await stat(abs).catch((err: unknown) => {
+      /* v8 ignore next -- Defensive branch for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+      if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') return null;
+      /* v8 ignore next -- Defensive rethrow for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+      throw err;
+    });
+    if (!s || !s.isFile()) return fail('not_found', 'file not found');
+
+    let trashPath: string | undefined;
+    if (input.permanent === true) {
+      await rm(abs);
+    } else {
+      trashPath = trashRelativePath(rel);
+      const trashAbs = vaultPath(ctx.root, trashPath);
+      await mkdir(path.dirname(trashAbs), { recursive: true });
+      await rename(abs, trashAbs);
+    }
+
+    const audit = await appendAudit({
+      root: ctx.root,
+      actor: ctx.actor,
+      operation: 'delete',
+      entityKind: 'file',
+      path: rel,
+      summary: input.permanent === true ? `Deleted ${rel} permanently` : `Moved ${rel} to trash`
+    });
+    return { ok: true, value: { path: rel, ...(trashPath !== undefined ? { trashPath } : {}), permanent: input.permanent === true, audit } };
+  } catch (err) {
+    const pathResult = classifyPathError(err);
+    /* v8 ignore next -- Defensive false branch rethrows unexpected folder-delete errors; invalid-path classification is covered. */
+    if (pathResult) return pathResult;
+    /* v8 ignore next -- Defensive rethrow for unexpected delete failures outside classified path/not-found errors. */
+    throw err;
+  }
+}
+
+export async function deleteVaultFolder(
+  ctx: VaultContext,
+  input: { path: string; recursive?: boolean; permanent?: boolean }
+): Promise<VaultResult<DeleteValue>> {
+  try {
+    const rel = validateVaultPath(input.path, 'folder');
+    const abs = vaultPath(ctx.root, rel);
+    const s = await stat(abs).catch((err: unknown) => {
+      /* v8 ignore next -- Defensive branch for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+      if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') return null;
+      /* v8 ignore next -- Defensive rethrow for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+      throw err;
+    });
+    if (!s || !s.isDirectory()) return fail('not_found', 'folder not found');
+
+    const children = await readdir(abs);
+    if (children.length > 0 && input.recursive !== true) {
+      return fail('folder_not_empty', 'folder is not empty');
+    }
+
+    let trashPath: string | undefined;
+    if (input.permanent === true) {
+      await rm(abs, { recursive: true });
+    } else {
+      trashPath = trashRelativePath(rel);
+      const trashAbs = vaultPath(ctx.root, trashPath);
+      await mkdir(path.dirname(trashAbs), { recursive: true });
+      await rename(abs, trashAbs);
+    }
+
+    const audit = await appendAudit({
+      root: ctx.root,
+      actor: ctx.actor,
+      operation: 'delete',
+      entityKind: 'folder',
+      path: rel,
+      summary: input.permanent === true ? `Deleted folder ${rel} permanently` : `Moved folder ${rel} to trash`
+    });
+    return { ok: true, value: { path: rel, ...(trashPath !== undefined ? { trashPath } : {}), permanent: input.permanent === true, audit } };
+  } catch (err) {
+    const pathResult = classifyPathError(err);
+    /* v8 ignore next -- Defensive false branch rethrows unexpected folder-delete errors; invalid-path classification is covered. */
+    if (pathResult) return pathResult;
+    /* v8 ignore next -- Defensive rethrow for unexpected folder delete failures outside classified path/not-empty/not-found errors. */
+    throw err;
+  }
+}
+
+export async function moveVaultPath(
+  ctx: VaultContext,
+  input: { fromPath: string; toPath: string; kind: 'file' | 'folder'; overwrite?: boolean }
+): Promise<VaultResult<MoveValue>> {
+  try {
+    const from = validateVaultPath(input.fromPath, input.kind);
+    const to = validateVaultPath(input.toPath, input.kind);
+    if (input.kind === 'folder' && relativeDescendantPath(from, to) !== null) {
+      return fail('invalid_path', 'folder cannot be moved into itself');
+    }
+    const fromAbs = vaultPath(ctx.root, from);
+    const toAbs = vaultPath(ctx.root, to);
+    const s = await stat(fromAbs).catch((err: unknown) => {
+      /* v8 ignore next -- Defensive branch for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+      if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') return null;
+      /* v8 ignore next -- Defensive rethrow for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+      throw err;
+    });
+    if (!s || (input.kind === 'file' ? !s.isFile() : !s.isDirectory())) {
+      return fail('not_found', `${input.kind} not found`);
+    }
+    if ((await exists(toAbs)) && input.overwrite !== true) {
+      return fail('path_collision', 'target path already exists');
+    }
+    await mkdir(path.dirname(toAbs), { recursive: true });
+    if (input.overwrite === true && (await exists(toAbs))) {
+      await rm(toAbs, { recursive: true });
+    }
+    try {
+      await rename(fromAbs, toAbs);
+    } catch (err) {
+      /* v8 ignore start -- Cross-device rename fallback cannot be triggered deterministically inside one temp filesystem. */
+      if (err && typeof err === 'object' && 'code' in err && err.code === 'EXDEV') {
+        if (input.kind === 'folder') {
+          await cp(fromAbs, toAbs, { recursive: true });
+        } else {
+          await copyFile(fromAbs, toAbs);
+        }
+        await rm(fromAbs, { recursive: true });
+      } else {
+        throw err;
+      }
+      /* v8 ignore stop */
+    }
+    const audit = await appendAudit({
+      root: ctx.root,
+      actor: ctx.actor,
+      operation: 'move',
+      entityKind: input.kind,
+      path: to,
+      fromPath: from,
+      toPath: to,
+      summary: `Moved ${from} to ${to}`
+    });
+    return { ok: true, value: { fromPath: from, toPath: to, kind: input.kind, audit } };
+  } catch (err) {
+    const pathResult = classifyPathError(err);
+    /* v8 ignore next -- Defensive false branch rethrows unexpected move errors; invalid-path classification is covered. */
+    if (pathResult) return pathResult;
+    const collisionResult = classifyFsCollision(err);
+    if (collisionResult) return collisionResult;
+    /* v8 ignore next -- Defensive rethrow for unexpected move failures outside classified path/not-found/collision errors. */
+    throw err;
+  }
+}

--- a/packages/vault-core/src/path.ts
+++ b/packages/vault-core/src/path.ts
@@ -1,0 +1,71 @@
+import path from 'node:path';
+
+const MAX_PATH_LENGTH = 1024;
+const MAX_SEGMENT_LENGTH = 255;
+
+export type VaultPathKind = 'file' | 'folder';
+
+export class InvalidPathError extends Error {
+  constructor(public readonly input: string, public readonly reason: string) {
+    super(`Invalid vault path "${input}": ${reason}`);
+    this.name = 'InvalidPathError';
+  }
+}
+
+export function validateVaultPath(input: string, kind: VaultPathKind): string {
+  if (typeof input !== 'string') {
+    throw new InvalidPathError(String(input), 'path must be a string');
+  }
+  if (input.length === 0) {
+    throw new InvalidPathError(input, 'path is empty');
+  }
+  if (input.length > MAX_PATH_LENGTH) {
+    throw new InvalidPathError(input, `path exceeds ${MAX_PATH_LENGTH} chars`);
+  }
+  if (input.includes('\\')) {
+    throw new InvalidPathError(input, 'path must use forward slashes');
+  }
+  if (path.posix.isAbsolute(input) || path.isAbsolute(input)) {
+    throw new InvalidPathError(input, 'path must be vault-relative');
+  }
+  if (input.startsWith('/') || input.endsWith('/')) {
+    throw new InvalidPathError(input, 'path must not start or end with "/"');
+  }
+
+  const segments = input.split('/');
+  for (const segment of segments) {
+    if (segment.length === 0) {
+      throw new InvalidPathError(input, 'path contains an empty segment');
+    }
+    if (segment === '.' || segment === '..') {
+      throw new InvalidPathError(input, 'path must not contain "." or ".." segments');
+    }
+    if (segment.length > MAX_SEGMENT_LENGTH) {
+      throw new InvalidPathError(input, `segment exceeds ${MAX_SEGMENT_LENGTH} chars`);
+    }
+    if (segment === '.kb2') {
+      throw new InvalidPathError(input, '.kb2 is reserved for vault metadata');
+    }
+  }
+
+  if (kind === 'file') {
+    const filename = segments[segments.length - 1]!;
+    const dot = filename.indexOf('.');
+    if (dot <= 0 || dot === filename.length - 1) {
+      throw new InvalidPathError(input, 'file paths must end in name.ext');
+    }
+  }
+
+  return input;
+}
+
+export function validateOptionalVaultPath(input: string | undefined, kind: VaultPathKind): string | undefined {
+  if (input === undefined || input.length === 0) return undefined;
+  return validateVaultPath(input, kind);
+}
+
+export function relativeDescendantPath(parent: string, child: string): string | null {
+  if (child === parent) return '';
+  const prefix = `${parent}/`;
+  return child.startsWith(prefix) ? child.slice(prefix.length) : null;
+}

--- a/packages/vault-core/tsconfig.build.json
+++ b/packages/vault-core/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "dist/tsconfig.build.tsbuildinfo",
+    "types": ["node"]
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/vault-core/tsconfig.json
+++ b/packages/vault-core/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/vault-core/vitest.config.ts
+++ b/packages/vault-core/vitest.config.ts
@@ -7,9 +7,13 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text'],
-      include: ['src/manager.ts'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts'],
       thresholds: {
-        lines: 90
+        statements: 100,
+        functions: 100,
+        lines: 100,
+        branches: 95
       }
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       ws:
         specifier: 8.21.0
         version: 8.21.0
@@ -95,6 +95,9 @@ importers:
       '@kb-2/doc-session':
         specifier: workspace:*
         version: link:../../packages/doc-session
+      '@kb-2/vault-core':
+        specifier: workspace:*
+        version: link:../../packages/vault-core
       hono:
         specifier: 4.12.25
         version: 4.12.25
@@ -105,6 +108,9 @@ importers:
       '@types/ws':
         specifier: 8.18.1
         version: 8.18.1
+      '@vitest/coverage-v8':
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
 
   apps/web:
     dependencies:
@@ -162,7 +168,7 @@ importers:
         version: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@types/node@25.9.2)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
       ws:
         specifier: 8.21.0
         version: 8.21.0
@@ -185,9 +191,12 @@ importers:
       '@types/ws':
         specifier: 8.18.1
         version: 8.18.1
+      '@vitest/coverage-v8':
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       ws:
         specifier: 8.21.0
         version: 8.21.0
@@ -260,13 +269,13 @@ importers:
         version: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@types/node@25.9.2)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/tunnel-protocol:
     devDependencies:
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/ui:
     dependencies:
@@ -321,7 +330,19 @@ importers:
         version: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@types/node@25.9.2)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/vault-core:
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      fast-check:
+        specifier: 4.8.0
+        version: 4.8.0
+      vitest:
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -332,13 +353,30 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@codemirror/autocomplete@6.20.3':
     resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
@@ -1348,6 +1386,15 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -1434,6 +1481,9 @@ packages:
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.3:
+    resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -1696,6 +1746,10 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
@@ -1779,6 +1833,9 @@ packages:
     resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -1834,9 +1891,24 @@ packages:
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2027,6 +2099,13 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2144,6 +2223,9 @@ packages:
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
@@ -2616,9 +2698,22 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.29.7': {}
 
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/runtime@7.29.7': {}
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@codemirror/autocomplete@6.20.3':
     dependencies:
@@ -3445,6 +3540,20 @@ snapshots:
     dependencies:
       '@types/node': 25.9.2
 
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.2
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -3547,6 +3656,12 @@ snapshots:
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.3:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   asynckit@0.4.0: {}
 
@@ -3813,6 +3928,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-diff@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
@@ -3880,6 +3999,8 @@ snapshots:
 
   hono@4.12.25: {}
 
+  html-escaper@2.0.2: {}
+
   ieee754@1.2.1: {}
 
   ignore@7.0.5: {}
@@ -3916,7 +4037,22 @@ snapshots:
 
   isomorphic.js@0.2.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.7.0: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -4044,6 +4180,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   math-intrinsics@1.1.0: {}
 
@@ -4264,6 +4410,8 @@ snapshots:
       react-is: 17.0.2
 
   proxy-from-env@2.1.0: {}
+
+  pure-rand@8.4.0: {}
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
@@ -4594,7 +4742,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  vitest@4.1.8(@types/node@25.9.2)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -4618,10 +4766,11 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.2
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.8(@types/node@25.9.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -4645,6 +4794,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.2
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
     transitivePeerDependencies:
       - msw
 

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+
+const skipNxCache = process.argv.includes('--skip-nx-cache');
+const env = {
+  ...process.env,
+  ...(skipNxCache ? { NX_SKIP_NX_CACHE: 'true' } : {})
+};
+
+for (const script of ['typecheck', 'test', 'build']) {
+  const code = await run('pnpm', [script], env);
+  if (code !== 0) {
+    process.exitCode = code;
+    break;
+  }
+}
+
+function run(command, args, env) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      env,
+      stdio: 'inherit'
+    });
+    child.on('exit', (code, signal) => {
+      if (signal) {
+        resolve(signal === 'SIGINT' ? 130 : 1);
+        return;
+      }
+      resolve(code ?? 1);
+    });
+  });
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
       "@kb-2/doc-session/protocol": ["./packages/doc-session/src/protocol.ts"],
       "@kb-2/editor": ["./packages/editor/src/lib/index.ts"],
       "@kb-2/tunnel-protocol": ["./packages/tunnel-protocol/src/index.ts"],
+      "@kb-2/vault-core": ["./packages/vault-core/src/index.ts"],
       "@kb-2/ui": ["./packages/ui/src/lib/index.ts"]
     },
     "strict": true,


### PR DESCRIPTION
Summary
- Added @kb-2/vault-core with vault-relative path validation, tree/info/read/write/mkdir/delete/move operations, JSONL audit rows, trash-backed deletes, and property-backed tests.
- Added DocumentSessionManager and path-aware doc-session rekey/delete flows so live Y.Doc sessions follow file/folder moves and enter a loud doc-deleted read-only state on deletion.
- Added daemon vault REST routes plus path-aware Yjs websocket routing, wired the web editor to arbitrary vault paths, and added the deleted-doc banner/read-only editor behavior.
- Added focused coverage gates for vault-core, doc-session manager, and daemon app route code; added a root check wrapper that honors --skip-nx-cache.

Explicit deviations
- Move/rename records file-operation audit metadata but does not rewrite wikilinks; link-index rewrite work remains outside this chunk.
- Live sessions remain manager-resident until daemon shutdown/delete, matching the existing daemon lifecycle; this chunk adds live rekey and loud delete teardown, but does not add idle last-client garbage collection.
- Browser verification used a real headless Google Chrome CDP fallback because the Browser plugin tool was not exposed in this session; it still exercised the actual local UI over localhost.

Verification evidence
- pnpm check -- --skip-nx-cache: passed across typecheck, tests, and builds for all seven projects. This completed before rebasing onto the three latest main docs/planning commits; post-rebase git diff --check is clean.
- Targeted coverage gates passed: @kb-2/vault-core statements/functions/lines 100%, branches 96.25%; @kb-2/doc-session manager lines 93.1%; @kb-2/daemon app lines 95.4%.
- Targeted tests passed: pnpm --filter @kb-2/vault-core test; pnpm --filter @kb-2/doc-session test; pnpm --filter @kb-2/daemon test; pnpm --filter @kb-2/editor test; pnpm --filter @kb-2/editor typecheck; pnpm --filter @kb-2/daemon build; pnpm --filter @kb-2/web build.
- Real-browser run used KB2_HOME=/tmp/kb2-chunk007-nKSrWt, daemon port 17392, and CDP port 17393; both ports were confirmed no longer listening afterward.
- Browser AC10: root visibly redirected to /hello-world.md, and a nested path rendered its path and seed content.
- Browser AC2: two tabs edited different vault paths independently; each marker persisted only to its own disk file.
- Browser AC3: while a document was open, rename to a new path completed, the browser URL followed the new path, and a marker typed during the rename survived on disk at the renamed path.
- Browser AC4: an open nested document followed a folder move, and a post-move browser edit persisted at the new nested path.
- Browser AC5: deleting an open document visibly showed the Document deleted read-only banner, flipped the editor non-editable, blocked post-delete typing, removed the file from the tree, and preserved the pre-delete browser edit in trash.
- Audit evidence: the browser run wrote 9 JSONL audit rows under the temp vault for create/move/delete file-operation activity.