### PR TITLE
KB-2 Chunk 008: Agent Write/Read Surface

### DIFF
--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -1,15 +1,22 @@
 import { Hono, type Context } from 'hono';
 import type { DocumentSessionManager, OneFileDocumentSession } from '@kb-2/doc-session';
 import {
+  InvalidPathError,
   appendAudit,
+  appendContent,
+  applyAnchoredSplice,
   deleteVaultFile,
   deleteVaultFolder,
   getVaultInfo,
   listVaultTree,
   makeVaultFolder,
   moveVaultPath,
+  prependContent,
   readVaultFile,
+  searchVaultFiles,
+  validateVaultPath,
   writeVaultFile,
+  type AnchoredSpliceRequest,
   type VaultErrorCode,
   type VaultResult
 } from '@kb-2/vault-core';
@@ -82,9 +89,43 @@ export function createApp(options: CreateAppOptions): Hono {
       ));
     });
 
+    api.get('/search', async (context) => {
+      try {
+        const result = await searchVaultFiles(options.vaultRoot!, {
+          q: context.req.query('q') ?? '',
+          under: context.req.query('under'),
+          context: queryNumber(context, 'context'),
+          limit: queryNumber(context, 'limit'),
+          offset: queryNumber(context, 'offset')
+        });
+        return context.json({ ok: true, ...result });
+      } catch (error) {
+        if (error instanceof InvalidPathError) {
+          return mapVaultResult(context, {
+            ok: false,
+            error: 'invalid_path',
+            message: error.message
+          });
+        }
+        throw error;
+      }
+    });
+
     api.get('/files/*', async (context) => {
       const filePath = filePathParam(context.req.path, '/api/files/');
-      return mapVaultResult(context, await readVaultFile({ root: options.vaultRoot! }, filePath));
+      const diskRead = await readVaultFile({ root: options.vaultRoot! }, filePath);
+      if (!diskRead.ok || !options.documentSessions) {
+        return mapVaultResult(context, diskRead);
+      }
+      const baselineRead = await options.documentSessions.withSession(filePath, (session) => session.readWithBaseline());
+      return context.json({
+        ok: true,
+        path: diskRead.value.path,
+        content: baselineRead.content,
+        baseline: baselineRead.baseline,
+        size: diskRead.value.size,
+        mtimeMs: diskRead.value.mtimeMs
+      });
     });
 
     api.put('/files/*', async (context) => {
@@ -146,6 +187,98 @@ export function createApp(options: CreateAppOptions): Hono {
     });
 
     api.post('/files/*', async (context) => {
+      if (context.req.path.endsWith('/splice')) {
+        const filePath = filePathParam(context.req.path, '/api/files/', '/splice');
+        const diskRead = await readVaultFile({ root: options.vaultRoot! }, filePath);
+        if (!diskRead.ok) return mapVaultResult(context, diskRead);
+        if (!options.documentSessions) {
+          return context.json({ ok: false, error: 'session_unavailable', message: 'document sessions are unavailable' }, 503);
+        }
+        const body = await readJsonObject(context.req.raw);
+        const splice = readSpliceRequest(body);
+        const result = await options.documentSessions.withSession(filePath, (session) =>
+          session.applyBaselineEdit(splice.baseline, (currentContent) =>
+            applyAnchoredSplice(currentContent, splice.request)
+          )
+        );
+        if (!result.ok) return mapSpliceReject(context, result);
+        const audit = await appendAudit({
+          root: options.vaultRoot!,
+          actor: { kind: 'mcp_client', client: 'api' },
+          operation: 'splice',
+          entityKind: 'file',
+          path: filePath,
+          summary: `Spliced ${filePath}`
+        });
+        return context.json({
+          ok: true,
+          path: filePath,
+          content: result.content,
+          baseline: result.baseline,
+          audit
+        });
+      }
+
+      if (context.req.path.endsWith('/append')) {
+        const filePath = filePathParam(context.req.path, '/api/files/', '/append');
+        const validPath = validateRouteFilePath(context, filePath);
+        if (validPath instanceof Response) return validPath;
+        if (!options.documentSessions) {
+          return context.json({ ok: false, error: 'session_unavailable', message: 'document sessions are unavailable' }, 503);
+        }
+        const body = await readJsonObject(context.req.raw);
+        const content = typeof body.content === 'string' ? body.content : '';
+        const result = await options.documentSessions.withSession(
+          filePath,
+          (session) => session.applyContentEdit((currentContent) => appendContent(currentContent, content)),
+          { defaultContent: '' }
+        );
+        const audit = await appendAudit({
+          root: options.vaultRoot!,
+          actor: { kind: 'mcp_client', client: 'api' },
+          operation: 'append',
+          entityKind: 'file',
+          path: filePath,
+          summary: `Appended to ${filePath}`
+        });
+        return context.json({
+          ok: true,
+          path: filePath,
+          content: result.content,
+          baseline: result.baseline,
+          audit
+        });
+      }
+
+      if (context.req.path.endsWith('/prepend')) {
+        const filePath = filePathParam(context.req.path, '/api/files/', '/prepend');
+        const diskRead = await readVaultFile({ root: options.vaultRoot! }, filePath);
+        if (!diskRead.ok) return mapVaultResult(context, diskRead);
+        if (!options.documentSessions) {
+          return context.json({ ok: false, error: 'session_unavailable', message: 'document sessions are unavailable' }, 503);
+        }
+        const body = await readJsonObject(context.req.raw);
+        const content = typeof body.content === 'string' ? body.content : '';
+        const result = await options.documentSessions.withSession(filePath, (session) =>
+          session.applyContentEdit((currentContent) => prependContent(currentContent, content))
+        );
+        const audit = await appendAudit({
+          root: options.vaultRoot!,
+          actor: { kind: 'mcp_client', client: 'api' },
+          operation: 'prepend',
+          entityKind: 'file',
+          path: filePath,
+          summary: `Prepended to ${filePath}`
+        });
+        return context.json({
+          ok: true,
+          path: filePath,
+          content: result.content,
+          baseline: result.baseline,
+          audit
+        });
+      }
+
       if (!context.req.path.endsWith('/move')) {
         return context.json({ ok: false, error: 'Not found' }, 404);
       }
@@ -258,6 +391,61 @@ export function createApp(options: CreateAppOptions): Hono {
   }
 
   return app;
+}
+
+function readSpliceRequest(body: Record<string, unknown>): { baseline: string; request: AnchoredSpliceRequest } {
+  return {
+    baseline: typeof body.baseline === 'string' ? body.baseline : '',
+    request: {
+      oldText: typeof body.old_text === 'string' ? body.old_text : '',
+      newText: typeof body.new_text === 'string' ? body.new_text : '',
+      ...(typeof body.before === 'string' ? { before: body.before } : {}),
+      ...(typeof body.after === 'string' ? { after: body.after } : {}),
+      ...(typeof body.occurrence === 'number' && Number.isInteger(body.occurrence)
+        ? { occurrence: body.occurrence }
+        : {})
+    }
+  };
+}
+
+function mapSpliceReject(context: Context, result: Exclude<Awaited<ReturnType<OneFileDocumentSession['applyBaselineEdit']>>, { ok: true }>): Response {
+  const status = statusForSpliceReject(result.rejected);
+  const { ok: _ok, ...body } = result;
+  return context.json({ ok: false, ...body }, status);
+}
+
+function statusForSpliceReject(rejected: string): 404 | 409 | 413 {
+  switch (rejected) {
+    case 'not_found':
+      return 404;
+    case 'too_large_splice':
+    case 'too_large_document':
+      return 413;
+    default:
+      return 409;
+  }
+}
+
+function queryNumber(context: Context, name: string): number | undefined {
+  const raw = context.req.query(name);
+  if (raw === undefined) return undefined;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function validateRouteFilePath(context: Context, filePath: string): string | Response {
+  try {
+    return validateVaultPath(filePath, 'file');
+  } catch (error) {
+    if (error instanceof InvalidPathError) {
+      return mapVaultResult(context, {
+        ok: false,
+        error: 'invalid_path',
+        message: error.message
+      });
+    }
+    throw error;
+  }
 }
 
 async function readOptionalJsonContent(request: Request): Promise<string | undefined> {

--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from 'hono';
-import type { DocumentSessionManager, OneFileDocumentSession } from '@kb-2/doc-session';
+import { PersistFailedError, type DocumentSessionManager, type OneFileDocumentSession } from '@kb-2/doc-session';
 import {
   InvalidPathError,
   appendAudit,
@@ -141,7 +141,8 @@ export function createApp(options: CreateAppOptions): Hono {
             message: 'file already exists'
           });
         }
-        await liveSession.applyContent(content);
+        const applied = await withMappedWriteError(context, () => liveSession.applyContent(content));
+        if (applied instanceof Response) return applied;
         const audit = await appendAudit({
           root: options.vaultRoot!,
           actor: { kind: 'user' },
@@ -153,7 +154,7 @@ export function createApp(options: CreateAppOptions): Hono {
         return context.json({
           ok: true,
           path: filePath,
-          content: await liveSession.getContent(),
+          content: applied,
           live: true,
           audit
         });
@@ -196,11 +197,12 @@ export function createApp(options: CreateAppOptions): Hono {
         }
         const body = await readJsonObject(context.req.raw);
         const splice = readSpliceRequest(body);
-        const result = await options.documentSessions.withSession(filePath, (session) =>
+        const result = await withMappedWriteError(context, () => options.documentSessions!.withSession(filePath, (session) =>
           session.applyBaselineEdit(splice.baseline, (currentContent) =>
             applyAnchoredSplice(currentContent, splice.request)
           )
-        );
+        ));
+        if (result instanceof Response) return result;
         if (!result.ok) return mapSpliceReject(context, result);
         const audit = await appendAudit({
           root: options.vaultRoot!,
@@ -228,11 +230,12 @@ export function createApp(options: CreateAppOptions): Hono {
         }
         const body = await readJsonObject(context.req.raw);
         const content = typeof body.content === 'string' ? body.content : '';
-        const result = await options.documentSessions.withSession(
+        const result = await withMappedWriteError(context, () => options.documentSessions!.withSession(
           filePath,
           (session) => session.applyContentEdit((currentContent) => appendContent(currentContent, content)),
           { defaultContent: '' }
-        );
+        ));
+        if (result instanceof Response) return result;
         const audit = await appendAudit({
           root: options.vaultRoot!,
           actor: { kind: 'mcp_client', client: 'api' },
@@ -259,9 +262,10 @@ export function createApp(options: CreateAppOptions): Hono {
         }
         const body = await readJsonObject(context.req.raw);
         const content = typeof body.content === 'string' ? body.content : '';
-        const result = await options.documentSessions.withSession(filePath, (session) =>
+        const result = await withMappedWriteError(context, () => options.documentSessions!.withSession(filePath, (session) =>
           session.applyContentEdit((currentContent) => prependContent(currentContent, content))
-        );
+        ));
+        if (result instanceof Response) return result;
         const audit = await appendAudit({
           root: options.vaultRoot!,
           actor: { kind: 'mcp_client', client: 'api' },
@@ -489,6 +493,24 @@ async function withMappedVaultError<T>(
   } catch (error) {
     if (error instanceof VaultResultFailure) {
       return mapVaultResult(context, error.result);
+    }
+    throw error;
+  }
+}
+
+async function withMappedWriteError<T>(
+  context: Context,
+  operation: () => T | Promise<T>
+): Promise<T | Response> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof PersistFailedError) {
+      return context.json({
+        ok: false,
+        error: 'persist_failed',
+        message: 'Document edit could not be durably saved to disk.'
+      }, 500);
     }
     throw error;
   }

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -85,13 +85,16 @@ export async function startDaemon(): Promise<StartedDaemon> {
 
       webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
         void (async () => {
+          const bindingLease = documentSessions.attachClientSession(documentPath);
           try {
-            const binding = await bindYjsWebSocket(documentSessions.getSession(documentPath), webSocket);
+            const binding = await bindYjsWebSocket(bindingLease.session, webSocket);
             activeDocumentConnections.add(binding.closed);
             binding.closed.finally(() => {
               activeDocumentConnections.delete(binding.closed);
+              bindingLease.release();
             }).catch(() => undefined);
           } catch (error) {
+            bindingLease.release();
             console.error(error);
             webSocket.close(1011, 'Document session failed to open');
           }

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { DocumentSessionManager, OneFileDocumentSession, type DocumentSessionEvent } from '@kb-2/doc-session';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import * as Y from 'yjs';
 
@@ -396,6 +396,148 @@ describe('daemon routing', () => {
     await sessions.close();
   });
 
+  it('serves baselines and applies agent splice with stale retry through live sessions', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    await writeFileWithParents(join(config.vaultRoot, 'notes', 'splice.md'), 'one two three\n');
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+
+    const read = await app.request('/api/files/notes/splice.md');
+    expect(read.status).toBe(200);
+    const readBody = await read.json() as { content: string; baseline: string };
+    expect(readBody.content).toBe('one two three\n');
+    expect(readBody.baseline.length).toBeGreaterThan(0);
+
+    const firstSplice = await app.request('/api/files/notes/splice.md/splice', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseline: readBody.baseline,
+        old_text: 'two',
+        new_text: 'TWO'
+      })
+    });
+    expect(firstSplice.status).toBe(200);
+    const firstBody = await firstSplice.json() as { content: string; baseline: string };
+    expect(firstBody.content).toBe('one TWO three\n');
+    await expect(readFile(join(config.vaultRoot, 'notes/splice.md'), 'utf8')).resolves.toBe('one TWO three\n');
+
+    const stale = await app.request('/api/files/notes/splice.md/splice', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseline: readBody.baseline,
+        old_text: 'three',
+        new_text: 'THREE'
+      })
+    });
+    expect(stale.status).toBe(409);
+    const staleBody = await stale.json() as { rejected: string; current_content: string; baseline: string };
+    expect(staleBody).toMatchObject({
+      rejected: 'stale_doc',
+      current_content: 'one TWO three\n'
+    });
+    expect(staleBody.baseline).not.toBe(readBody.baseline);
+
+    const retry = await app.request('/api/files/notes/splice.md/splice', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        baseline: staleBody.baseline,
+        old_text: 'three',
+        new_text: 'THREE'
+      })
+    });
+    expect(retry.status).toBe(200);
+    await expect(retry.json()).resolves.toMatchObject({ ok: true, content: 'one TWO THREE\n' });
+    await expect(readFile(join(config.vaultRoot, 'notes/splice.md'), 'utf8')).resolves.toBe('one TWO THREE\n');
+
+    const audit = await readAuditRows(config.vaultRoot);
+    expect(audit).toHaveLength(2);
+    expect(audit.map((row) => row.operation)).toEqual(['splice', 'splice']);
+    expect(audit.every((row) => (row.actor as { kind?: string }).kind === 'mcp_client')).toBe(true);
+    await sessions.close();
+  });
+
+  it('applies anchored splice disambiguation and structured rejections', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    await writeFileWithParents(join(config.vaultRoot, 'ambiguous.md'), 'foo bar foo baz foo');
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const read = await (await app.request('/api/files/ambiguous.md')).json() as { baseline: string };
+
+    const ambiguous = await app.request('/api/files/ambiguous.md/splice', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ baseline: read.baseline, old_text: 'foo', new_text: 'FOO' })
+    });
+    expect(ambiguous.status).toBe(409);
+    await expect(ambiguous.json()).resolves.toMatchObject({ ok: false, rejected: 'ambiguous', match_count: 3 });
+
+    const occurrence = await app.request('/api/files/ambiguous.md/splice', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ baseline: read.baseline, old_text: 'foo', new_text: 'FOO', occurrence: 2 })
+    });
+    expect(occurrence.status).toBe(200);
+    await expect(readFile(join(config.vaultRoot, 'ambiguous.md'), 'utf8')).resolves.toBe('foo bar FOO baz foo');
+
+    const reread = await (await app.request('/api/files/ambiguous.md')).json() as { baseline: string };
+    const notFound = await app.request('/api/files/ambiguous.md/splice', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ baseline: reread.baseline, old_text: 'missing', new_text: 'x' })
+    });
+    expect(notFound.status).toBe(404);
+    await expect(notFound.json()).resolves.toMatchObject({ ok: false, rejected: 'not_found' });
+    await sessions.close();
+  });
+
+  it('appends missing files, prepends after frontmatter, searches with context, and does not audit search', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+
+    const append = await app.request('/api/files/notes/new.md/append', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content: 'created by append\n' })
+    });
+    expect(append.status).toBe(200);
+    await expect(append.json()).resolves.toMatchObject({ ok: true, path: 'notes/new.md', content: 'created by append\n' });
+    await expect(readFile(join(config.vaultRoot, 'notes/new.md'), 'utf8')).resolves.toBe('created by append\n');
+
+    await writeFileWithParents(join(config.vaultRoot, 'notes/front.md'), '---\ntitle: Front\n---\nbody\n');
+    const prepend = await app.request('/api/files/notes/front.md/prepend', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content: 'inserted\n' })
+    });
+    expect(prepend.status).toBe(200);
+    await expect(readFile(join(config.vaultRoot, 'notes/front.md'), 'utf8')).resolves.toBe(
+      '---\ntitle: Front\n---\ninserted\nbody\n'
+    );
+
+    await writeFileWithParents(join(config.vaultRoot, 'notes/deep/search.md'), 'before\nneedle here\nafter\n');
+    await writeFileWithParents(join(config.vaultRoot, '.kb2/trash/hidden.md'), 'needle hidden\n');
+    const search = await app.request('/api/search?q=NEEDLE&under=notes&context=1&limit=5');
+    expect(search.status).toBe(200);
+    await expect(search.json()).resolves.toMatchObject({
+      ok: true,
+      total: 1,
+      results: [{
+        path: 'notes/deep/search.md',
+        line: 2,
+        lineText: 'needle here',
+        context: { before: ['before'], after: ['after'] }
+      }]
+    });
+
+    const audit = await readAuditRows(config.vaultRoot);
+    expect(audit.map((row) => row.operation)).toEqual(['append', 'prepend']);
+    await sessions.close();
+  });
+
   it('keeps live move failures classified and resumes old-path watching', async () => {
     const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
     const sessions = new DocumentSessionManager({
@@ -549,6 +691,11 @@ function close(server: ReturnType<typeof createServer>): Promise<void> {
 async function readAuditRows(root: string): Promise<Array<Record<string, unknown>>> {
   const content = await readFile(join(root, '.kb2/audit/changes.jsonl'), 'utf8');
   return content.trim().split('\n').map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+async function writeFileWithParents(filePath: string, content: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, 'utf8');
 }
 
 async function waitUntil(

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { DocumentSessionManager, OneFileDocumentSession, type DocumentSessionEvent } from '@kb-2/doc-session';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
@@ -535,6 +535,56 @@ describe('daemon routing', () => {
 
     const audit = await readAuditRows(config.vaultRoot);
     expect(audit.map((row) => row.operation)).toEqual(['append', 'prepend']);
+    await sessions.close();
+  });
+
+  it('surfaces live append persist failures without auditing or idle-dropping unsaved content, then recovers', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({
+      root: config.vaultRoot,
+      defaultContent: '',
+      idleSessionGraceMs: 30
+    });
+    await writeFileWithParents(join(config.vaultRoot, 'notes', 'readonly.md'), 'base\n');
+    const hydrated = sessions.getSession('notes/readonly.md');
+    await hydrated.open();
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const notesDir = join(config.vaultRoot, 'notes');
+
+    await chmod(notesDir, 0o500);
+    const failedAppend = await app.request('/api/files/notes/readonly.md/append', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content: 'lost if dropped\n' })
+    });
+
+    expect(failedAppend.status).toBe(500);
+    await expect(failedAppend.json()).resolves.toMatchObject({ ok: false, error: 'persist_failed' });
+    await expect(readFile(join(config.vaultRoot, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\n');
+    await expect(readFile(join(config.vaultRoot, '.kb2/audit/changes.jsonl'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+
+    await new Promise((resolve) => setTimeout(resolve, 90));
+    expect(sessions.getOpenSession('notes/readonly.md')).toBe(hydrated);
+    await expect(hydrated.getContent()).resolves.toBe('base\nlost if dropped\n');
+
+    await chmod(notesDir, 0o700);
+    const recoveredAppend = await app.request('/api/files/notes/readonly.md/append', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ content: 'after recovery\n' })
+    });
+
+    expect(recoveredAppend.status).toBe(200);
+    await expect(recoveredAppend.json()).resolves.toMatchObject({
+      ok: true,
+      path: 'notes/readonly.md',
+      content: 'base\nlost if dropped\nafter recovery\n'
+    });
+    await expect(readFile(join(config.vaultRoot, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\nlost if dropped\nafter recovery\n');
+    const audit = await readAuditRows(config.vaultRoot);
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({ operation: 'append', path: 'notes/readonly.md' });
+    expect(hydrated.getActivePersistFailureEvent()).toBeUndefined();
     await sessions.close();
   });
 

--- a/packages/doc-session/src/index.ts
+++ b/packages/doc-session/src/index.ts
@@ -6,7 +6,9 @@ export {
   type OneFileDocumentSessionOptions
 } from './session.js';
 export {
+  DEFAULT_IDLE_SESSION_GRACE_MS,
   DocumentSessionManager,
+  type ClientDocumentSession,
   type DocumentSessionManagerOptions
 } from './manager.js';
 export {

--- a/packages/doc-session/src/index.ts
+++ b/packages/doc-session/src/index.ts
@@ -1,6 +1,7 @@
 export {
   DEFAULT_DEMO_DOCUMENT_CONTENT,
   OneFileDocumentSession,
+  PersistFailedError,
   type DocumentSessionEventHandler,
   type DocumentSessionWarning,
   type OneFileDocumentSessionOptions

--- a/packages/doc-session/src/manager.ts
+++ b/packages/doc-session/src/manager.ts
@@ -30,6 +30,7 @@ export class DocumentSessionManager {
   }
 
   getSession(vaultPath: string, overrides: Partial<Pick<OneFileDocumentSessionOptions, 'defaultContent'>> = {}): OneFileDocumentSession {
+    this.cancelIdleClose(vaultPath);
     const existing = this.sessions.get(vaultPath);
     if (existing) return existing;
 
@@ -77,6 +78,7 @@ export class DocumentSessionManager {
     operation: (session: OneFileDocumentSession) => Promise<T>,
     options: Partial<Pick<OneFileDocumentSessionOptions, 'defaultContent'>> = {}
   ): Promise<T> {
+    this.cancelIdleClose(vaultPath);
     const session = this.getSession(vaultPath, options);
     try {
       return await operation(session);
@@ -208,9 +210,23 @@ export class DocumentSessionManager {
     if (this.hasClients(vaultPath)) return;
     const session = this.sessions.get(vaultPath);
     if (!session) return;
-    await session.close();
-    if (!this.hasClients(vaultPath) && this.sessions.get(vaultPath) === session) {
-      this.sessions.delete(vaultPath);
+    if (session.hasActivePersistFailure()) {
+      console.warn(`KB-2 refused to close idle document session for ${vaultPath}; content is not durably persisted.`);
+      return;
+    }
+
+    // If a client acquires this path while close is in flight, it must hydrate
+    // a fresh session rather than reusing a half-detached closing session.
+    this.sessions.delete(vaultPath);
+    try {
+      await session.close();
+    } catch (error) {
+      if (session.hasActivePersistFailure()) {
+        this.sessions.set(vaultPath, session);
+        console.warn(`KB-2 refused to close idle document session for ${vaultPath}; content is not durably persisted.`, error);
+        return;
+      }
+      throw error;
     }
   }
 }

--- a/packages/doc-session/src/manager.ts
+++ b/packages/doc-session/src/manager.ts
@@ -2,27 +2,40 @@ import { join } from 'node:path';
 
 import { OneFileDocumentSession, type OneFileDocumentSessionOptions } from './session.js';
 
+export const DEFAULT_IDLE_SESSION_GRACE_MS = 30_000;
+
 export interface DocumentSessionManagerOptions extends OneFileDocumentSessionOptions {
   root: string;
+  idleSessionGraceMs?: number;
+}
+
+export interface ClientDocumentSession {
+  session: OneFileDocumentSession;
+  release: () => void;
 }
 
 export class DocumentSessionManager {
   private readonly root: string;
   private readonly options: Omit<OneFileDocumentSessionOptions, 'eventPath'>;
+  private readonly idleSessionGraceMs: number;
   private readonly sessions = new Map<string, OneFileDocumentSession>();
+  private readonly clientCounts = new Map<string, number>();
+  private readonly idleCloseTimers = new Map<string, NodeJS.Timeout>();
 
   constructor(options: DocumentSessionManagerOptions) {
     this.root = options.root;
-    const { root: _root, ...sessionOptions } = options;
+    this.idleSessionGraceMs = options.idleSessionGraceMs ?? DEFAULT_IDLE_SESSION_GRACE_MS;
+    const { root: _root, idleSessionGraceMs: _idleSessionGraceMs, ...sessionOptions } = options;
     this.options = sessionOptions;
   }
 
-  getSession(vaultPath: string): OneFileDocumentSession {
+  getSession(vaultPath: string, overrides: Partial<Pick<OneFileDocumentSessionOptions, 'defaultContent'>> = {}): OneFileDocumentSession {
     const existing = this.sessions.get(vaultPath);
     if (existing) return existing;
 
     const session = new OneFileDocumentSession(this.toFilePath(vaultPath), {
       ...this.options,
+      ...overrides,
       eventPath: vaultPath
     });
     this.sessions.set(vaultPath, session);
@@ -38,8 +51,48 @@ export class DocumentSessionManager {
     return session;
   }
 
+  attachClientSession(vaultPath: string): ClientDocumentSession {
+    const session = this.getSession(vaultPath);
+    this.cancelIdleClose(vaultPath);
+    this.clientCounts.set(vaultPath, (this.clientCounts.get(vaultPath) ?? 0) + 1);
+    let released = false;
+    return {
+      session,
+      release: () => {
+        if (released) return;
+        released = true;
+        const nextCount = (this.clientCounts.get(vaultPath) ?? 1) - 1;
+        if (nextCount > 0) {
+          this.clientCounts.set(vaultPath, nextCount);
+          return;
+        }
+        this.clientCounts.delete(vaultPath);
+        this.scheduleIdleClose(vaultPath);
+      }
+    };
+  }
+
+  async withSession<T>(
+    vaultPath: string,
+    operation: (session: OneFileDocumentSession) => Promise<T>,
+    options: Partial<Pick<OneFileDocumentSessionOptions, 'defaultContent'>> = {}
+  ): Promise<T> {
+    const session = this.getSession(vaultPath, options);
+    try {
+      return await operation(session);
+    } finally {
+      if (!this.hasClients(vaultPath)) {
+        this.scheduleIdleClose(vaultPath);
+      }
+    }
+  }
+
   getOpenSession(vaultPath: string): OneFileDocumentSession | undefined {
     return this.sessions.get(vaultPath);
+  }
+
+  getOpenSessionCount(): number {
+    return this.sessions.size;
   }
 
   async moveSession(
@@ -114,11 +167,50 @@ export class DocumentSessionManager {
   }
 
   async close(): Promise<void> {
+    for (const timer of this.idleCloseTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.idleCloseTimers.clear();
     await Promise.all([...this.sessions.values()].map((session) => session.close()));
     this.sessions.clear();
+    this.clientCounts.clear();
   }
 
   private toFilePath(vaultPath: string): string {
     return join(this.root, ...vaultPath.split('/'));
+  }
+
+  private hasClients(vaultPath: string): boolean {
+    return (this.clientCounts.get(vaultPath) ?? 0) > 0;
+  }
+
+  private cancelIdleClose(vaultPath: string): void {
+    const existing = this.idleCloseTimers.get(vaultPath);
+    if (!existing) return;
+    clearTimeout(existing);
+    this.idleCloseTimers.delete(vaultPath);
+  }
+
+  private scheduleIdleClose(vaultPath: string): void {
+    if (this.hasClients(vaultPath) || !this.sessions.has(vaultPath)) return;
+    this.cancelIdleClose(vaultPath);
+    const timer = setTimeout(() => {
+      void this.closeSession(vaultPath).catch((error: unknown) => {
+        console.warn(`KB-2 failed to close idle document session for ${vaultPath}.`, error);
+      });
+    }, this.idleSessionGraceMs);
+    timer.unref?.();
+    this.idleCloseTimers.set(vaultPath, timer);
+  }
+
+  private async closeSession(vaultPath: string): Promise<void> {
+    this.cancelIdleClose(vaultPath);
+    if (this.hasClients(vaultPath)) return;
+    const session = this.sessions.get(vaultPath);
+    if (!session) return;
+    await session.close();
+    if (!this.hasClients(vaultPath) && this.sessions.get(vaultPath) === session) {
+      this.sessions.delete(vaultPath);
+    }
   }
 }

--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -107,6 +107,66 @@ describe('OneFileDocumentSession', () => {
     await session.close();
   });
 
+  it('issues baselines, rejects stale baseline edits with current content, and retries with the fresh baseline', async () => {
+    const session = new OneFileDocumentSession(filePath, { defaultContent: 'one two three\n' });
+    await session.open();
+
+    const firstRead = await session.readWithBaseline();
+    expect(firstRead).toMatchObject({ content: 'one two three\n' });
+    expect(firstRead.baseline.length).toBeGreaterThan(0);
+
+    await session.applyContentEdit((current) => current.replace('two', 'TWO'));
+    const stale = await session.applyBaselineEdit(firstRead.baseline, (current) => ({
+      ok: true,
+      content: current.replace('three', 'THREE')
+    }));
+
+    expect(stale).toMatchObject({
+      ok: false,
+      rejected: 'stale_doc',
+      current_content: 'one TWO three\n'
+    });
+    if (stale.ok || stale.rejected !== 'stale_doc') throw new Error('expected stale_doc');
+    if (typeof stale.baseline !== 'string') throw new Error('expected fresh baseline');
+    expect(stale.baseline).not.toBe(firstRead.baseline);
+
+    const retry = await session.applyBaselineEdit(stale.baseline, (current) => ({
+      ok: true,
+      content: current.replace('three', 'THREE')
+    }));
+    expect(retry).toMatchObject({
+      ok: true,
+      content: 'one TWO THREE\n'
+    });
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('one TWO THREE\n');
+    await session.close();
+  });
+
+  it('applies a baseline edit through the session Y.Text so concurrent Yjs updates survive', async () => {
+    const session = new OneFileDocumentSession(filePath, { defaultContent: 'alpha\nomega\n' });
+    await session.open();
+    const read = await session.readWithBaseline();
+
+    const clientDoc = new Y.Doc();
+    Y.applyUpdate(clientDoc, Y.encodeStateAsUpdate(session.ydoc), session);
+    clientDoc.getText('markdown').insert('alpha\n'.length, 'typed while splice lands\n');
+    const inFlightUpdate = Y.encodeStateAsUpdate(clientDoc, Y.encodeStateVector(session.ydoc));
+
+    const splice = await session.applyBaselineEdit(read.baseline, (current) => ({
+      ok: true,
+      content: current.replace('omega', 'agent splice')
+    }));
+    expect(splice).toMatchObject({ ok: true, content: 'alpha\nagent splice\n' });
+
+    Y.applyUpdate(session.ydoc, inFlightUpdate, clientDoc);
+    await session.flush();
+
+    const persisted = await readFile(filePath, 'utf8');
+    expect(persisted).toContain('typed while splice lands\n');
+    expect(persisted).toContain('agent splice\n');
+    await session.close();
+  });
+
   it('rebuilds a fresh session from the last materialized content', async () => {
     const firstSession = new OneFileDocumentSession(filePath, { defaultContent: '' });
     await firstSession.open();
@@ -403,6 +463,125 @@ describe('OneFileDocumentSession', () => {
     })).resolves.toEqual([]);
     expect(deleted).toBe(true);
     await manager.close();
+  });
+
+  it('keeps a released client session alive through the idle grace and closes it after', async () => {
+    const manager = new DocumentSessionManager({
+      root: join(kb2Home, 'demo-vault'),
+      defaultContent: 'base\n',
+      idleSessionGraceMs: 80
+    });
+    const first = manager.attachClientSession('idle.md');
+    await first.session.open();
+    first.release();
+
+    const second = manager.attachClientSession('idle.md');
+    expect(second.session).toBe(first.session);
+    second.release();
+
+    await waitUntil(() => manager.getOpenSessionCount() === 0, () =>
+      `Timed out waiting for idle close; count=${manager.getOpenSessionCount()}`
+    );
+    await manager.close();
+  });
+
+  it('flushes a pending client edit before idle close removes the session', async () => {
+    const manager = new DocumentSessionManager({
+      root: join(kb2Home, 'demo-vault'),
+      defaultContent: '',
+      idleSessionGraceMs: 1
+    });
+    const lease = manager.attachClientSession('flush-before-close.md');
+    await lease.session.open();
+    lease.session.ydoc.getText('markdown').insert(0, 'pending before close\n');
+    lease.release();
+
+    await waitUntil(() => manager.getOpenSessionCount() === 0, () =>
+      `Timed out waiting for idle close; count=${manager.getOpenSessionCount()}`
+    );
+    await expect(readFile(join(kb2Home, 'demo-vault', 'flush-before-close.md'), 'utf8'))
+      .resolves.toBe('pending before close\n');
+    await manager.close();
+  });
+
+  it('hydrates API sessions with default content, keeps them through idle grace, then closes them', async () => {
+    const manager = new DocumentSessionManager({
+      root: join(kb2Home, 'demo-vault'),
+      idleSessionGraceMs: 20
+    });
+
+    const result = await manager.withSession(
+      'api-created.md',
+      async (session) => {
+        await session.open();
+        return session.getContent();
+      },
+      { defaultContent: '' }
+    );
+
+    expect(result).toBe('');
+    expect(manager.getOpenSession('api-created.md')).toBeDefined();
+    await waitUntil(() => manager.getOpenSessionCount() === 0, () =>
+      `Timed out waiting for API session idle close; count=${manager.getOpenSessionCount()}`
+    );
+    await manager.close();
+  });
+
+  it('does not idle-close an API-touched session while a client is attached', async () => {
+    const manager = new DocumentSessionManager({
+      root: join(kb2Home, 'demo-vault'),
+      defaultContent: 'client\n',
+      idleSessionGraceMs: 10
+    });
+    const lease = manager.attachClientSession('client-held.md');
+    await lease.session.open();
+
+    await manager.withSession('client-held.md', async (session) => {
+      expect(session).toBe(lease.session);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(manager.getOpenSession('client-held.md')).toBe(lease.session);
+
+    lease.release();
+    await waitUntil(() => manager.getOpenSessionCount() === 0, () =>
+      `Timed out waiting for released client idle close; count=${manager.getOpenSessionCount()}`
+    );
+    await manager.close();
+  });
+
+  it('moves a single live manager session and updates the path registry', async () => {
+    const manager = new DocumentSessionManager({
+      root: join(kb2Home, 'demo-vault'),
+      defaultContent: ''
+    });
+    const session = manager.getSession('single-move.md');
+    await session.open();
+    session.ydoc.getText('markdown').insert(0, 'single\n');
+    await session.flush();
+
+    await expect(manager.moveSession('single-move.md', 'moved-single.md', async () => {
+      await rename(join(kb2Home, 'demo-vault', 'single-move.md'), join(kb2Home, 'demo-vault', 'moved-single.md'));
+    })).resolves.toBe(true);
+
+    expect(manager.getOpenSession('single-move.md')).toBeUndefined();
+    expect(manager.getOpenSession('moved-single.md')).toBe(session);
+    await expect(readFile(join(kb2Home, 'demo-vault', 'moved-single.md'), 'utf8')).resolves.toBe('single\n');
+    await manager.close();
+  });
+
+  it('clears pending idle timers when the manager closes', async () => {
+    const manager = new DocumentSessionManager({
+      root: join(kb2Home, 'demo-vault'),
+      defaultContent: '',
+      idleSessionGraceMs: 10_000
+    });
+    await manager.withSession('timer.md', async (session) => {
+      await session.open();
+    });
+    expect(manager.getOpenSession('timer.md')).toBeDefined();
+
+    await manager.close();
+    expect(manager.getOpenSessionCount()).toBe(0);
   });
 
   it('deletes every live session under a folder subtree once after the disk delete', async () => {

--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -126,7 +126,9 @@ describe('OneFileDocumentSession', () => {
       rejected: 'stale_doc',
       current_content: 'one TWO three\n'
     });
-    if (stale.ok || stale.rejected !== 'stale_doc') throw new Error('expected stale_doc');
+    if (stale.ok || stale.rejected !== 'stale_doc' || typeof stale.current_content !== 'string') {
+      throw new Error('expected stale_doc');
+    }
     if (typeof stale.baseline !== 'string') throw new Error('expected fresh baseline');
     expect(stale.baseline).not.toBe(firstRead.baseline);
 
@@ -139,6 +141,31 @@ describe('OneFileDocumentSession', () => {
       content: 'one TWO THREE\n'
     });
     await expect(readFile(filePath, 'utf8')).resolves.toBe('one TWO THREE\n');
+    await session.close();
+  });
+
+  it('truncates stale baseline echoes for oversized resident documents', async () => {
+    const session = new OneFileDocumentSession(filePath, { defaultContent: 'small\n' });
+    await session.open();
+    const firstRead = await session.readWithBaseline();
+
+    await session.applyContent(`${'x'.repeat(1024 * 1024 + 32)}\n`);
+    const stale = await session.applyBaselineEdit(firstRead.baseline, (current) => ({
+      ok: true,
+      content: `${current}unreachable`
+    }));
+
+    expect(stale).toMatchObject({
+      ok: false,
+      rejected: 'stale_doc',
+      truncated: true
+    });
+    if (stale.ok || stale.rejected !== 'stale_doc') {
+      throw new Error('expected stale_doc');
+    }
+    const staleContent = stale.current_content;
+    if (typeof staleContent !== 'string') throw new Error('expected current_content');
+    expect(new TextEncoder().encode(staleContent).length).toBeLessThanOrEqual(1024 * 1024);
     await session.close();
   });
 
@@ -197,6 +224,38 @@ describe('OneFileDocumentSession', () => {
     );
 
     expect(eventKinds(events)).toEqual(['external-merge']);
+    await session.close();
+  });
+
+  it('uses the default external-change warning and keeps notifying after a handler throws', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const events: DocumentSessionEvent[] = [];
+    await writeFileWithParents(filePath, 'active\n');
+    const session = new OneFileDocumentSession(filePath, {
+      watchDebounceMs: 10,
+      watchPollMs: 50
+    });
+    session.onEvent(() => {
+      throw new Error('handler failed');
+    });
+    session.onEvent((event) => events.push(event));
+    await session.open();
+
+    await writeFile(filePath, 'external edit\n', 'utf8');
+
+    await waitUntil(() => events.some((event) => event.kind === 'external-merge'), () =>
+      `Timed out waiting for external merge; events=${JSON.stringify(events)}`
+    );
+
+    await writeFile(filePath, 'racing disk edit\n', 'utf8');
+    await session.reset('session edit\n');
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('external document change detected'));
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('document session event handler failed'),
+      expect.any(Error)
+    );
+    warnSpy.mockRestore();
     await session.close();
   });
 
@@ -362,6 +421,33 @@ describe('OneFileDocumentSession', () => {
     await session.close();
   });
 
+  it('fails explicit flushes until a later write successfully persists', async () => {
+    const session = new OneFileDocumentSession(filePath, { defaultContent: '' });
+    await session.open();
+    const vaultDir = dirname(filePath);
+
+    try {
+      await chmod(vaultDir, 0o500);
+      session.ydoc.getText('markdown').insert(0, 'unsaved\n');
+      await expect(session.flush()).rejects.toThrow('Failed to persist document session');
+      await expect(session.flush()).rejects.toThrow('Failed to persist document session');
+      expect(session.hasActivePersistFailure()).toBe(true);
+
+      await chmod(vaultDir, 0o700);
+      session.ydoc.getText('markdown').insert(session.ydoc.getText('markdown').length, 'saved\n');
+      await session.flush();
+      expect(session.hasActivePersistFailure()).toBe(false);
+      await expect(readFile(filePath, 'utf8')).resolves.toBe('unsaved\nsaved\n');
+    } finally {
+      await chmod(vaultDir, 0o700).catch(() => undefined);
+      if (session.hasActivePersistFailure()) {
+        session.ydoc.getText('markdown').insert(session.ydoc.getText('markdown').length, 'cleanup\n');
+        await session.flush().catch(() => undefined);
+      }
+      await session.close();
+    }
+  });
+
   it('reconciles direct filesystem changes before materializing a racing session edit', async () => {
     const events: DocumentSessionEvent[] = [];
     const warnings: DocumentSessionWarning[] = [];
@@ -485,6 +571,31 @@ describe('OneFileDocumentSession', () => {
     await manager.close();
   });
 
+  it('keeps a session open until every simultaneous client lease is released', async () => {
+    const manager = new DocumentSessionManager({
+      root: join(kb2Home, 'demo-vault'),
+      defaultContent: '',
+      idleSessionGraceMs: 30
+    });
+    const first = manager.attachClientSession('leased.md');
+    const second = manager.attachClientSession('leased.md');
+    await first.session.open();
+
+    try {
+      first.release();
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      expect(manager.getOpenSession('leased.md')).toBe(first.session);
+
+      second.release();
+      await waitUntil(() => manager.getOpenSessionCount() === 0, () =>
+        `Timed out waiting for all leases to release; count=${manager.getOpenSessionCount()}`
+      );
+    } finally {
+      second.release();
+      await manager.close();
+    }
+  });
+
   it('flushes a pending client edit before idle close removes the session', async () => {
     const manager = new DocumentSessionManager({
       root: join(kb2Home, 'demo-vault'),
@@ -502,6 +613,41 @@ describe('OneFileDocumentSession', () => {
     await expect(readFile(join(kb2Home, 'demo-vault', 'flush-before-close.md'), 'utf8'))
       .resolves.toBe('pending before close\n');
     await manager.close();
+  });
+
+  it('does not idle-close a session whose latest content failed to persist', async () => {
+    const manager = new DocumentSessionManager({
+      root: join(kb2Home, 'demo-vault'),
+      defaultContent: 'base\n',
+      idleSessionGraceMs: 20
+    });
+    const lease = manager.attachClientSession('readonly.md');
+    await lease.session.open();
+    const vaultDir = join(kb2Home, 'demo-vault');
+
+    try {
+      await chmod(vaultDir, 0o500);
+      lease.session.ydoc.getText('markdown').insert(lease.session.ydoc.getText('markdown').length, 'unsaved\n');
+      await expect(lease.session.flush()).rejects.toThrow('Failed to persist document session');
+      lease.release();
+
+      await new Promise((resolve) => setTimeout(resolve, 70));
+      expect(manager.getOpenSession('readonly.md')).toBe(lease.session);
+      await expect(lease.session.getContent()).resolves.toBe('base\nunsaved\n');
+
+      await chmod(vaultDir, 0o700);
+      lease.session.ydoc.getText('markdown').insert(lease.session.ydoc.getText('markdown').length, 'saved\n');
+      await lease.session.flush();
+      await expect(readFile(join(kb2Home, 'demo-vault', 'readonly.md'), 'utf8')).resolves.toBe('base\nunsaved\nsaved\n');
+    } finally {
+      await chmod(vaultDir, 0o700).catch(() => undefined);
+      if (lease.session.hasActivePersistFailure()) {
+        lease.session.ydoc.getText('markdown').insert(lease.session.ydoc.getText('markdown').length, 'cleanup recovery\n');
+        await lease.session.flush().catch(() => undefined);
+      }
+      lease.release();
+      await manager.close();
+    }
   });
 
   it('hydrates API sessions with default content, keeps them through idle grace, then closes them', async () => {
@@ -527,6 +673,29 @@ describe('OneFileDocumentSession', () => {
     await manager.close();
   });
 
+  it('cancels a pending idle close when an API session is acquired again', async () => {
+    const manager = new DocumentSessionManager({
+      root: join(kb2Home, 'demo-vault'),
+      idleSessionGraceMs: 30
+    });
+
+    const result = await manager.withSession(
+      'api-retained.md',
+      async (session) => {
+        await session.open();
+        return session;
+      },
+      { defaultContent: '' }
+    );
+
+    expect(manager.getOpenSession('api-retained.md')).toBe(result);
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(manager.getSession('api-retained.md')).toBe(result);
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(manager.getOpenSession('api-retained.md')).toBe(result);
+    await manager.close();
+  });
+
   it('does not idle-close an API-touched session while a client is attached', async () => {
     const manager = new DocumentSessionManager({
       root: join(kb2Home, 'demo-vault'),
@@ -547,6 +716,116 @@ describe('OneFileDocumentSession', () => {
       `Timed out waiting for released client idle close; count=${manager.getOpenSessionCount()}`
     );
     await manager.close();
+  });
+
+  it('hydrates a fresh session when a client attaches while idle close is in flight', async () => {
+    const manager = new DocumentSessionManager({
+      root: join(kb2Home, 'demo-vault'),
+      defaultContent: 'base\n',
+      idleSessionGraceMs: 1
+    });
+    const original = manager.getSession('closing.md');
+    await original.open();
+    let closeStarted!: () => void;
+    let allowClose!: () => void;
+    const closeStartedPromise = new Promise<void>((resolve) => {
+      closeStarted = resolve;
+    });
+    const allowClosePromise = new Promise<void>((resolve) => {
+      allowClose = resolve;
+    });
+    const originalClose = original.close.bind(original);
+    original.close = async () => {
+      closeStarted();
+      await allowClosePromise;
+      await originalClose();
+    };
+
+    await manager.withSession('closing.md', async (session) => {
+      expect(session).toBe(original);
+    });
+    await closeStartedPromise;
+
+    const attachedDuringClose = manager.attachClientSession('closing.md');
+    try {
+      expect(attachedDuringClose.session).not.toBe(original);
+      await attachedDuringClose.session.open();
+      expect(manager.getOpenSession('closing.md')).toBe(attachedDuringClose.session);
+    } finally {
+      allowClose();
+      attachedDuringClose.release();
+      await waitUntil(() => manager.getOpenSessionCount() === 0, () =>
+        `Timed out waiting for fresh attached session to close; count=${manager.getOpenSessionCount()}`
+      );
+      await manager.close();
+    }
+  });
+
+  it('logs unexpected idle close failures without keeping the failed session registered', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const manager = new DocumentSessionManager({
+      root: join(kb2Home, 'demo-vault'),
+      defaultContent: '',
+      idleSessionGraceMs: 1
+    });
+    const session = manager.getSession('close-error.md');
+    await session.open();
+    session.close = async () => {
+      throw new Error('unexpected close failure');
+    };
+
+    try {
+      await manager.withSession('close-error.md', async (active) => {
+        expect(active).toBe(session);
+      });
+      await waitUntil(() => manager.getOpenSession('close-error.md') === undefined, () =>
+        'Timed out waiting for failed close to unregister session'
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('failed to close idle document session'),
+        expect.any(Error)
+      );
+    } finally {
+      warnSpy.mockRestore();
+      await manager.close();
+    }
+  });
+
+  it('restores an idle-closing session when close discovers a persist failure', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const manager = new DocumentSessionManager({
+      root: join(kb2Home, 'demo-vault'),
+      defaultContent: '',
+      idleSessionGraceMs: 1
+    });
+    const session = manager.getSession('late-persist-failure.md');
+    await session.open();
+    const originalClose = session.close.bind(session);
+    session.close = async () => {
+      (session as unknown as { persistFailed: boolean }).persistFailed = true;
+      throw new Error('late persist failure');
+    };
+
+    try {
+      await manager.withSession('late-persist-failure.md', async (active) => {
+        expect(active).toBe(session);
+      });
+      await waitUntil(() => warnSpy.mock.calls.length > 0, () =>
+        'Timed out waiting for failed-persist close warning'
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('refused to close idle document session'),
+        expect.any(Error)
+      );
+      expect(manager.getOpenSession('late-persist-failure.md')).toBe(session);
+      (session as unknown as { persistFailed: boolean }).persistFailed = false;
+      session.close = originalClose;
+    } finally {
+      warnSpy.mockRestore();
+      (session as unknown as { persistFailed: boolean }).persistFailed = false;
+      session.close = originalClose;
+      await manager.close();
+    }
   });
 
   it('moves a single live manager session and updates the path registry', async () => {

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -55,6 +55,16 @@ export type SessionSpliceResult =
     }
   | SessionContentEditReject;
 
+export class PersistFailedError extends Error {
+  constructor(
+    readonly filePath: string,
+    readonly cause: unknown
+  ) {
+    super(`Failed to persist document session for ${filePath}`);
+    this.name = 'PersistFailedError';
+  }
+}
+
 export class OneFileDocumentSession {
   filePath: string;
 
@@ -74,6 +84,7 @@ export class OneFileDocumentSession {
   private persistRequested = false;
   private persistPromise: Promise<void> | undefined;
   private persistFailed = false;
+  private persistFailureError: PersistFailedError | undefined;
   private activePersistFailureEvent: DocumentSessionEvent | undefined;
   private watcher: FSWatcher | undefined;
   private watchDebounceTimer: NodeJS.Timeout | undefined;
@@ -143,6 +154,10 @@ export class OneFileDocumentSession {
 
   getActivePersistFailureEvent(): DocumentSessionEvent | undefined {
     return this.activePersistFailureEvent;
+  }
+
+  hasActivePersistFailure(): boolean {
+    return this.persistFailed;
   }
 
   async reset(content = this.defaultContent): Promise<string> {
@@ -217,6 +232,9 @@ export class OneFileDocumentSession {
   async flush(): Promise<void> {
     if (this.persistPromise) {
       await this.persistPromise;
+    }
+    if (this.persistFailureError) {
+      throw this.persistFailureError;
     }
   }
 
@@ -341,13 +359,17 @@ export class OneFileDocumentSession {
   }
 
   private async persistLoop(): Promise<void> {
+    let failure: PersistFailedError | undefined;
     while (this.persistRequested) {
       this.persistRequested = false;
       try {
         await this.materialize();
       } catch (error) {
-        this.markPersistFailed(error);
+        failure = this.markPersistFailed(error);
       }
+    }
+    if (failure) {
+      throw failure;
     }
   }
 
@@ -575,12 +597,17 @@ export class OneFileDocumentSession {
     this.emitEvent(eventKind);
   }
 
-  private markPersistFailed(error: unknown): void {
+  private markPersistFailed(error: unknown): PersistFailedError {
     this.persistFailed = true;
+    const persistError = error instanceof PersistFailedError
+      ? error
+      : new PersistFailedError(this.filePath, error);
+    this.persistFailureError = persistError;
     const event = this.createEvent('persist-failure');
     this.activePersistFailureEvent = event;
     this.emitEvent(event);
     console.warn(`KB-2 failed to persist document update for ${this.filePath}; keeping active Yjs session open.`, error);
+    return persistError;
   }
 
   private markPersistRecovered(): void {
@@ -589,6 +616,7 @@ export class OneFileDocumentSession {
     }
 
     this.persistFailed = false;
+    this.persistFailureError = undefined;
     this.activePersistFailureEvent = undefined;
     this.emitEvent('persist-recovered');
   }

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -17,8 +17,10 @@ export const DEFAULT_DEMO_DOCUMENT_CONTENT = [
 
 const Y_TEXT_NAME = 'markdown';
 const EXTERNAL_CHANGE_ORIGIN = Symbol('kb2.external-change');
+const AGENT_SPLICE_ORIGIN = Symbol('kb2.agent-splice');
 const WATCH_DEBOUNCE_MS = 150;
 const WATCH_POLL_MS = 2000;
+const DOCUMENT_BYTES_LIMIT = 1024 * 1024;
 
 export interface DocumentSessionWarning {
   type: 'external-change-detected';
@@ -36,6 +38,22 @@ export interface OneFileDocumentSessionOptions {
 }
 
 export type DocumentSessionEventHandler = (event: DocumentSessionEvent) => void;
+
+export type SessionContentEditResult =
+  | { ok: true; content: string }
+  | ({ ok: false; rejected: string } & Record<string, unknown>);
+export type SessionContentEditReject = Exclude<SessionContentEditResult, { ok: true }>;
+
+export type SessionSpliceResult =
+  | { ok: true; content: string; baseline: string }
+  | {
+      ok: false;
+      rejected: 'stale_doc';
+      current_content: string;
+      baseline: string;
+      truncated?: boolean;
+    }
+  | SessionContentEditReject;
 
 export class OneFileDocumentSession {
   filePath: string;
@@ -108,6 +126,14 @@ export class OneFileDocumentSession {
     return this.currentContent();
   }
 
+  async readWithBaseline(): Promise<{ content: string; baseline: string }> {
+    await this.open();
+    return {
+      content: this.currentContent(),
+      baseline: this.currentBaseline()
+    };
+  }
+
   onEvent(handler: DocumentSessionEventHandler): () => void {
     this.eventHandlers.add(handler);
     return () => {
@@ -149,6 +175,43 @@ export class OneFileDocumentSession {
 
     await this.flush();
     return this.currentContent();
+  }
+
+  async applyBaselineEdit(
+    baseline: string,
+    edit: (currentContent: string) => SessionContentEditResult
+  ): Promise<SessionSpliceResult> {
+    await this.open();
+    if (this.deleted) {
+      throw new Error(`Document session for ${this.eventPath} has been deleted.`);
+    }
+
+    const currentBaseline = this.currentBaseline();
+    if (baseline !== currentBaseline) {
+      return this.staleDocResult(currentBaseline);
+    }
+
+    const current = this.currentContent();
+    const result = edit(current);
+    if (!result.ok) return result;
+
+    if (current !== result.content) {
+      this.doc.transact(() => {
+        this.text.applyDelta(createFastDiffYTextDelta(current, result.content));
+      }, AGENT_SPLICE_ORIGIN);
+    }
+
+    await this.flush();
+    return {
+      ok: true,
+      content: this.currentContent(),
+      baseline: this.currentBaseline()
+    };
+  }
+
+  async applyContentEdit(edit: (currentContent: string) => string): Promise<{ content: string; baseline: string }> {
+    await this.open();
+    return this.applyPositionedContent(edit(this.currentContentAfterOpen()));
   }
 
   async flush(): Promise<void> {
@@ -337,6 +400,55 @@ export class OneFileDocumentSession {
 
   private currentContent(): string {
     return this.text.toString();
+  }
+
+  private currentBaseline(): string {
+    return encodeBase64Bytes(Y.encodeStateVector(this.doc));
+  }
+
+  private currentContentAfterOpen(): string {
+    if (!this.opened || this.deleted) {
+      throw new Error(`Document session for ${this.eventPath} is not open.`);
+    }
+    return this.currentContent();
+  }
+
+  private async applyPositionedContent(content: string): Promise<{ content: string; baseline: string }> {
+    await this.open();
+    if (this.deleted) {
+      throw new Error(`Document session for ${this.eventPath} has been deleted.`);
+    }
+    const current = this.currentContent();
+    if (current !== content) {
+      this.doc.transact(() => {
+        this.text.applyDelta(createFastDiffYTextDelta(current, content));
+      }, AGENT_SPLICE_ORIGIN);
+    }
+    await this.flush();
+    return {
+      content: this.currentContent(),
+      baseline: this.currentBaseline()
+    };
+  }
+
+  private staleDocResult(currentBaseline: string): Extract<SessionSpliceResult, { rejected: 'stale_doc' }> {
+    const content = this.currentContent();
+    if (utf8ByteLength(content) <= DOCUMENT_BYTES_LIMIT) {
+      return {
+        ok: false,
+        rejected: 'stale_doc',
+        current_content: content,
+        baseline: currentBaseline
+      };
+    }
+
+    return {
+      ok: false,
+      rejected: 'stale_doc',
+      current_content: truncateUtf8(content, DOCUMENT_BYTES_LIMIT),
+      baseline: currentBaseline,
+      truncated: true
+    };
   }
 
   private startWatching(): void {
@@ -546,6 +658,26 @@ function hashContent(content: string): string {
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && 'code' in error;
+}
+
+function encodeBase64Bytes(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64');
+}
+
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+function truncateUtf8(value: string, limitBytes: number): string {
+  let output = '';
+  let bytes = 0;
+  for (const char of value) {
+    const next = utf8ByteLength(char);
+    if (bytes + next > limitBytes) break;
+    output += char;
+    bytes += next;
+  }
+  return output;
 }
 
 export type YTextDeltaOperation =

--- a/packages/doc-session/src/websocket.test.ts
+++ b/packages/doc-session/src/websocket.test.ts
@@ -192,6 +192,10 @@ describe('Yjs WebSocket session', () => {
       } finally {
         lateClient.close();
       }
+
+      await chmod(vaultDir, 0o700);
+      clientA.text.insert(clientA.text.length, 'saved after replay\n');
+      await waitForSessionEvent([clientA], 'persist-recovered');
     } finally {
       await chmod(vaultDir, 0o700).catch(() => undefined);
       clientA.close();

--- a/packages/doc-session/src/websocket.ts
+++ b/packages/doc-session/src/websocket.ts
@@ -2,7 +2,7 @@ import * as decoding from 'lib0/decoding';
 import * as encoding from 'lib0/encoding';
 import * as syncProtocol from 'y-protocols/sync';
 
-import type { OneFileDocumentSession } from './session.js';
+import { PersistFailedError, type OneFileDocumentSession } from './session.js';
 import { MESSAGE_SYNC, encodeSessionEvent } from './protocol.js';
 
 export const DEMO_DOCUMENT_YJS_PATH = '/api/demo-document/yjs';
@@ -54,7 +54,13 @@ export async function bindYjsWebSocket(
     cleanupStarted = true;
     unsubscribeSessionEvents();
     session.ydoc.off('update', updateHandler);
-    session.flush().then(resolveClosed, rejectClosed);
+    session.flush().then(resolveClosed, (error: unknown) => {
+      if (error instanceof PersistFailedError) {
+        resolveClosed();
+        return;
+      }
+      rejectClosed(error);
+    });
   };
 
   socket.on('message', (data) => {

--- a/packages/doc-session/vitest.config.ts
+++ b/packages/doc-session/vitest.config.ts
@@ -7,9 +7,14 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text'],
-      include: ['src/manager.ts'],
+      include: ['src/manager.ts', 'src/session.ts'],
       thresholds: {
-        lines: 95
+        'src/manager.ts': {
+          lines: 95
+        },
+        'src/session.ts': {
+          lines: 90
+        }
       }
     }
   }

--- a/packages/doc-session/vitest.config.ts
+++ b/packages/doc-session/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       reporter: ['text'],
       include: ['src/manager.ts'],
       thresholds: {
-        lines: 90
+        lines: 95
       }
     }
   }

--- a/packages/vault-core/package.json
+++ b/packages/vault-core/package.json
@@ -23,5 +23,8 @@
     "@vitest/coverage-v8": "4.1.8",
     "fast-check": "4.8.0",
     "vitest": "4.1.8"
+  },
+  "dependencies": {
+    "gray-matter": "4.0.3"
   }
 }

--- a/packages/vault-core/src/audit.ts
+++ b/packages/vault-core/src/audit.ts
@@ -6,7 +6,15 @@ export interface VaultActor {
   client?: string;
 }
 
-export type AuditOperation = 'create' | 'write' | 'mkdir' | 'delete' | 'move';
+export type AuditOperation =
+  | 'create'
+  | 'write'
+  | 'mkdir'
+  | 'delete'
+  | 'move'
+  | 'splice'
+  | 'append'
+  | 'prepend';
 export type AuditEntityKind = 'file' | 'folder';
 
 export interface AuditEntry {

--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -1,16 +1,22 @@
-import { chmod, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import fc from 'fast-check';
 
 import {
+  DOCUMENT_BYTES_LIMIT,
+  SPLICE_BYTES_LIMIT,
+  appendContent,
+  applyAnchoredSplice,
   deleteVaultFile,
   deleteVaultFolder,
   getVaultInfo,
   listVaultTree,
   makeVaultFolder,
   moveVaultPath,
+  prependContent,
   readVaultFile,
+  searchVaultFiles,
   validateVaultPath,
   writeVaultFile,
   type VaultContext
@@ -291,7 +297,217 @@ describe('vault-core filesystem operations', () => {
   });
 });
 
+describe('anchored splice and positioned content helpers', () => {
+  it('applies exact replacements with anchors, occurrence, LF normalization, and surrogate pairs', () => {
+    expect(applyAnchoredSplice('one two three', {
+      oldText: 'two',
+      newText: 'TWO'
+    })).toEqual({ ok: true, content: 'one TWO three' });
+
+    expect(applyAnchoredSplice('foo bar foo baz foo', {
+      oldText: 'foo',
+      newText: 'FOO',
+      occurrence: 2
+    })).toEqual({ ok: true, content: 'foo bar FOO baz foo' });
+
+    expect(applyAnchoredSplice('aa aa aa', {
+      before: 'aa ',
+      oldText: 'aa',
+      after: ' aa',
+      newText: 'XX'
+    })).toEqual({ ok: true, content: 'aa XX aa' });
+
+    expect(applyAnchoredSplice('line one\nline two', {
+      oldText: 'one\r\nline',
+      newText: 'ONE\nLINE'
+    })).toEqual({ ok: true, content: 'line ONE\nLINE two' });
+
+    expect(applyAnchoredSplice('before 😀 after', {
+      oldText: '😀',
+      newText: '🧪'
+    })).toEqual({ ok: true, content: 'before 🧪 after' });
+  });
+
+  it('rejects missing, ambiguous, out-of-range, and size-capped splices', () => {
+    expect(applyAnchoredSplice('hello', {
+      oldText: 'missing',
+      newText: 'x'
+    })).toEqual({ ok: false, rejected: 'not_found' });
+
+    expect(applyAnchoredSplice('hello', {
+      oldText: '',
+      newText: 'x'
+    })).toEqual({ ok: false, rejected: 'not_found' });
+
+    expect(applyAnchoredSplice('aaa', {
+      oldText: 'aa',
+      newText: 'b'
+    })).toEqual({ ok: false, rejected: 'ambiguous', match_count: 2 });
+
+    expect(applyAnchoredSplice('foo foo', {
+      oldText: 'foo',
+      newText: 'bar',
+      occurrence: 3
+    })).toEqual({ ok: false, rejected: 'not_found' });
+
+    expect(applyAnchoredSplice('x', {
+      oldText: 'x'.repeat(SPLICE_BYTES_LIMIT + 1),
+      newText: 'y'
+    })).toEqual({ ok: false, rejected: 'too_large_splice', limit_bytes: SPLICE_BYTES_LIMIT });
+
+    const base = `x${'a'.repeat(DOCUMENT_BYTES_LIMIT - 1)}`;
+    expect(applyAnchoredSplice(base, {
+      oldText: 'x',
+      newText: 'yy'
+    })).toEqual({
+      ok: false,
+      rejected: 'too_large_document',
+      current_bytes: DOCUMENT_BYTES_LIMIT + 1,
+      limit_bytes: DOCUMENT_BYTES_LIMIT
+    });
+  });
+
+  it('property: anchored splice result equals the direct string replacement for generated unicode documents', () => {
+    fc.assert(fc.property(
+      fc.string({ minLength: 1, maxLength: 120 }),
+      fc.string({ maxLength: 40 }),
+      fc.string({ maxLength: 40 }),
+      fc.string({ maxLength: 40 }),
+      (left, oldText, right, replacement) => {
+        fc.pre(oldText.length > 0);
+        const before = '__KB2_LEFT__';
+        const after = '__KB2_RIGHT__';
+        fc.pre(!left.includes(before + oldText + after));
+        fc.pre(!right.includes(before + oldText + after));
+        const source = `${left}${before}${oldText}${after}${right}😀`;
+        const expected = `${left}${before}${replacement}${after}${right}😀`;
+        const result = applyAnchoredSplice(source, {
+          before,
+          oldText,
+          after,
+          newText: replacement
+        });
+        expect(result).toEqual({ ok: true, content: expected });
+      }
+    ));
+  });
+
+  it('appends and prepends after YAML frontmatter using gray-matter detection', () => {
+    expect(appendContent('a\r\n', 'b\r\n')).toBe('a\r\nb\n');
+    expect(prependContent('body\n', 'top\r\n')).toBe('top\nbody\n');
+    expect(prependContent('---\ntitle: Test\n---\nbody\n', 'inserted\n')).toBe(
+      '---\ntitle: Test\n---\ninserted\nbody\n'
+    );
+  });
+});
+
+describe('scan search', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'kb2-search-'));
+    await writeFileWithParents(path.join(root, 'notes', 'a.md'), 'alpha\nBeta target\ngamma\n', 'utf8');
+    await writeFileWithParents(path.join(root, 'notes', 'deep', 'b.txt'), 'target two\nnext\n', 'utf8');
+    await writeFileWithParents(path.join(root, 'notes', 'deep', 'c.markdown'), 'no hit\n', 'utf8');
+    await writeFileWithParents(path.join(root, 'notes', 'skip.json'), 'target ignored\n', 'utf8');
+    await writeFileWithParents(path.join(root, '.kb2', 'audit', 'hidden.md'), 'target hidden\n', 'utf8');
+    await writeFileWithParents(path.join(root, 'trash', 'old.md'), 'target trashed\n', 'utf8');
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('finds case-insensitive line matches with context, filters, and pagination', async () => {
+    const result = await searchVaultFiles(root, {
+      q: 'TARGET',
+      under: 'notes',
+      context: 1,
+      limit: 1,
+      offset: 1
+    });
+
+    expect(result).toMatchObject({
+      q: 'TARGET',
+      under: 'notes',
+      limit: 1,
+      offset: 1,
+      total: 2
+    });
+    expect(result.results).toEqual([
+      {
+        path: 'notes/deep/b.txt',
+        line: 1,
+        lineText: 'target two',
+        context: { before: [], after: ['next'] }
+      }
+    ]);
+  });
+
+  it('searches from the vault root and excludes metadata and trash folders', async () => {
+    const result = await searchVaultFiles(root, { q: 'target', context: 0, limit: 10 });
+
+    expect(result.total).toBe(2);
+    expect(result.results.map((hit) => hit.path)).toEqual([
+      'notes/a.md',
+      'notes/deep/b.txt'
+    ]);
+    expect(result.results.every((hit) => hit.context.before.length === 0 && hit.context.after.length === 0)).toBe(true);
+  });
+
+  it('caps the searchable file walk before unbounded scans', async () => {
+    const cappedRoot = await mkdtemp(path.join(tmpdir(), 'kb2-search-cap-'));
+    try {
+      await Promise.all(Array.from({ length: 5001 }, async (_value, index) => {
+        await writeFile(path.join(cappedRoot, `file-${index}.md`), 'needle\n', 'utf8');
+      }));
+
+      const result = await searchVaultFiles(cappedRoot, { q: 'needle', limit: 10 });
+      expect(result.total).toBe(5000);
+      expect(result.results).toHaveLength(10);
+    } finally {
+      await rm(cappedRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('returns empty results for empty and missing-folder searches', async () => {
+    await expect(searchVaultFiles(root, { q: '   ' })).resolves.toMatchObject({
+      q: '   ',
+      total: 0,
+      results: []
+    });
+    await expect(searchVaultFiles(root, { q: 'target', under: 'missing' })).resolves.toMatchObject({
+      total: 0,
+      results: []
+    });
+    await expect(searchVaultFiles(root, {
+      q: 'target',
+      under: 'notes/a.md',
+      context: 50,
+      limit: -1,
+      offset: -1
+    })).resolves.toMatchObject({
+      limit: 20,
+      offset: 0,
+      total: 0,
+      results: []
+    });
+  });
+
+  it('rejects invalid folder filters through path validation', async () => {
+    await expect(searchVaultFiles(root, { q: 'target', under: '../outside' })).rejects.toThrow('Invalid vault path');
+  });
+});
+
 async function readAuditLines(root: string): Promise<unknown[]> {
   const content = await readFile(path.join(root, '.kb2/audit/changes.jsonl'), 'utf8');
   return content.trim().split('\n').map((line) => JSON.parse(line) as unknown);
+}
+
+async function writeFileWithParents(pathname: string, content: string, encoding: BufferEncoding): Promise<void> {
+  await writeFile(pathname, content, encoding).catch(async (error: unknown) => {
+    if (!(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT')) throw error;
+    await mkdir(path.dirname(pathname), { recursive: true });
+    await writeFile(pathname, content, encoding);
+  });
 }

--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -12,6 +12,7 @@ import {
   deleteVaultFolder,
   getVaultInfo,
   listVaultTree,
+  lfNormalize,
   makeVaultFolder,
   moveVaultPath,
   prependContent,
@@ -367,23 +368,35 @@ describe('anchored splice and positioned content helpers', () => {
     });
   });
 
-  it('property: anchored splice result equals the direct string replacement for generated unicode documents', () => {
+  it('property: anchored splice result equals the direct string replacement for generated full-unicode documents', () => {
+    const unicodeFragment = fc.array(
+      fc.oneof(
+        fc.string({ maxLength: 4 }),
+        fc.constantFrom('😀', '🧪', '𝌆', 'é', '中', '\uD800', '\uDC00', '\r\n', '\r')
+      ),
+      { maxLength: 20 }
+    ).map((parts) => parts.join(''));
+    const boundary = fc.constantFrom('', '😀', '🧪', '𝌆', '\uD800', '\uDC00');
+
     fc.assert(fc.property(
-      fc.string({ minLength: 1, maxLength: 120 }),
-      fc.string({ maxLength: 40 }),
-      fc.string({ maxLength: 40 }),
-      fc.string({ maxLength: 40 }),
-      (left, oldText, right, replacement) => {
-        fc.pre(oldText.length > 0);
+      unicodeFragment,
+      unicodeFragment,
+      unicodeFragment,
+      unicodeFragment,
+      boundary,
+      boundary,
+      (left, oldText, right, replacement, edgeBefore, edgeAfter) => {
+        const splicedText = `${edgeBefore}${oldText}${edgeAfter}`;
+        fc.pre(splicedText.length > 0);
         const before = '__KB2_LEFT__';
         const after = '__KB2_RIGHT__';
-        fc.pre(!left.includes(before + oldText + after));
-        fc.pre(!right.includes(before + oldText + after));
-        const source = `${left}${before}${oldText}${after}${right}😀`;
-        const expected = `${left}${before}${replacement}${after}${right}😀`;
+        fc.pre(!left.includes(before + splicedText + after));
+        fc.pre(!right.includes(before + splicedText + after));
+        const source = `${left}${before}${splicedText}${after}${right}`;
+        const expected = `${left}${before}${lfNormalize(replacement)}${after}${right}`;
         const result = applyAnchoredSplice(source, {
           before,
-          oldText,
+          oldText: splicedText,
           after,
           newText: replacement
         });
@@ -392,11 +405,45 @@ describe('anchored splice and positioned content helpers', () => {
     ));
   });
 
+  it('splices across CRLF, CR, and mixed line boundaries while preserving surrounding bytes', () => {
+    expect(applyAnchoredSplice('alpha\r\nold\r\nomega', {
+      oldText: 'old\nomega',
+      newText: 'NEW'
+    })).toEqual({ ok: true, content: 'alpha\r\nNEW' });
+
+    expect(applyAnchoredSplice('alpha\r\nold\r\nomega', {
+      oldText: 'old\r\nomega',
+      newText: 'NEW'
+    })).toEqual({ ok: true, content: 'alpha\r\nNEW' });
+
+    expect(applyAnchoredSplice('a\r\nb\rc\nd', {
+      oldText: 'b\nc\nd',
+      newText: 'B'
+    })).toEqual({ ok: true, content: 'a\r\nB' });
+
+    expect(applyAnchoredSplice('a\rb\rc', {
+      oldText: 'a\nb',
+      newText: 'AB'
+    })).toEqual({ ok: true, content: 'AB\rc' });
+  });
+
   it('appends and prepends after YAML frontmatter using gray-matter detection', () => {
     expect(appendContent('a\r\n', 'b\r\n')).toBe('a\r\nb\n');
     expect(prependContent('body\n', 'top\r\n')).toBe('top\nbody\n');
     expect(prependContent('---\ntitle: Test\n---\nbody\n', 'inserted\n')).toBe(
       '---\ntitle: Test\n---\ninserted\nbody\n'
+    );
+    expect(prependContent('---\nonly: front\n---', 'inserted\n')).toBe(
+      '---\nonly: front\n---\ninserted\n'
+    );
+    expect(prependContent('---\r\ntitle: Test\r\n---\r\nbody\r\n', 'inserted\n')).toBe(
+      '---\r\ntitle: Test\r\n---\r\ninserted\nbody\r\n'
+    );
+    expect(prependContent('---\ronly: front\r---\rbody\r', 'inserted\n')).toBe(
+      '---\ronly: front\r---\rinserted\nbody\r'
+    );
+    expect(prependContent('---\nonly: front\nbody\n', 'inserted\n')).toBe(
+      'inserted\n---\nonly: front\nbody\n'
     );
   });
 });
@@ -457,6 +504,7 @@ describe('scan search', () => {
 
   it('caps the searchable file walk before unbounded scans', async () => {
     const cappedRoot = await mkdtemp(path.join(tmpdir(), 'kb2-search-cap-'));
+    const nestedRoot = await mkdtemp(path.join(tmpdir(), 'kb2-search-nested-cap-'));
     try {
       await Promise.all(Array.from({ length: 5001 }, async (_value, index) => {
         await writeFile(path.join(cappedRoot, `file-${index}.md`), 'needle\n', 'utf8');
@@ -464,10 +512,61 @@ describe('scan search', () => {
 
       const result = await searchVaultFiles(cappedRoot, { q: 'needle', limit: 10 });
       expect(result.total).toBe(5000);
+      expect(result.truncated).toBe(true);
       expect(result.results).toHaveLength(10);
+
+      await mkdir(path.join(nestedRoot, 'nested'), { recursive: true });
+      await Promise.all(Array.from({ length: 5000 }, async (_value, index) => {
+        await writeFile(path.join(nestedRoot, 'nested', `file-${index}.md`), 'needle\n', 'utf8');
+      }));
+      await writeFile(path.join(nestedRoot, 'after.md'), 'needle\n', 'utf8');
+      const nested = await searchVaultFiles(nestedRoot, { q: 'needle', limit: 10 });
+      expect(nested.total).toBe(5000);
+      expect(nested.truncated).toBe(true);
     } finally {
       await rm(cappedRoot, { recursive: true, force: true });
+      await rm(nestedRoot, { recursive: true, force: true });
     }
+  });
+
+  it('property: every randomized search result references a real line in a real file', async () => {
+    const segment = fc.stringMatching(/^[a-z]{1,8}$/);
+    const relativeFile = fc.tuple(fc.array(segment, { maxLength: 2 }), segment)
+      .map(([folders, name]) => [...folders, `${name}.md`].join('/'));
+    const line = fc.string({ maxLength: 24 }).filter((value) => !value.includes('\n'));
+    const fileSet = fc.uniqueArray(
+      fc.record({
+        path: relativeFile,
+        lines: fc.array(line, { minLength: 1, maxLength: 8 })
+      }),
+      { minLength: 1, maxLength: 12, selector: (file) => file.path }
+    );
+
+    await fc.assert(fc.asyncProperty(fileSet, async (files) => {
+      const propertyRoot = await mkdtemp(path.join(tmpdir(), 'kb2-search-property-'));
+      try {
+        const expectedLines = new Map<string, string[]>();
+        for (const file of files) {
+          const lines = file.lines.length > 0 && file.lines.some((candidate) => candidate.includes('needle'))
+            ? file.lines
+            : ['needle', ...file.lines];
+          expectedLines.set(file.path, lines);
+          await writeFileWithParents(path.join(propertyRoot, file.path), `${lines.join('\n')}\n`, 'utf8');
+        }
+
+        const result = await searchVaultFiles(propertyRoot, { q: 'needle', limit: 100, context: 2 });
+        for (const hit of result.results) {
+          const lines = expectedLines.get(hit.path);
+          expect(lines).toBeDefined();
+          expect(hit.line).toBeGreaterThanOrEqual(1);
+          expect(hit.line).toBeLessThanOrEqual(lines!.length);
+          expect(hit.lineText).toBe(lines![hit.line - 1]);
+          expect(hit.lineText.toLocaleLowerCase()).toContain('needle');
+        }
+      } finally {
+        await rm(propertyRoot, { recursive: true, force: true });
+      }
+    }), { numRuns: 35 });
   });
 
   it('returns empty results for empty and missing-folder searches', async () => {

--- a/packages/vault-core/src/index.ts
+++ b/packages/vault-core/src/index.ts
@@ -20,6 +20,23 @@ import {
 
 export { appendAudit, InvalidPathError, validateVaultPath };
 export type { AuditEntry, VaultActor };
+export {
+  DOCUMENT_BYTES_LIMIT,
+  SPLICE_BYTES_LIMIT,
+  appendContent,
+  applyAnchoredSplice,
+  lfNormalize,
+  prependContent,
+  utf8ByteLength,
+  type AnchoredSpliceRequest,
+  type AnchoredSpliceResult
+} from './splice.js';
+export {
+  searchVaultFiles,
+  type SearchHit,
+  type SearchInput,
+  type SearchResult
+} from './search.js';
 
 export type VaultErrorCode =
   | 'invalid_path'

--- a/packages/vault-core/src/search.ts
+++ b/packages/vault-core/src/search.ts
@@ -1,0 +1,156 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+import { InvalidPathError, validateOptionalVaultPath } from './path.js';
+
+export interface SearchInput {
+  q: string;
+  under?: string;
+  context?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface SearchHit {
+  path: string;
+  line: number;
+  lineText: string;
+  context: {
+    before: string[];
+    after: string[];
+  };
+}
+
+export interface SearchResult {
+  q: string;
+  under: string;
+  limit: number;
+  offset: number;
+  total: number;
+  results: SearchHit[];
+}
+
+const DEFAULT_CONTEXT_LINES = 2;
+const MAX_CONTEXT_LINES = 5;
+const DEFAULT_SEARCH_LIMIT = 20;
+const MAX_SEARCH_LIMIT = 100;
+const SEARCH_ENTRY_CAP = 5000;
+
+export async function searchVaultFiles(root: string, input: SearchInput): Promise<SearchResult> {
+  const query = input.q.trim();
+  if (query.length === 0) {
+    return {
+      q: input.q,
+      under: '',
+      limit: clampPositiveInteger(input.limit, DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT),
+      offset: clampNonNegativeInteger(input.offset),
+      total: 0,
+      results: []
+    };
+  }
+
+  const under = validateOptionalVaultPath(input.under, 'folder') ?? '';
+  const limit = clampPositiveInteger(input.limit, DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT);
+  const offset = clampNonNegativeInteger(input.offset);
+  const context = clampNonNegativeInteger(input.context, DEFAULT_CONTEXT_LINES, MAX_CONTEXT_LINES);
+  const allHits: SearchHit[] = [];
+  const files = await collectSearchableFiles(root, under);
+  const lowerQuery = query.toLocaleLowerCase();
+
+  for (const filePath of files) {
+    const absolute = vaultPath(root, filePath);
+    const content = await readFile(absolute, 'utf8');
+    const lines = content.split('\n');
+    for (const [index, lineText] of lines.entries()) {
+      if (!lineText.toLocaleLowerCase().includes(lowerQuery)) continue;
+      allHits.push({
+        path: filePath,
+        line: index + 1,
+        lineText,
+        context: {
+          before: lines.slice(Math.max(0, index - context), index),
+          after: lines.slice(index + 1, index + 1 + context)
+        }
+      });
+    }
+  }
+
+  return {
+    q: input.q,
+    under,
+    limit,
+    offset,
+    total: allHits.length,
+    results: allHits.slice(offset, offset + limit)
+  };
+}
+
+async function collectSearchableFiles(root: string, under: string): Promise<string[]> {
+  const start = under.length === 0 ? root : vaultPath(root, under);
+  const startStat = await stat(start).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === 'ENOENT') return null;
+    /* v8 ignore next -- Defensive rethrow for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+    throw error;
+  });
+  if (!startStat?.isDirectory()) return [];
+
+  const files: string[] = [];
+  await walk(root, under, files);
+  return files.sort((left, right) => left.localeCompare(right));
+}
+
+async function walk(root: string, relDir: string, files: string[]): Promise<void> {
+  /* v8 ignore next -- The post-push cap return is covered; this pre-entry guard protects future recursive call shapes. */
+  if (files.length >= SEARCH_ENTRY_CAP) return;
+  const absDir = relDir.length === 0 ? root : vaultPath(root, relDir);
+  const dirents = await readdir(absDir, { withFileTypes: true });
+  for (const dirent of dirents) {
+    const rel = relDir.length === 0 ? dirent.name : path.posix.join(relDir, dirent.name);
+    if (isExcludedSearchPath(rel)) continue;
+    if (dirent.isDirectory()) {
+      await walk(root, rel, files);
+    } else if (dirent.isFile() && isMarkdownLikePath(rel)) {
+      files.push(rel);
+      if (files.length >= SEARCH_ENTRY_CAP) return;
+    }
+  }
+}
+
+function vaultPath(root: string, relPath: string): string {
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, relPath);
+  /* v8 ignore next -- Public search validates folder paths before resolution; this is a second containment guard for future call sites. */
+  if (resolved !== resolvedRoot && !resolved.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new InvalidPathError(relPath, 'path escapes vault root');
+  }
+  return resolved;
+}
+
+function isExcludedSearchPath(relPath: string): boolean {
+  return relPath === '.kb2' ||
+    relPath.startsWith('.kb2/') ||
+    relPath === 'trash' ||
+    relPath.startsWith('trash/');
+}
+
+function isMarkdownLikePath(relPath: string): boolean {
+  return relPath.endsWith('.md') || relPath.endsWith('.markdown') || relPath.endsWith('.txt');
+}
+
+function clampPositiveInteger(value: number | undefined, fallback: number, max: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) return fallback;
+  return Math.min(Math.floor(value), max);
+}
+
+function clampNonNegativeInteger(
+  value: number | undefined,
+  fallback = 0,
+  max = Number.MAX_SAFE_INTEGER
+): number {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return fallback;
+  return Math.min(Math.floor(value), max);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}

--- a/packages/vault-core/src/search.ts
+++ b/packages/vault-core/src/search.ts
@@ -27,6 +27,7 @@ export interface SearchResult {
   limit: number;
   offset: number;
   total: number;
+  truncated: boolean;
   results: SearchHit[];
 }
 
@@ -45,6 +46,7 @@ export async function searchVaultFiles(root: string, input: SearchInput): Promis
       limit: clampPositiveInteger(input.limit, DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT),
       offset: clampNonNegativeInteger(input.offset),
       total: 0,
+      truncated: false,
       results: []
     };
   }
@@ -54,7 +56,7 @@ export async function searchVaultFiles(root: string, input: SearchInput): Promis
   const offset = clampNonNegativeInteger(input.offset);
   const context = clampNonNegativeInteger(input.context, DEFAULT_CONTEXT_LINES, MAX_CONTEXT_LINES);
   const allHits: SearchHit[] = [];
-  const files = await collectSearchableFiles(root, under);
+  const { files, truncated } = await collectSearchableFiles(root, under);
   const lowerQuery = query.toLocaleLowerCase();
 
   for (const filePath of files) {
@@ -81,39 +83,39 @@ export async function searchVaultFiles(root: string, input: SearchInput): Promis
     limit,
     offset,
     total: allHits.length,
+    truncated,
     results: allHits.slice(offset, offset + limit)
   };
 }
 
-async function collectSearchableFiles(root: string, under: string): Promise<string[]> {
+async function collectSearchableFiles(root: string, under: string): Promise<{ files: string[]; truncated: boolean }> {
   const start = under.length === 0 ? root : vaultPath(root, under);
   const startStat = await stat(start).catch((error: unknown) => {
     if (isNodeError(error) && error.code === 'ENOENT') return null;
-    /* v8 ignore next -- Defensive rethrow for unexpected fs.stat failures; ENOENT classification is covered with real temp files. */
+    /* v8 ignore next */
     throw error;
   });
-  if (!startStat?.isDirectory()) return [];
+  if (!startStat?.isDirectory()) return { files: [], truncated: false };
 
   const files: string[] = [];
-  await walk(root, under, files);
-  return files.sort((left, right) => left.localeCompare(right));
+  const truncated = await walk(root, under, files);
+  return { files: files.sort((left, right) => left.localeCompare(right)), truncated };
 }
 
-async function walk(root: string, relDir: string, files: string[]): Promise<void> {
-  /* v8 ignore next -- The post-push cap return is covered; this pre-entry guard protects future recursive call shapes. */
-  if (files.length >= SEARCH_ENTRY_CAP) return;
+async function walk(root: string, relDir: string, files: string[]): Promise<boolean> {
   const absDir = relDir.length === 0 ? root : vaultPath(root, relDir);
   const dirents = await readdir(absDir, { withFileTypes: true });
   for (const dirent of dirents) {
     const rel = relDir.length === 0 ? dirent.name : path.posix.join(relDir, dirent.name);
     if (isExcludedSearchPath(rel)) continue;
     if (dirent.isDirectory()) {
-      await walk(root, rel, files);
+      if (await walk(root, rel, files)) return true;
     } else if (dirent.isFile() && isMarkdownLikePath(rel)) {
       files.push(rel);
-      if (files.length >= SEARCH_ENTRY_CAP) return;
+      if (files.length >= SEARCH_ENTRY_CAP) return true;
     }
   }
+  return false;
 }
 
 function vaultPath(root: string, relPath: string): string {

--- a/packages/vault-core/src/splice.ts
+++ b/packages/vault-core/src/splice.ts
@@ -1,5 +1,3 @@
-import matter from 'gray-matter';
-
 export const SPLICE_BYTES_LIMIT = 64 * 1024;
 export const DOCUMENT_BYTES_LIMIT = 1024 * 1024;
 
@@ -43,8 +41,9 @@ export function applyAnchoredSplice(
     };
   }
 
+  const normalizedContent = normalizeWithRawOffsets(content);
   const needle = before + oldText + after;
-  const matches = findAllSubstringOffsets(content, needle);
+  const matches = findAllSubstringOffsets(normalizedContent.value, needle);
   if (matches.length === 0) return { ok: false, rejected: 'not_found' };
 
   let matchOffset: number;
@@ -63,10 +62,12 @@ export function applyAnchoredSplice(
   }
 
   const oldOffset = matchOffset + before.length;
+  const rawOldOffset = normalizedContent.rawOffsets[oldOffset]!;
+  const rawOldEndOffset = normalizedContent.rawOffsets[oldOffset + oldText.length]!;
   const next =
-    content.slice(0, oldOffset) +
+    content.slice(0, rawOldOffset) +
     newText +
-    content.slice(oldOffset + oldText.length);
+    content.slice(rawOldEndOffset);
   const nextBytes = utf8ByteLength(next);
   if (nextBytes > DOCUMENT_BYTES_LIMIT) {
     return {
@@ -86,11 +87,31 @@ export function appendContent(content: string, addition: string): string {
 
 export function prependContent(content: string, addition: string): string {
   const normalizedAddition = lfNormalize(addition);
-  const parsed = matter(content);
-  const insertionPoint = matter.test(content)
-    ? content.length - parsed.content.length
-    : 0;
-  return content.slice(0, insertionPoint) + normalizedAddition + content.slice(insertionPoint);
+  const insertionPoint = frontmatterInsertionPoint(content) ?? 0;
+  const separator = insertionPoint > 0 &&
+    normalizedAddition.length > 0 &&
+    !endsWithLineEnding(content.slice(0, insertionPoint))
+    ? '\n'
+    : '';
+  return content.slice(0, insertionPoint) + separator + normalizedAddition + content.slice(insertionPoint);
+}
+
+function frontmatterInsertionPoint(content: string): number | undefined {
+  const opening = /^---(?:\r\n|\n|\r)/.exec(content);
+  if (!opening) return undefined;
+
+  let lineStart = opening[0].length;
+  while (lineStart < content.length) {
+    const lineEnd = nextLineEnd(content, lineStart);
+    const line = content.slice(lineStart, lineEnd.contentEnd);
+    if (line.trim() === '---') {
+      return lineEnd.nextStart;
+    }
+    lineStart = lineEnd.nextStart;
+  }
+
+  // Unterminated frontmatter is treated as ordinary body content.
+  return undefined;
 }
 
 export function lfNormalize(value: string): string {
@@ -112,4 +133,47 @@ function findAllSubstringOffsets(haystack: string, needle: string): number[] {
     from = at + 1;
   }
   return offsets;
+}
+
+function normalizeWithRawOffsets(content: string): { value: string; rawOffsets: number[] } {
+  let value = '';
+  const rawOffsets: number[] = [];
+  let rawIndex = 0;
+
+  while (rawIndex < content.length) {
+    rawOffsets.push(rawIndex);
+    const char = content[rawIndex]!;
+    if (char === '\r') {
+      value += '\n';
+      rawIndex += content[rawIndex + 1] === '\n' ? 2 : 1;
+      continue;
+    }
+    value += char;
+    rawIndex += 1;
+  }
+
+  rawOffsets.push(content.length);
+  return { value, rawOffsets };
+}
+
+function nextLineEnd(content: string, lineStart: number): { contentEnd: number; nextStart: number } {
+  let index = lineStart;
+  while (index < content.length) {
+    const char = content[index]!;
+    if (char === '\n') {
+      return { contentEnd: index, nextStart: index + 1 };
+    }
+    if (char === '\r') {
+      return {
+        contentEnd: index,
+        nextStart: content[index + 1] === '\n' ? index + 2 : index + 1
+      };
+    }
+    index += 1;
+  }
+  return { contentEnd: content.length, nextStart: content.length };
+}
+
+function endsWithLineEnding(value: string): boolean {
+  return value.endsWith('\n') || value.endsWith('\r');
 }

--- a/packages/vault-core/src/splice.ts
+++ b/packages/vault-core/src/splice.ts
@@ -1,0 +1,115 @@
+import matter from 'gray-matter';
+
+export const SPLICE_BYTES_LIMIT = 64 * 1024;
+export const DOCUMENT_BYTES_LIMIT = 1024 * 1024;
+
+export interface AnchoredSpliceRequest {
+  oldText: string;
+  newText: string;
+  before?: string;
+  after?: string;
+  occurrence?: number;
+}
+
+export type AnchoredSpliceResult =
+  | { ok: true; content: string }
+  | { ok: false; rejected: 'not_found' }
+  | { ok: false; rejected: 'ambiguous'; match_count: number }
+  | { ok: false; rejected: 'too_large_splice'; limit_bytes: number }
+  | {
+      ok: false;
+      rejected: 'too_large_document';
+      current_bytes: number;
+      limit_bytes: number;
+    };
+
+export function applyAnchoredSplice(
+  content: string,
+  request: AnchoredSpliceRequest
+): AnchoredSpliceResult {
+  const oldText = lfNormalize(request.oldText);
+  const newText = lfNormalize(request.newText);
+  const before = request.before === undefined ? '' : lfNormalize(request.before);
+  const after = request.after === undefined ? '' : lfNormalize(request.after);
+
+  if (
+    utf8ByteLength(oldText) > SPLICE_BYTES_LIMIT ||
+    utf8ByteLength(newText) > SPLICE_BYTES_LIMIT
+  ) {
+    return {
+      ok: false,
+      rejected: 'too_large_splice',
+      limit_bytes: SPLICE_BYTES_LIMIT
+    };
+  }
+
+  const needle = before + oldText + after;
+  const matches = findAllSubstringOffsets(content, needle);
+  if (matches.length === 0) return { ok: false, rejected: 'not_found' };
+
+  let matchOffset: number;
+  if (matches.length === 1) {
+    matchOffset = matches[0]!;
+  } else if (request.occurrence !== undefined) {
+    const picked = matches[request.occurrence - 1];
+    if (picked === undefined) return { ok: false, rejected: 'not_found' };
+    matchOffset = picked;
+  } else {
+    return {
+      ok: false,
+      rejected: 'ambiguous',
+      match_count: matches.length
+    };
+  }
+
+  const oldOffset = matchOffset + before.length;
+  const next =
+    content.slice(0, oldOffset) +
+    newText +
+    content.slice(oldOffset + oldText.length);
+  const nextBytes = utf8ByteLength(next);
+  if (nextBytes > DOCUMENT_BYTES_LIMIT) {
+    return {
+      ok: false,
+      rejected: 'too_large_document',
+      current_bytes: nextBytes,
+      limit_bytes: DOCUMENT_BYTES_LIMIT
+    };
+  }
+
+  return { ok: true, content: next };
+}
+
+export function appendContent(content: string, addition: string): string {
+  return content + lfNormalize(addition);
+}
+
+export function prependContent(content: string, addition: string): string {
+  const normalizedAddition = lfNormalize(addition);
+  const parsed = matter(content);
+  const insertionPoint = matter.test(content)
+    ? content.length - parsed.content.length
+    : 0;
+  return content.slice(0, insertionPoint) + normalizedAddition + content.slice(insertionPoint);
+}
+
+export function lfNormalize(value: string): string {
+  return value.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+export function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+function findAllSubstringOffsets(haystack: string, needle: string): number[] {
+  if (needle.length === 0) return [];
+  const offsets: number[] = [];
+  let from = 0;
+  while (from <= haystack.length - needle.length) {
+    const at = haystack.indexOf(needle, from);
+    if (at === -1) break;
+    offsets.push(at);
+    from = at + 1;
+  }
+  return offsets;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,10 @@ importers:
         version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/vault-core:
+    dependencies:
+      gray-matter:
+        specifier: 4.0.3
+        version: 4.0.3
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 4.1.8
@@ -1464,6 +1468,9 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1746,6 +1753,10 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
   fast-check@4.8.0:
     resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
     engines: {node: '>=12.17.0'}
@@ -1813,6 +1824,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1859,6 +1874,10 @@ packages:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -1913,6 +1932,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -1920,6 +1943,10 @@ packages:
 
   jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -2294,6 +2321,10 @@ packages:
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -2324,6 +2355,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2349,6 +2383,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -3643,6 +3681,10 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   aria-query@5.3.0:
@@ -3928,6 +3970,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
   fast-check@4.8.0:
     dependencies:
       pure-rand: 8.4.0
@@ -3985,6 +4031,13 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -4012,6 +4065,8 @@ snapshots:
   is-docker@2.2.1: {}
 
   is-docker@3.0.0: {}
+
+  is-extendable@0.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -4056,9 +4111,16 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
   json5@2.2.3: {}
 
   jsonc-parser@3.2.0: {}
+
+  kind-of@6.0.3: {}
 
   kleur@4.1.5: {}
 
@@ -4516,6 +4578,11 @@ snapshots:
 
   scule@1.3.0: {}
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   semver@7.7.4: {}
 
   set-cookie-parser@3.1.0: {}
@@ -4535,6 +4602,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
+
+  sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
 
@@ -4574,6 +4643,8 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 


### PR DESCRIPTION
## Summary
- Added baseline-issued file reads plus session-anchored splice, append, prepend, and scan search API routes.
- Added vault-core splice/search/frontmatter helpers, audit operations for splice/append/prepend, and exact-pinned gray-matter for YAML frontmatter detection.
- Added session baseline edits and idle-session GC with flush-before-close behavior; WebSocket clients now acquire/release client leases for last-client-disconnect GC.
- Expanded real-temp-filesystem tests with API read-back plus direct fs/audit assertions, fast-check splice property coverage including unicode, and coverage gates for vault-core and manager GC paths.

## Deviations
- API-created sessions idle-close after the grace window instead of closing immediately after every operation. Closing immediately makes a read-issued Yjs state-vector baseline unusable for the following splice because a new Y.Doc gets a fresh state vector on rehydrate. The sessions still flush and GC automatically when no browser client attaches.
- Coverage ignore added only for defensive search guards: an unexpected fs.stat rethrow and a pre-entry cap guard; the reachable ENOENT path and actual 5,000-file cap behavior are tested.

## Verification
- pnpm check -- --skip-nx-cache
- Focused coverage observed in full check: vault-core 100% statements / 100% lines / 96.99% branches; doc-session manager GC 97.11% lines; daemon app route coverage 93.33% lines.
- Real browser criterion 4 on port 17692 with temp KB2_HOME: browser typed BROWSER-A-B, API splice returned 200 replacing SPLICE_TARGET with API_SPLICE_LANDED while typing continued, final visible editor/API/fs content contained API_SPLICE_LANDED and BROWSER-A-B-C-D.
- Real browser rekey regression: browser typed REKEY-A, API moved rekey-live.md to rekey-moved.md, browser URL followed to /rekey-moved.md, later typed -B-C persisted at the new path.
- Real browser doc-deleted regression: API delete returned 200 live=true, API read became 404, browser visibly showed Document deleted and read-only editor state.
- Direct fs/audit inspection during browser verification confirmed concurrent.md contained the merged browser/API content and audit JSONL contained the splice row.

## Notes
- The full check emits existing Svelte nested-class/chunk-size warnings in editor/web builds; no new errors.