### PR TITLE
KB-2 Chunk 009: Local MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,31 @@ pnpm dev     # one command: web UI + API behind one daemon port
 | Surface | URL | Notes |
 |---|---|---|
 | App (UI + API) | http://127.0.0.1:7382 | The daemon front door serves both; API under `/api/*` |
+| MCP | http://127.0.0.1:7382/mcp | Streamable HTTP MCP endpoint for local agents |
 | Storybook | http://localhost:6006 | `pnpm storybook`; pass `-p <port>` if 6006 is taken |
 
 Port/env overrides: `KB2_PORT` (daemon), `KB2_WEB_PORT` (internal Vite dev
 server), `KB2_HOME` (daemon state directory, defaults to `~/.kb2`).
+
+## MCP
+
+The daemon hosts a streamable-HTTP MCP server at `/mcp` on the same loopback
+port as the app and API. Start the daemon, then add it to Claude Code:
+
+```bash
+KB2_HOME=$(mktemp -d) KB2_PORT=17992 pnpm dev:daemon
+claude mcp add kb-2 --transport http http://127.0.0.1:17992/mcp
+```
+
+Available tools: `vault_info`, `list_files`, `read_note`, `create_note`,
+`edit_note`, `append_note`, `prepend_note`, `delete_note`, `move_note`,
+`create_folder`, `delete_folder`, `move_folder`, `search`.
+
+`read_note` returns a `baseline` for edit loops. `edit_note` uses the same
+anchored splice contract as the REST API: stale baselines return
+`stale_doc` with current content and a fresh baseline, ambiguous matches return
+`match_count`, and persist failures are surfaced without writing a success
+audit row. `move_note` and `move_folder` do not rewrite links.
 
 ## Other Commands
 

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -18,11 +18,13 @@
   "dependencies": {
     "@hono/node-server": "2.0.4",
     "@kb-2/doc-session": "workspace:*",
+    "@kb-2/local-mcp": "workspace:*",
     "@kb-2/vault-core": "workspace:*",
     "hono": "4.12.25",
     "ws": "8.21.0"
   },
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "4.1.8"
   }

--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -1,36 +1,25 @@
 import { Hono, type Context } from 'hono';
-import { PersistFailedError, type DocumentSessionManager, type OneFileDocumentSession } from '@kb-2/doc-session';
+import type { DocumentSessionManager, OneFileDocumentSession } from '@kb-2/doc-session';
 import {
-  InvalidPathError,
-  appendAudit,
-  appendContent,
-  applyAnchoredSplice,
-  deleteVaultFile,
-  deleteVaultFolder,
-  getVaultInfo,
-  listVaultTree,
-  makeVaultFolder,
-  moveVaultPath,
-  prependContent,
-  readVaultFile,
-  searchVaultFiles,
-  validateVaultPath,
-  writeVaultFile,
-  type AnchoredSpliceRequest,
-  type VaultErrorCode,
-  type VaultResult
-} from '@kb-2/vault-core';
+  createLocalMcpEndpoint,
+  type LocalMcpEndpoint,
+  type LocalMcpVaultService,
+  type ServiceResult
+} from '@kb-2/local-mcp';
 import { readFile, stat } from 'node:fs/promises';
 import { extname, join, relative, resolve, sep } from 'node:path';
 
 import { SERVICE_NAME } from './config.js';
 import { readDaemonStatus } from './status.js';
+import { createVaultService } from './vault-service.js';
 
 export interface CreateAppOptions {
   statusFile: string;
   vaultRoot?: string;
   documentSessions?: DocumentSessionManager;
+  vaultService?: LocalMcpVaultService;
   demoDocumentSession?: OneFileDocumentSession;
+  mcpEndpoint?: LocalMcpEndpoint;
   webBuildDir?: string;
   webProxyTarget?: string;
 }
@@ -73,214 +62,99 @@ export function createApp(options: CreateAppOptions): Hono {
   }
 
   if (options.vaultRoot) {
+    const vaultService = options.vaultService ?? createVaultService({
+      vaultRoot: options.vaultRoot,
+      documentSessions: options.documentSessions
+    });
+    const mcpEndpoint = options.mcpEndpoint ?? createLocalMcpEndpoint(vaultService);
+
     api.get('/vault', async (context) => {
-      return mapVaultResult(context, await getVaultInfo({ root: options.vaultRoot! }));
+      return mapServiceResult(context, await vaultService.vaultInfo());
     });
 
     api.get('/tree', async (context) => {
       const depthRaw = context.req.query('depth');
       const depth = depthRaw === undefined ? undefined : Number(depthRaw);
-      return mapVaultResult(context, await listVaultTree(
-        { root: options.vaultRoot! },
-        {
-          under: context.req.query('under'),
-          ...(depth !== undefined && Number.isInteger(depth) ? { depth } : {})
-        }
-      ));
+      return mapServiceResult(context, await vaultService.listFiles({
+        under: context.req.query('under'),
+        ...(depth !== undefined && Number.isInteger(depth) ? { depth } : {})
+      }));
     });
 
     api.get('/search', async (context) => {
-      try {
-        const result = await searchVaultFiles(options.vaultRoot!, {
-          q: context.req.query('q') ?? '',
-          under: context.req.query('under'),
-          context: queryNumber(context, 'context'),
-          limit: queryNumber(context, 'limit'),
-          offset: queryNumber(context, 'offset')
-        });
-        return context.json({ ok: true, ...result });
-      } catch (error) {
-        if (error instanceof InvalidPathError) {
-          return mapVaultResult(context, {
-            ok: false,
-            error: 'invalid_path',
-            message: error.message
-          });
-        }
-        throw error;
-      }
+      return mapServiceResult(context, await vaultService.search({
+        query: context.req.query('q') ?? '',
+        under: context.req.query('under'),
+        context: queryNumber(context, 'context'),
+        limit: queryNumber(context, 'limit'),
+        offset: queryNumber(context, 'offset')
+      }));
     });
 
     api.get('/files/*', async (context) => {
       const filePath = filePathParam(context.req.path, '/api/files/');
-      const diskRead = await readVaultFile({ root: options.vaultRoot! }, filePath);
-      if (!diskRead.ok || !options.documentSessions) {
-        return mapVaultResult(context, diskRead);
-      }
-      const baselineRead = await options.documentSessions.withSession(filePath, (session) => session.readWithBaseline());
-      return context.json({
-        ok: true,
-        path: diskRead.value.path,
-        content: baselineRead.content,
-        baseline: baselineRead.baseline,
-        size: diskRead.value.size,
-        mtimeMs: diskRead.value.mtimeMs
-      });
+      return mapServiceResult(context, await vaultService.readNote({ path: filePath }));
     });
 
     api.put('/files/*', async (context) => {
       const filePath = filePathParam(context.req.path, '/api/files/');
       const content = await requestTextContent(context.req.raw);
       const overwrite = context.req.query('overwrite') === 'true';
-      const liveSession = options.documentSessions?.getOpenSession(filePath);
-      if (liveSession) {
-        if (!overwrite) {
-          return mapVaultResult(context, {
-            ok: false,
-            error: 'already_exists',
-            message: 'file already exists'
-          });
-        }
-        const applied = await withMappedWriteError(context, () => liveSession.applyContent(content));
-        if (applied instanceof Response) return applied;
-        const audit = await appendAudit({
-          root: options.vaultRoot!,
-          actor: { kind: 'user' },
-          operation: 'write',
-          entityKind: 'file',
-          path: filePath,
-          summary: `Wrote ${filePath}`
-        });
-        return context.json({
-          ok: true,
-          path: filePath,
-          content: applied,
-          live: true,
-          audit
-        });
-      }
-
-      return mapVaultResult(context, await writeVaultFile(
-        { root: options.vaultRoot!, actor: { kind: 'user' } },
-        { path: filePath, content, overwrite }
-      ), overwrite ? 200 : 201);
+      return mapServiceResult(context, await vaultService.createNote({
+        path: filePath,
+        content,
+        overwrite,
+        actor: { kind: 'user' }
+      }), overwrite ? 200 : 201);
     });
 
     api.delete('/files/*', async (context) => {
       const filePath = filePathParam(context.req.path, '/api/files/');
       const permanent = context.req.query('permanent') === 'true';
-      const deleteOnDisk = () => expectOk(deleteVaultFile(
-        { root: options.vaultRoot!, actor: { kind: 'user' } },
-        { path: filePath, permanent }
-      ));
-      const deletedLive = await withMappedVaultError(
-        context,
-        () => options.documentSessions?.deleteSession(filePath, deleteOnDisk)
-      );
-      if (deletedLive instanceof Response) return deletedLive;
-      if (deletedLive) {
-        return context.json({ ok: true, path: filePath, live: true });
-      }
-      return mapVaultResult(context, await deleteVaultFile(
-        { root: options.vaultRoot!, actor: { kind: 'user' } },
-        { path: filePath, permanent }
-      ));
+      return mapServiceResult(context, await vaultService.deleteNote({
+        path: filePath,
+        permanent,
+        actor: { kind: 'user' }
+      }));
     });
 
     api.post('/files/*', async (context) => {
       if (context.req.path.endsWith('/splice')) {
         const filePath = filePathParam(context.req.path, '/api/files/', '/splice');
-        const diskRead = await readVaultFile({ root: options.vaultRoot! }, filePath);
-        if (!diskRead.ok) return mapVaultResult(context, diskRead);
-        if (!options.documentSessions) {
-          return context.json({ ok: false, error: 'session_unavailable', message: 'document sessions are unavailable' }, 503);
-        }
         const body = await readJsonObject(context.req.raw);
         const splice = readSpliceRequest(body);
-        const result = await withMappedWriteError(context, () => options.documentSessions!.withSession(filePath, (session) =>
-          session.applyBaselineEdit(splice.baseline, (currentContent) =>
-            applyAnchoredSplice(currentContent, splice.request)
-          )
-        ));
-        if (result instanceof Response) return result;
-        if (!result.ok) return mapSpliceReject(context, result);
-        const audit = await appendAudit({
-          root: options.vaultRoot!,
-          actor: { kind: 'mcp_client', client: 'api' },
-          operation: 'splice',
-          entityKind: 'file',
+        return mapServiceResult(context, await vaultService.editNote({
           path: filePath,
-          summary: `Spliced ${filePath}`
-        });
-        return context.json({
-          ok: true,
-          path: filePath,
-          content: result.content,
-          baseline: result.baseline,
-          audit
-        });
+          baseline: splice.baseline,
+          oldText: splice.request.oldText,
+          newText: splice.request.newText,
+          before: splice.request.before,
+          after: splice.request.after,
+          occurrence: splice.request.occurrence,
+          actor: { kind: 'user' }
+        }));
       }
 
       if (context.req.path.endsWith('/append')) {
         const filePath = filePathParam(context.req.path, '/api/files/', '/append');
-        const validPath = validateRouteFilePath(context, filePath);
-        if (validPath instanceof Response) return validPath;
-        if (!options.documentSessions) {
-          return context.json({ ok: false, error: 'session_unavailable', message: 'document sessions are unavailable' }, 503);
-        }
         const body = await readJsonObject(context.req.raw);
         const content = typeof body.content === 'string' ? body.content : '';
-        const result = await withMappedWriteError(context, () => options.documentSessions!.withSession(
-          filePath,
-          (session) => session.applyContentEdit((currentContent) => appendContent(currentContent, content)),
-          { defaultContent: '' }
-        ));
-        if (result instanceof Response) return result;
-        const audit = await appendAudit({
-          root: options.vaultRoot!,
-          actor: { kind: 'mcp_client', client: 'api' },
-          operation: 'append',
-          entityKind: 'file',
+        return mapServiceResult(context, await vaultService.appendNote({
           path: filePath,
-          summary: `Appended to ${filePath}`
-        });
-        return context.json({
-          ok: true,
-          path: filePath,
-          content: result.content,
-          baseline: result.baseline,
-          audit
-        });
+          content,
+          actor: { kind: 'user' }
+        }));
       }
 
       if (context.req.path.endsWith('/prepend')) {
         const filePath = filePathParam(context.req.path, '/api/files/', '/prepend');
-        const diskRead = await readVaultFile({ root: options.vaultRoot! }, filePath);
-        if (!diskRead.ok) return mapVaultResult(context, diskRead);
-        if (!options.documentSessions) {
-          return context.json({ ok: false, error: 'session_unavailable', message: 'document sessions are unavailable' }, 503);
-        }
         const body = await readJsonObject(context.req.raw);
         const content = typeof body.content === 'string' ? body.content : '';
-        const result = await withMappedWriteError(context, () => options.documentSessions!.withSession(filePath, (session) =>
-          session.applyContentEdit((currentContent) => prependContent(currentContent, content))
-        ));
-        if (result instanceof Response) return result;
-        const audit = await appendAudit({
-          root: options.vaultRoot!,
-          actor: { kind: 'mcp_client', client: 'api' },
-          operation: 'prepend',
-          entityKind: 'file',
+        return mapServiceResult(context, await vaultService.prependNote({
           path: filePath,
-          summary: `Prepended to ${filePath}`
-        });
-        return context.json({
-          ok: true,
-          path: filePath,
-          content: result.content,
-          baseline: result.baseline,
-          audit
-        });
+          content,
+          actor: { kind: 'user' }
+        }));
       }
 
       if (!context.req.path.endsWith('/move')) {
@@ -291,53 +165,32 @@ export function createApp(options: CreateAppOptions): Hono {
       const body = await readJsonObject(context.req.raw);
       const to = typeof body.to === 'string' ? body.to : '';
       // Chunk 007 records the move but does not rewrite wikilinks; link-index handling lands later.
-      const moveOnDisk = () => expectOk(moveVaultPath(
-        { root: options.vaultRoot!, actor: { kind: 'user' } },
-        { kind: 'file', fromPath, toPath: to }
-      ));
-      const movedLive = await withMappedVaultError(
-        context,
-        () => options.documentSessions?.moveSession(fromPath, to, moveOnDisk)
-      );
-      if (movedLive instanceof Response) return movedLive;
-      if (movedLive) {
-        return context.json({ ok: true, fromPath, toPath: to, live: true });
-      }
-      return mapVaultResult(context, await moveVaultPath(
-        { root: options.vaultRoot!, actor: { kind: 'user' } },
-        { kind: 'file', fromPath, toPath: to }
-      ));
+      return mapServiceResult(context, await vaultService.moveNote({
+        fromPath,
+        toPath: to,
+        actor: { kind: 'user' }
+      }));
     });
 
     api.post('/folders', async (context) => {
       const body = await readJsonObject(context.req.raw);
       const folderPath = typeof body.path === 'string' ? body.path : '';
-      return mapVaultResult(context, await makeVaultFolder(
-        { root: options.vaultRoot!, actor: { kind: 'user' } },
-        folderPath
-      ), 201);
+      return mapServiceResult(context, await vaultService.createFolder({
+        path: folderPath,
+        actor: { kind: 'user' }
+      }), 201);
     });
 
     api.delete('/folders/*', async (context) => {
       const folderPath = filePathParam(context.req.path, '/api/folders/');
       const recursive = context.req.query('recursive') === 'true';
       const permanent = context.req.query('permanent') === 'true';
-      const deleteOnDisk = () => expectOk(deleteVaultFolder(
-        { root: options.vaultRoot!, actor: { kind: 'user' } },
-        { path: folderPath, recursive, permanent }
-      ));
-      if (options.documentSessions) {
-        const deletedLive = await withMappedVaultError(
-          context,
-          () => options.documentSessions!.deleteSessionSubtree(folderPath, deleteOnDisk)
-        );
-        if (deletedLive instanceof Response) return deletedLive;
-        return context.json({ ok: true, path: folderPath, liveDeleted: deletedLive });
-      }
-      return mapVaultResult(context, await deleteVaultFolder(
-        { root: options.vaultRoot!, actor: { kind: 'user' } },
-        { path: folderPath, recursive, permanent }
-      ));
+      return mapServiceResult(context, await vaultService.deleteFolder({
+        path: folderPath,
+        recursive,
+        permanent,
+        actor: { kind: 'user' }
+      }));
     });
 
     api.post('/folders/*', async (context) => {
@@ -349,22 +202,15 @@ export function createApp(options: CreateAppOptions): Hono {
       const body = await readJsonObject(context.req.raw);
       const to = typeof body.to === 'string' ? body.to : '';
       // Chunk 007 records the move but does not rewrite wikilinks; link-index handling lands later.
-      const moveOnDisk = () => expectOk(moveVaultPath(
-        { root: options.vaultRoot!, actor: { kind: 'user' } },
-        { kind: 'folder', fromPath, toPath: to }
-      ));
-      if (options.documentSessions) {
-        const movedLive = await withMappedVaultError(
-          context,
-          () => options.documentSessions!.moveSessionSubtree(fromPath, to, moveOnDisk)
-        );
-        if (movedLive instanceof Response) return movedLive;
-        return context.json({ ok: true, fromPath, toPath: to, liveMoved: movedLive });
-      }
-      return mapVaultResult(context, await moveVaultPath(
-        { root: options.vaultRoot!, actor: { kind: 'user' } },
-        { kind: 'folder', fromPath, toPath: to }
-      ));
+      return mapServiceResult(context, await vaultService.moveFolder({
+        fromPath,
+        toPath: to,
+        actor: { kind: 'user' }
+      }));
+    });
+
+    app.all('/mcp', async (context) => {
+      return mcpEndpoint.handleRequest(context.req.raw);
     });
   }
 
@@ -397,7 +243,16 @@ export function createApp(options: CreateAppOptions): Hono {
   return app;
 }
 
-function readSpliceRequest(body: Record<string, unknown>): { baseline: string; request: AnchoredSpliceRequest } {
+function readSpliceRequest(body: Record<string, unknown>): {
+  baseline: string;
+  request: {
+    oldText: string;
+    newText: string;
+    before?: string;
+    after?: string;
+    occurrence?: number;
+  };
+} {
   return {
     baseline: typeof body.baseline === 'string' ? body.baseline : '',
     request: {
@@ -412,44 +267,11 @@ function readSpliceRequest(body: Record<string, unknown>): { baseline: string; r
   };
 }
 
-function mapSpliceReject(context: Context, result: Exclude<Awaited<ReturnType<OneFileDocumentSession['applyBaselineEdit']>>, { ok: true }>): Response {
-  const status = statusForSpliceReject(result.rejected);
-  const { ok: _ok, ...body } = result;
-  return context.json({ ok: false, ...body }, status);
-}
-
-function statusForSpliceReject(rejected: string): 404 | 409 | 413 {
-  switch (rejected) {
-    case 'not_found':
-      return 404;
-    case 'too_large_splice':
-    case 'too_large_document':
-      return 413;
-    default:
-      return 409;
-  }
-}
-
 function queryNumber(context: Context, name: string): number | undefined {
   const raw = context.req.query(name);
   if (raw === undefined) return undefined;
   const parsed = Number(raw);
   return Number.isFinite(parsed) ? parsed : undefined;
-}
-
-function validateRouteFilePath(context: Context, filePath: string): string | Response {
-  try {
-    return validateVaultPath(filePath, 'file');
-  } catch (error) {
-    if (error instanceof InvalidPathError) {
-      return mapVaultResult(context, {
-        ok: false,
-        error: 'invalid_path',
-        message: error.message
-      });
-    }
-    throw error;
-  }
 }
 
 async function readOptionalJsonContent(request: Request): Promise<string | undefined> {
@@ -477,51 +299,6 @@ async function readJsonObject(request: Request): Promise<Record<string, unknown>
     : {};
 }
 
-async function expectOk<T>(resultPromise: Promise<VaultResult<T>>): Promise<void> {
-  const result = await resultPromise;
-  if (!result.ok) {
-    throw new VaultResultFailure(result);
-  }
-}
-
-async function withMappedVaultError<T>(
-  context: Context,
-  operation: () => T | Promise<T>
-): Promise<T | Response> {
-  try {
-    return await operation();
-  } catch (error) {
-    if (error instanceof VaultResultFailure) {
-      return mapVaultResult(context, error.result);
-    }
-    throw error;
-  }
-}
-
-async function withMappedWriteError<T>(
-  context: Context,
-  operation: () => T | Promise<T>
-): Promise<T | Response> {
-  try {
-    return await operation();
-  } catch (error) {
-    if (error instanceof PersistFailedError) {
-      return context.json({
-        ok: false,
-        error: 'persist_failed',
-        message: 'Document edit could not be durably saved to disk.'
-      }, 500);
-    }
-    throw error;
-  }
-}
-
-class VaultResultFailure extends Error {
-  constructor(readonly result: VaultResult<unknown>) {
-    super(result.ok ? 'Unexpected successful vault result' : result.message);
-  }
-}
-
 function filePathParam(pathname: string, prefix: string, suffix = ''): string {
   const withoutPrefix = pathname.startsWith(prefix) ? pathname.slice(prefix.length) : '';
   const withoutSuffix = suffix.length > 0 && withoutPrefix.endsWith(suffix)
@@ -530,31 +307,20 @@ function filePathParam(pathname: string, prefix: string, suffix = ''): string {
   return decodeURIComponent(withoutSuffix);
 }
 
-function mapVaultResult<T>(
+function mapServiceResult(
   context: Context,
-  result: VaultResult<T>,
+  result: ServiceResult,
   okStatus: 200 | 201 = 200
 ): Response {
   if (result.ok) {
-    return context.json({ ok: true, ...valueBody(result.value) }, okStatus);
+    return context.json(result, okStatus);
   }
 
-  return context.json({
-    ok: false,
-    error: result.error,
-    message: result.message
-  }, statusForVaultError(result.error));
+  const error = ('error' in result ? result.error : result.rejected) as string | undefined;
+  return context.json(result, statusForServiceError(error ?? 'unknown'));
 }
 
-function valueBody(value: unknown): Record<string, unknown> {
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
-  }
-
-  return { value };
-}
-
-function statusForVaultError(error: VaultErrorCode): 400 | 404 | 409 | 413 {
+function statusForServiceError(error: string): 400 | 404 | 409 | 413 | 500 | 503 {
   switch (error) {
     case 'invalid_path':
       return 400;
@@ -565,7 +331,15 @@ function statusForVaultError(error: VaultErrorCode): 400 | 404 | 409 | 413 {
     case 'folder_not_empty':
       return 409;
     case 'entry_cap_exceeded':
+    case 'too_large_splice':
+    case 'too_large_document':
       return 413;
+    case 'session_unavailable':
+      return 503;
+    case 'persist_failed':
+      return 500;
+    default:
+      return 409;
   }
 }
 

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { serve } from '@hono/node-server';
 import { DEMO_DOCUMENT_YJS_PATH, DocumentSessionManager, bindYjsWebSocket } from '@kb-2/doc-session';
+import { createLocalMcpEndpoint } from '@kb-2/local-mcp';
 import { validateVaultPath } from '@kb-2/vault-core';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { WebSocketServer } from 'ws';
@@ -8,6 +9,7 @@ import { WebSocketServer } from 'ws';
 import { createApp } from './app.js';
 import { createDaemonConfig, type DaemonConfig } from './config.js';
 import { writeDaemonStatus, type DaemonStatus } from './status.js';
+import { createVaultService } from './vault-service.js';
 
 export interface StartedDaemon {
   config: DaemonConfig;
@@ -20,12 +22,19 @@ export async function startDaemon(): Promise<StartedDaemon> {
   const documentSessions = new DocumentSessionManager({ root: config.vaultRoot });
   const demoDocumentSession = documentSessions.getSession('hello-world.md');
   await demoDocumentSession.open();
+  const vaultService = createVaultService({
+    vaultRoot: config.vaultRoot,
+    documentSessions
+  });
+  const mcpEndpoint = createLocalMcpEndpoint(vaultService);
 
   const app = createApp({
     statusFile: config.statusFile,
     vaultRoot: config.vaultRoot,
+    vaultService,
     documentSessions,
     demoDocumentSession,
+    mcpEndpoint,
     webBuildDir: fileURLToPath(new URL('../../web/build', import.meta.url)),
     webProxyTarget: config.webProxyTarget
   });
@@ -63,6 +72,7 @@ export async function startDaemon(): Promise<StartedDaemon> {
             config,
             status,
             close: async () => {
+              await mcpEndpoint.close();
               await closeWebSocketServer(webSocketServer, activeDocumentConnections);
               await closeServer(server);
               await documentSessions.close();

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -1,5 +1,8 @@
 import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { DocumentSessionManager, OneFileDocumentSession, type DocumentSessionEvent } from '@kb-2/doc-session';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { Hono } from 'hono';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { dirname, join } from 'node:path';
@@ -455,7 +458,148 @@ describe('daemon routing', () => {
     const audit = await readAuditRows(config.vaultRoot);
     expect(audit).toHaveLength(2);
     expect(audit.map((row) => row.operation)).toEqual(['splice', 'splice']);
-    expect(audit.every((row) => (row.actor as { kind?: string }).kind === 'mcp_client')).toBe(true);
+    expect(audit.every((row) => (row.actor as { kind?: string }).kind === 'user')).toBe(true);
+    await sessions.close();
+  });
+
+  it('exercises every MCP tool end-to-end through the SDK client with mcp_client audit attribution', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const { client, transport } = await connectMcpClient(app, 'daemon-sdk-test');
+
+    await expect(mcpToolJson(client, 'create_note', { path: 'notes/a.md', content: 'alpha beta alpha\n' }))
+      .resolves.toMatchObject({ ok: true, path: 'notes/a.md' });
+    await expect(readFile(join(config.vaultRoot, 'notes/a.md'), 'utf8')).resolves.toBe('alpha beta alpha\n');
+
+    await expect(mcpToolJson(client, 'vault_info', {})).resolves.toMatchObject({ ok: true, fileCount: 1 });
+    await expect(mcpToolJson(client, 'list_files', { under: 'notes', depth: 1 }))
+      .resolves.toMatchObject({ ok: true, entries: [{ path: 'notes/a.md', kind: 'file' }] });
+
+    const read = await mcpToolJson(client, 'read_note', { path: 'notes/a.md' }) as { content: string; baseline: string };
+    expect(read.content).toBe('alpha beta alpha\n');
+    expect(read.baseline.length).toBeGreaterThan(0);
+
+    await expect(mcpToolJson(client, 'edit_note', {
+      path: 'notes/a.md',
+      baseline: read.baseline,
+      old_text: 'beta',
+      new_text: 'BETA'
+    })).resolves.toMatchObject({ ok: true, content: 'alpha BETA alpha\n' });
+    await expect(readFile(join(config.vaultRoot, 'notes/a.md'), 'utf8')).resolves.toBe('alpha BETA alpha\n');
+
+    const stale = await client.callTool({
+      name: 'edit_note',
+      arguments: {
+        path: 'notes/a.md',
+        baseline: read.baseline,
+        old_text: 'alpha',
+        new_text: 'ALPHA'
+      }
+    });
+    expect(stale.isError).toBe(true);
+    expect(mcpText(stale)).toContain('"rejected":"stale_doc"');
+    expect(mcpText(stale)).toContain('"current_content":"alpha BETA alpha\\n"');
+    expect(mcpText(stale)).toContain('"baseline"');
+
+    const fresh = await mcpToolJson(client, 'read_note', { path: 'notes/a.md' }) as { baseline: string };
+    const ambiguous = await client.callTool({
+      name: 'edit_note',
+      arguments: {
+        path: 'notes/a.md',
+        baseline: fresh.baseline,
+        old_text: 'alpha',
+        new_text: 'ALPHA'
+      }
+    });
+    expect(ambiguous.isError).toBe(true);
+    expect(mcpText(ambiguous)).toContain('"rejected":"ambiguous"');
+    expect(mcpText(ambiguous)).toContain('"match_count":2');
+
+    await expect(mcpToolJson(client, 'append_note', { path: 'notes/a.md', content: 'tail\n' }))
+      .resolves.toMatchObject({ ok: true, content: 'alpha BETA alpha\ntail\n' });
+    await expect(mcpToolJson(client, 'prepend_note', { path: 'notes/a.md', content: 'head\n' }))
+      .resolves.toMatchObject({ ok: true, content: 'head\nalpha BETA alpha\ntail\n' });
+    await expect(readFile(join(config.vaultRoot, 'notes/a.md'), 'utf8')).resolves.toBe('head\nalpha BETA alpha\ntail\n');
+
+    await expect(mcpToolJson(client, 'create_folder', { path: 'moved' })).resolves.toMatchObject({ ok: true, path: 'moved' });
+    await expect(mcpToolJson(client, 'move_note', { from_path: 'notes/a.md', to_path: 'moved/a.md' }))
+      .resolves.toMatchObject({ ok: true, fromPath: 'notes/a.md', toPath: 'moved/a.md', live: true });
+    await expect(readFile(join(config.vaultRoot, 'moved/a.md'), 'utf8')).resolves.toBe('head\nalpha BETA alpha\ntail\n');
+    await expect(stat(join(config.vaultRoot, 'notes/a.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+    await expect(mcpToolJson(client, 'move_folder', { from_path: 'moved', to_path: 'archived' }))
+      .resolves.toMatchObject({ ok: true, fromPath: 'moved', toPath: 'archived', liveMoved: ['archived/a.md'] });
+    await expect(readFile(join(config.vaultRoot, 'archived/a.md'), 'utf8')).resolves.toContain('BETA');
+
+    await expect(mcpToolJson(client, 'search', { query: 'BETA', under: 'archived', context: 0 }))
+      .resolves.toMatchObject({ ok: true, total: 1, results: [{ path: 'archived/a.md' }] });
+
+    await expect(mcpToolJson(client, 'delete_note', { path: 'archived/a.md' }))
+      .resolves.toMatchObject({ ok: true, path: 'archived/a.md', live: true });
+    await expect(stat(join(config.vaultRoot, 'archived/a.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+    await expect(mcpToolJson(client, 'delete_folder', { path: 'archived', recursive: true }))
+      .resolves.toMatchObject({ ok: true, path: 'archived', liveDeleted: [] });
+    await expect(stat(join(config.vaultRoot, 'archived'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+    const audit = await readAuditRows(config.vaultRoot);
+    expect(audit.map((row) => row.operation)).toEqual([
+      'create',
+      'splice',
+      'append',
+      'prepend',
+      'mkdir',
+      'move',
+      'move',
+      'delete',
+      'delete'
+    ]);
+    expect(audit.every((row) => {
+      const actor = row.actor as { kind?: string; client?: string };
+      return actor.kind === 'mcp_client' && actor.client === 'daemon-sdk-test';
+    })).toBe(true);
+
+    await transport.terminateSession();
+    await sessions.close();
+  });
+
+  it('surfaces MCP persist failures without a success audit row and recovers the live session', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const { client, transport } = await connectMcpClient(app, 'mcp-persist-test');
+
+    await expect(mcpToolJson(client, 'create_note', { path: 'notes/readonly.md', content: 'base\n' }))
+      .resolves.toMatchObject({ ok: true, path: 'notes/readonly.md' });
+    await mcpToolJson(client, 'read_note', { path: 'notes/readonly.md' });
+
+    const beforeAudit = await readAuditRows(config.vaultRoot);
+    await chmod(join(config.vaultRoot, 'notes'), 0o500);
+    const failed = await client.callTool({
+      name: 'append_note',
+      arguments: { path: 'notes/readonly.md', content: 'unsaved\n' }
+    });
+
+    expect(failed.isError).toBe(true);
+    expect(mcpText(failed)).toBe('append_note rejected: {"ok":false,"error":"persist_failed","message":"Document edit could not be durably saved to disk."}');
+    await expect(readFile(join(config.vaultRoot, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\n');
+    expect(await readAuditRows(config.vaultRoot)).toHaveLength(beforeAudit.length);
+
+    await chmod(join(config.vaultRoot, 'notes'), 0o700);
+    await expect(mcpToolJson(client, 'append_note', { path: 'notes/readonly.md', content: 'recovered\n' }))
+      .resolves.toMatchObject({ ok: true, content: 'base\nunsaved\nrecovered\n' });
+    await expect(readFile(join(config.vaultRoot, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\nunsaved\nrecovered\n');
+
+    const audit = await readAuditRows(config.vaultRoot);
+    expect(audit).toHaveLength(beforeAudit.length + 1);
+    expect(audit.at(-1)).toMatchObject({
+      operation: 'append',
+      actor: { kind: 'mcp_client', client: 'mcp-persist-test' },
+      path: 'notes/readonly.md'
+    });
+
+    await transport.terminateSession();
     await sessions.close();
   });
 
@@ -723,6 +867,33 @@ function listen(server: ReturnType<typeof createServer>): Promise<void> {
     server.once('error', reject);
     server.listen(0, '127.0.0.1', () => resolve());
   });
+}
+
+async function connectMcpClient(app: Hono, clientName: string): Promise<{
+  client: Client;
+  transport: StreamableHTTPClientTransport;
+}> {
+  const client = new Client({ name: clientName, version: '1.0.0' });
+  const transport = new StreamableHTTPClientTransport(new URL('http://127.0.0.1/mcp'), {
+    fetch: async (input, init) => app.fetch(input instanceof Request ? input : new Request(input, init))
+  });
+  await client.connect(transport);
+  return { client, transport };
+}
+
+async function mcpToolJson(client: Client, name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  return JSON.parse(mcpText(await client.callTool({ name, arguments: args }))) as Record<string, unknown>;
+}
+
+function mcpText(result: Awaited<ReturnType<Client['callTool']>>): string {
+  if (!Array.isArray(result.content)) {
+    throw new Error('Expected MCP content array');
+  }
+  const first = result.content[0] as { type?: unknown; text?: unknown } | undefined;
+  if (!first || first.type !== 'text' || typeof first.text !== 'string') {
+    throw new Error('Expected text MCP content');
+  }
+  return first.text;
 }
 
 function close(server: ReturnType<typeof createServer>): Promise<void> {

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -9,6 +9,7 @@ import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import * as Y from 'yjs';
 
+import { anchoredSpliceContractCases } from '../../../packages/vault-core/src/splice-contract-cases.test-support.js';
 import { createApp } from './app.js';
 import { createDaemonConfig } from './config.js';
 import { writeDaemonStatus } from './status.js';
@@ -564,6 +565,46 @@ describe('daemon routing', () => {
     await sessions.close();
   });
 
+  it.each(anchoredSpliceContractCases)('runs the shared splice contract over MCP: $name', async ({ initialContent, request, expected }) => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    const notePath = 'notes/contract.md';
+    await writeFileWithParents(join(config.vaultRoot, notePath), initialContent);
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const { client, transport } = await connectMcpClient(app, 'mcp-splice-contract-test');
+
+    const read = await mcpToolJson(client, 'read_note', { path: notePath }) as { baseline: string };
+    const result = await client.callTool({
+      name: 'edit_note',
+      arguments: {
+        path: notePath,
+        baseline: read.baseline,
+        old_text: request.oldText,
+        new_text: request.newText,
+        ...(request.before !== undefined ? { before: request.before } : {}),
+        ...(request.after !== undefined ? { after: request.after } : {}),
+        ...(request.occurrence !== undefined ? { occurrence: request.occurrence } : {})
+      }
+    });
+
+    if (expected.ok) {
+      expect(result.isError).not.toBe(true);
+      expect(JSON.parse(mcpText(result))).toMatchObject({
+        ok: true,
+        path: notePath,
+        content: expected.content
+      });
+      await expect(readFile(join(config.vaultRoot, notePath), 'utf8')).resolves.toBe(expected.content);
+    } else {
+      expect(result.isError).toBe(true);
+      expect(parseMcpRejection(result, 'edit_note')).toMatchObject(expected);
+      await expect(readFile(join(config.vaultRoot, notePath), 'utf8')).resolves.toBe(initialContent);
+    }
+
+    await transport.terminateSession();
+    await sessions.close();
+  });
+
   it('surfaces MCP persist failures without a success audit row and recovers the live session', async () => {
     const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
     const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
@@ -894,6 +935,15 @@ function mcpText(result: Awaited<ReturnType<Client['callTool']>>): string {
     throw new Error('Expected text MCP content');
   }
   return first.text;
+}
+
+function parseMcpRejection(result: Awaited<ReturnType<Client['callTool']>>, toolName: string): Record<string, unknown> {
+  const prefix = `${toolName} rejected: `;
+  const text = mcpText(result);
+  if (!text.startsWith(prefix)) {
+    throw new Error(`Expected ${toolName} rejection, got ${text}`);
+  }
+  return JSON.parse(text.slice(prefix.length)) as Record<string, unknown>;
 }
 
 function close(server: ReturnType<typeof createServer>): Promise<void> {

--- a/apps/daemon/src/vault-service.test.ts
+++ b/apps/daemon/src/vault-service.test.ts
@@ -1,0 +1,125 @@
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { DocumentSessionManager } from '@kb-2/doc-session';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { createVaultService } from './vault-service.js';
+
+describe('vault service failure mapping', () => {
+  let root: string;
+  let sessions: DocumentSessionManager | undefined;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'kb2-vault-service-'));
+  });
+
+  afterEach(async () => {
+    await sessions?.close();
+    await rm(root, { recursive: true, force: true });
+    sessions = undefined;
+  });
+
+  it('returns session_unavailable for edit and positioned write operations that require document sessions', async () => {
+    await writeFileWithParents(join(root, 'notes', 'a.md'), 'alpha beta\n');
+    const service = createVaultService({ vaultRoot: root });
+
+    await expect(service.editNote({
+      path: 'notes/a.md',
+      baseline: 'unused',
+      oldText: 'beta',
+      newText: 'BETA',
+      actor: { kind: 'user' }
+    })).resolves.toMatchObject({
+      ok: false,
+      error: 'session_unavailable',
+      message: 'document sessions are unavailable'
+    });
+
+    await expect(service.appendNote({
+      path: 'notes/a.md',
+      content: 'tail\n',
+      actor: { kind: 'user' }
+    })).resolves.toMatchObject({
+      ok: false,
+      error: 'session_unavailable'
+    });
+
+    await expect(service.prependNote({
+      path: 'notes/a.md',
+      content: 'head\n',
+      actor: { kind: 'user' }
+    })).resolves.toMatchObject({
+      ok: false,
+      error: 'session_unavailable'
+    });
+
+    await expect(readFile(join(root, 'notes/a.md'), 'utf8')).resolves.toBe('alpha beta\n');
+    await expect(stat(join(root, '.kb2/audit/changes.jsonl'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('maps live-session persist failures without writing a success audit row', async () => {
+    await writeFileWithParents(join(root, 'notes', 'readonly.md'), 'base\n');
+    sessions = new DocumentSessionManager({ root, defaultContent: '' });
+    const service = createVaultService({ vaultRoot: root, documentSessions: sessions });
+
+    await service.readNote({ path: 'notes/readonly.md' });
+    const notesDir = join(root, 'notes');
+    await chmod(notesDir, 0o500);
+    const failed = await service.appendNote({
+      path: 'notes/readonly.md',
+      content: 'unsaved\n',
+      actor: { kind: 'user' }
+    });
+
+    expect(failed).toEqual({
+      ok: false,
+      error: 'persist_failed',
+      message: 'Document edit could not be durably saved to disk.'
+    });
+    await expect(readFile(join(root, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\n');
+    await expect(stat(join(root, '.kb2/audit/changes.jsonl'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+    await chmod(notesDir, 0o700);
+    await expect(service.appendNote({
+      path: 'notes/readonly.md',
+      content: 'recovered\n',
+      actor: { kind: 'user' }
+    })).resolves.toMatchObject({
+      ok: true,
+      content: 'base\nunsaved\nrecovered\n'
+    });
+  });
+
+  it('maps live move and folder subtree failures from vault operations', async () => {
+    await writeFileWithParents(join(root, 'notes', 'live.md'), 'live\n');
+    await writeFileWithParents(join(root, 'notes', 'target.md'), 'target\n');
+    await writeFileWithParents(join(root, 'folder', 'child.md'), 'child\n');
+    await writeFileWithParents(join(root, 'existing', 'child.md'), 'existing\n');
+    sessions = new DocumentSessionManager({ root, defaultContent: '' });
+    const service = createVaultService({ vaultRoot: root, documentSessions: sessions });
+    await sessions.getSession('notes/live.md').open();
+
+    await expect(service.moveNote({
+      fromPath: 'notes/live.md',
+      toPath: 'notes/target.md',
+      actor: { kind: 'user' }
+    })).resolves.toMatchObject({
+      ok: false,
+      error: 'path_collision'
+    });
+
+    await expect(service.moveFolder({
+      fromPath: 'folder',
+      toPath: 'existing',
+      actor: { kind: 'user' }
+    })).resolves.toMatchObject({
+      ok: false,
+      error: 'path_collision'
+    });
+  });
+});
+
+async function writeFileWithParents(filePath: string, content: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, content, 'utf8');
+}

--- a/apps/daemon/src/vault-service.ts
+++ b/apps/daemon/src/vault-service.ts
@@ -1,0 +1,349 @@
+import { PersistFailedError, type DocumentSessionManager } from '@kb-2/doc-session';
+import type { LocalMcpVaultService, ServiceFailure, ServiceResult } from '@kb-2/local-mcp';
+import {
+  InvalidPathError,
+  appendAudit,
+  appendContent,
+  applyAnchoredSplice,
+  deleteVaultFile,
+  deleteVaultFolder,
+  getVaultInfo,
+  listVaultTree,
+  makeVaultFolder,
+  moveVaultPath,
+  prependContent,
+  readVaultFile,
+  searchVaultFiles,
+  validateVaultPath,
+  writeVaultFile,
+  type AnchoredSpliceRequest,
+  type VaultActor,
+  type VaultResult
+} from '@kb-2/vault-core';
+
+export interface VaultServiceOptions {
+  vaultRoot: string;
+  documentSessions?: DocumentSessionManager;
+}
+
+export function createVaultService(options: VaultServiceOptions): LocalMcpVaultService {
+  const ctx = (actor?: VaultActor) => ({ root: options.vaultRoot, ...(actor ? { actor } : {}) });
+
+  return {
+    async vaultInfo() {
+      return serviceResult(await getVaultInfo(ctx()));
+    },
+
+    async listFiles(input) {
+      return serviceResult(await listVaultTree(ctx(), input));
+    },
+
+    async readNote(input) {
+      const diskRead = await readVaultFile(ctx(), input.path);
+      if (!diskRead.ok || !options.documentSessions) {
+        return serviceResult(diskRead);
+      }
+
+      const baselineRead = await options.documentSessions.withSession(input.path, (session) => session.readWithBaseline());
+      return {
+        ok: true,
+        path: diskRead.value.path,
+        content: baselineRead.content,
+        baseline: baselineRead.baseline,
+        size: diskRead.value.size,
+        mtimeMs: diskRead.value.mtimeMs
+      };
+    },
+
+    async createNote(input) {
+      const liveSession = options.documentSessions?.getOpenSession(input.path);
+      if (liveSession) {
+        if (!input.overwrite) {
+          return failure('already_exists', 'file already exists');
+        }
+        const applied = await mapWriteFailure(() => liveSession.applyContent(input.content));
+        if (!applied.ok) return applied;
+        const audit = await appendAudit({
+          root: options.vaultRoot,
+          actor: input.actor,
+          operation: 'write',
+          entityKind: 'file',
+          path: input.path,
+          summary: `Wrote ${input.path}`
+        });
+        return {
+          ok: true,
+          path: input.path,
+          content: applied.value,
+          live: true,
+          audit
+        };
+      }
+
+      return serviceResult(await writeVaultFile(ctx(input.actor), {
+        path: input.path,
+        content: input.content,
+        overwrite: input.overwrite
+      }));
+    },
+
+    async editNote(input) {
+      const diskRead = await readVaultFile(ctx(), input.path);
+      if (!diskRead.ok) return serviceResult(diskRead);
+      if (!options.documentSessions) {
+        return failure('session_unavailable', 'document sessions are unavailable');
+      }
+
+      const request: AnchoredSpliceRequest = {
+        oldText: input.oldText,
+        newText: input.newText,
+        ...(input.before !== undefined ? { before: input.before } : {}),
+        ...(input.after !== undefined ? { after: input.after } : {}),
+        ...(input.occurrence !== undefined ? { occurrence: input.occurrence } : {})
+      };
+      const result = await mapWriteFailure(() => options.documentSessions!.withSession(input.path, (session) =>
+        session.applyBaselineEdit(input.baseline, (currentContent) => applyAnchoredSplice(currentContent, request))
+      ));
+      if (!result.ok) return result;
+      if (!result.value.ok) return { ok: false, ...withoutOk(result.value) };
+
+      const audit = await appendAudit({
+        root: options.vaultRoot,
+        actor: input.actor,
+        operation: 'splice',
+        entityKind: 'file',
+        path: input.path,
+        summary: `Spliced ${input.path}`
+      });
+      return {
+        ok: true,
+        path: input.path,
+        content: result.value.content,
+        baseline: result.value.baseline,
+        audit
+      };
+    },
+
+    async appendNote(input) {
+      const validPath = validateServiceFilePath(input.path);
+      if (!validPath.ok) return validPath;
+      if (!options.documentSessions) {
+        return failure('session_unavailable', 'document sessions are unavailable');
+      }
+
+      const result = await mapWriteFailure(() => options.documentSessions!.withSession(
+        input.path,
+        (session) => session.applyContentEdit((currentContent) => appendContent(currentContent, input.content)),
+        { defaultContent: '' }
+      ));
+      if (!result.ok) return result;
+      const audit = await appendAudit({
+        root: options.vaultRoot,
+        actor: input.actor,
+        operation: 'append',
+        entityKind: 'file',
+        path: input.path,
+        summary: `Appended to ${input.path}`
+      });
+      return {
+        ok: true,
+        path: input.path,
+        content: result.value.content,
+        baseline: result.value.baseline,
+        audit
+      };
+    },
+
+    async prependNote(input) {
+      const diskRead = await readVaultFile(ctx(), input.path);
+      if (!diskRead.ok) return serviceResult(diskRead);
+      if (!options.documentSessions) {
+        return failure('session_unavailable', 'document sessions are unavailable');
+      }
+
+      const result = await mapWriteFailure(() => options.documentSessions!.withSession(input.path, (session) =>
+        session.applyContentEdit((currentContent) => prependContent(currentContent, input.content))
+      ));
+      if (!result.ok) return result;
+      const audit = await appendAudit({
+        root: options.vaultRoot,
+        actor: input.actor,
+        operation: 'prepend',
+        entityKind: 'file',
+        path: input.path,
+        summary: `Prepended to ${input.path}`
+      });
+      return {
+        ok: true,
+        path: input.path,
+        content: result.value.content,
+        baseline: result.value.baseline,
+        audit
+      };
+    },
+
+    async deleteNote(input) {
+      const deleteOnDisk = () => expectOk(deleteVaultFile(ctx(input.actor), {
+        path: input.path,
+        permanent: input.permanent
+      }));
+      const deletedLive = await mapVaultFailure(() => options.documentSessions?.deleteSession(input.path, deleteOnDisk));
+      if (!deletedLive.ok) return deletedLive;
+      if (deletedLive.value) {
+        return { ok: true, path: input.path, live: true };
+      }
+      return serviceResult(await deleteVaultFile(ctx(input.actor), {
+        path: input.path,
+        permanent: input.permanent
+      }));
+    },
+
+    async moveNote(input) {
+      const moveOnDisk = () => expectOk(moveVaultPath(ctx(input.actor), {
+        kind: 'file',
+        fromPath: input.fromPath,
+        toPath: input.toPath
+      }));
+      const movedLive = await mapVaultFailure(() => options.documentSessions?.moveSession(input.fromPath, input.toPath, moveOnDisk));
+      if (!movedLive.ok) return movedLive;
+      if (movedLive.value) {
+        return { ok: true, fromPath: input.fromPath, toPath: input.toPath, live: true };
+      }
+      return serviceResult(await moveVaultPath(ctx(input.actor), {
+        kind: 'file',
+        fromPath: input.fromPath,
+        toPath: input.toPath
+      }));
+    },
+
+    async createFolder(input) {
+      return serviceResult(await makeVaultFolder(ctx(input.actor), input.path));
+    },
+
+    async deleteFolder(input) {
+      const deleteOnDisk = () => expectOk(deleteVaultFolder(ctx(input.actor), {
+        path: input.path,
+        recursive: input.recursive,
+        permanent: input.permanent
+      }));
+      if (options.documentSessions) {
+        const deletedLive = await mapVaultFailure(() => options.documentSessions!.deleteSessionSubtree(input.path, deleteOnDisk));
+        if (!deletedLive.ok) return deletedLive;
+        return { ok: true, path: input.path, liveDeleted: deletedLive.value };
+      }
+      return serviceResult(await deleteVaultFolder(ctx(input.actor), {
+        path: input.path,
+        recursive: input.recursive,
+        permanent: input.permanent
+      }));
+    },
+
+    async moveFolder(input) {
+      const moveOnDisk = () => expectOk(moveVaultPath(ctx(input.actor), {
+        kind: 'folder',
+        fromPath: input.fromPath,
+        toPath: input.toPath
+      }));
+      if (options.documentSessions) {
+        const movedLive = await mapVaultFailure(() => options.documentSessions!.moveSessionSubtree(input.fromPath, input.toPath, moveOnDisk));
+        if (!movedLive.ok) return movedLive;
+        return { ok: true, fromPath: input.fromPath, toPath: input.toPath, liveMoved: movedLive.value };
+      }
+      return serviceResult(await moveVaultPath(ctx(input.actor), {
+        kind: 'folder',
+        fromPath: input.fromPath,
+        toPath: input.toPath
+      }));
+    },
+
+    async search(input) {
+      try {
+        return {
+          ok: true,
+          ...await searchVaultFiles(options.vaultRoot, {
+            q: input.query,
+            under: input.under,
+            context: input.context,
+            limit: input.limit,
+            offset: input.offset
+          })
+        };
+      } catch (error) {
+        if (error instanceof InvalidPathError) {
+          return failure('invalid_path', error.message);
+        }
+        throw error;
+      }
+    }
+  };
+}
+
+function serviceResult<T extends object>(result: VaultResult<T>): ServiceResult<T> {
+  if (result.ok) {
+    return { ok: true, ...result.value };
+  }
+
+  return failure(result.error, result.message);
+}
+
+function failure(error: string, message: string): ServiceFailure {
+  return { ok: false, error, message };
+}
+
+function validateServiceFilePath(filePath: string): ServiceResult<{ path: string }> {
+  try {
+    return { ok: true, path: validateVaultPath(filePath, 'file') };
+  } catch (error) {
+    if (error instanceof InvalidPathError) {
+      return failure('invalid_path', error.message);
+    }
+    throw error;
+  }
+}
+
+async function expectOk<T>(resultPromise: Promise<VaultResult<T>>): Promise<void> {
+  const result = await resultPromise;
+  if (!result.ok) {
+    throw new VaultResultFailure(result);
+  }
+}
+
+async function mapVaultFailure<T>(operation: () => T | Promise<T>): Promise<{ ok: true; value: T } | ServiceFailure> {
+  try {
+    return { ok: true, value: await operation() };
+  } catch (error) {
+    if (error instanceof VaultResultFailure) {
+      return vaultFailureResult(error.result);
+    }
+    throw error;
+  }
+}
+
+async function mapWriteFailure<T>(operation: () => T | Promise<T>): Promise<{ ok: true; value: T } | ServiceFailure> {
+  try {
+    return { ok: true, value: await operation() };
+  } catch (error) {
+    if (error instanceof PersistFailedError) {
+      return failure('persist_failed', 'Document edit could not be durably saved to disk.');
+    }
+    throw error;
+  }
+}
+
+class VaultResultFailure extends Error {
+  constructor(readonly result: VaultResult<unknown>) {
+    super(result.ok ? 'Unexpected successful vault result' : result.message);
+  }
+}
+
+function vaultFailureResult(result: VaultResult<unknown>): ServiceFailure {
+  if (result.ok) {
+    throw new Error('Expected failed vault result');
+  }
+  return failure(result.error, result.message);
+}
+
+function withoutOk<T extends { ok: false }>(value: T): Omit<T, 'ok'> {
+  const { ok: _ok, ...rest } = value;
+  return rest;
+}

--- a/apps/daemon/vitest.config.ts
+++ b/apps/daemon/vitest.config.ts
@@ -15,9 +15,10 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text'],
-      include: ['src/app.ts'],
+      include: ['src/app.ts', 'src/vault-service.ts'],
       thresholds: {
-        lines: 90
+        lines: 90,
+        perFile: true
       }
     }
   }

--- a/apps/daemon/vitest.config.ts
+++ b/apps/daemon/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@kb-2/doc-session': fileURLToPath(new URL('../../packages/doc-session/src/index.ts', import.meta.url)),
+      '@kb-2/local-mcp': fileURLToPath(new URL('../../packages/local-mcp/src/index.ts', import.meta.url)),
       '@kb-2/vault-core': fileURLToPath(new URL('../../packages/vault-core/src/index.ts', import.meta.url))
     }
   },

--- a/packages/local-mcp/package.json
+++ b/packages/local-mcp/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@kb-2/local-mcp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run --coverage",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "4.1.8",
+    "vitest": "4.1.8"
+  }
+}

--- a/packages/local-mcp/project.json
+++ b/packages/local-mcp/project.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "local-mcp",
+  "sourceRoot": "packages/local-mcp/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/local-mcp build"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/local-mcp test"
+      }
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm --filter @kb-2/local-mcp typecheck"
+      }
+    }
+  }
+}

--- a/packages/local-mcp/src/index.ts
+++ b/packages/local-mcp/src/index.ts
@@ -1,0 +1,9 @@
+export { createLocalMcpEndpoint, createLocalMcpServer, type LocalMcpEndpoint } from './server.js';
+export type {
+  EditNoteInput,
+  LocalMcpActor,
+  LocalMcpVaultService,
+  ReadNoteValue,
+  ServiceFailure,
+  ServiceResult
+} from './types.js';

--- a/packages/local-mcp/src/server.test.ts
+++ b/packages/local-mcp/src/server.test.ts
@@ -1,0 +1,110 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+import { createLocalMcpEndpoint } from './server.js';
+import type { LocalMcpVaultService, ServiceResult, VaultActor } from './types.js';
+
+describe('local MCP server', () => {
+  it('registers every tier-1 tool and forwards calls to the injected service with initialize attribution', async () => {
+    const mutationActors: VaultActor[] = [];
+    const service: LocalMcpVaultService = {
+      vaultInfo: async () => ({ ok: true, rootName: 'demo-vault', fileCount: 1, folderCount: 1 }),
+      listFiles: async (input) => ({ ok: true, entries: [{ path: input.under ?? 'note.md', kind: 'file', size: 4, mtimeMs: 1 }] }),
+      readNote: async () => ({ ok: true, path: 'note.md', content: 'alpha beta', baseline: 'b1', size: 10, mtimeMs: 1 }),
+      createNote: async (input) => recordActor(mutationActors, input.actor, { ok: true, path: input.path, audit: audit(input.actor, 'create') }),
+      editNote: async (input) => recordActor(mutationActors, input.actor, input.baseline === 'stale'
+        ? { ok: false, rejected: 'stale_doc', current_content: 'alpha beta', baseline: 'fresh' }
+        : { ok: true, path: input.path, content: input.newText, baseline: 'b2', audit: audit(input.actor, 'splice') }),
+      appendNote: async (input) => recordActor(mutationActors, input.actor, { ok: true, path: input.path, content: input.content, baseline: 'b3', audit: audit(input.actor, 'append') }),
+      prependNote: async (input) => recordActor(mutationActors, input.actor, { ok: true, path: input.path, content: input.content, baseline: 'b4', audit: audit(input.actor, 'prepend') }),
+      deleteNote: async (input) => recordActor(mutationActors, input.actor, { ok: true, path: input.path, permanent: input.permanent, audit: audit(input.actor, 'delete') }),
+      moveNote: async (input) => recordActor(mutationActors, input.actor, { ok: true, fromPath: input.fromPath, toPath: input.toPath, kind: 'file', audit: audit(input.actor, 'move') }),
+      createFolder: async (input) => recordActor(mutationActors, input.actor, { ok: true, path: input.path, audit: audit(input.actor, 'mkdir') }),
+      deleteFolder: async (input) => recordActor(mutationActors, input.actor, { ok: true, path: input.path, permanent: input.permanent, liveDeleted: [], audit: audit(input.actor, 'delete') }),
+      moveFolder: async (input) => recordActor(mutationActors, input.actor, { ok: true, fromPath: input.fromPath, toPath: input.toPath, liveMoved: [], audit: audit(input.actor, 'move') }),
+      search: async () => ({ ok: true, total: 1, results: [{ path: 'note.md', line: 1, lineText: 'alpha beta', context: { before: [], after: [] } }], truncated: false })
+    };
+    const endpoint = createLocalMcpEndpoint(service);
+    const client = new Client({ name: 'sdk-test-client', version: '1.0.0' });
+    const transport = new StreamableHTTPClientTransport(new URL('http://127.0.0.1/mcp'), {
+      fetch: async (input, init) => endpoint.handleRequest(input instanceof Request ? input : new Request(input, init))
+    });
+
+    await client.connect(transport);
+    const tools = await client.listTools();
+    expect(tools.tools.map((tool) => tool.name).sort()).toEqual([
+      'append_note',
+      'create_folder',
+      'create_note',
+      'delete_folder',
+      'delete_note',
+      'edit_note',
+      'list_files',
+      'move_folder',
+      'move_note',
+      'prepend_note',
+      'read_note',
+      'search',
+      'vault_info'
+    ]);
+
+    expect(await toolJson(client, 'vault_info', {})).toMatchObject({ ok: true, rootName: 'demo-vault' });
+    expect(await toolJson(client, 'list_files', { under: 'notes', depth: 1 })).toMatchObject({ ok: true, entries: [{ path: 'notes' }] });
+    expect(await toolJson(client, 'read_note', { path: 'note.md' })).toMatchObject({ ok: true, baseline: 'b1' });
+    expect(await toolJson(client, 'create_note', { path: 'created.md', content: 'created' })).toMatchObject({ ok: true, path: 'created.md' });
+    expect(await toolJson(client, 'edit_note', { path: 'note.md', baseline: 'b1', old_text: 'alpha', new_text: 'ALPHA' })).toMatchObject({ ok: true, content: 'ALPHA' });
+    expect(await toolJson(client, 'append_note', { path: 'note.md', content: '\nnext' })).toMatchObject({ ok: true, baseline: 'b3' });
+    expect(await toolJson(client, 'prepend_note', { path: 'note.md', content: 'first\n' })).toMatchObject({ ok: true, baseline: 'b4' });
+    expect(await toolJson(client, 'delete_note', { path: 'note.md' })).toMatchObject({ ok: true, path: 'note.md' });
+    expect(await toolJson(client, 'move_note', { from_path: 'note.md', to_path: 'moved.md' })).toMatchObject({ ok: true, toPath: 'moved.md' });
+    expect(await toolJson(client, 'create_folder', { path: 'folder' })).toMatchObject({ ok: true, path: 'folder' });
+    expect(await toolJson(client, 'delete_folder', { path: 'folder', recursive: true })).toMatchObject({ ok: true, path: 'folder' });
+    expect(await toolJson(client, 'move_folder', { from_path: 'old', to_path: 'new' })).toMatchObject({ ok: true, toPath: 'new' });
+    expect(await toolJson(client, 'search', { query: 'alpha' })).toMatchObject({ ok: true, total: 1 });
+
+    const stale = await client.callTool({
+      name: 'edit_note',
+      arguments: { path: 'note.md', baseline: 'stale', old_text: 'alpha', new_text: 'ALPHA' }
+    });
+    expect(stale.isError).toBe(true);
+    expect(textContent(stale)).toBe('edit_note rejected: {"ok":false,"rejected":"stale_doc","current_content":"alpha beta","baseline":"fresh"}');
+
+    expect(mutationActors).toHaveLength(10);
+    expect(mutationActors.every((actor) => actor.kind === 'mcp_client' && actor.client === 'sdk-test-client')).toBe(true);
+
+    await transport.terminateSession();
+    await endpoint.close();
+  });
+});
+
+async function toolJson(client: Client, name: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  return JSON.parse(textContent(await client.callTool({ name, arguments: args }))) as Record<string, unknown>;
+}
+
+function textContent(result: Awaited<ReturnType<Client['callTool']>>): string {
+  if (!Array.isArray(result.content)) {
+    throw new Error('Expected MCP content array');
+  }
+  const first = result.content[0] as { type?: unknown; text?: unknown } | undefined;
+  if (!first || first.type !== 'text' || typeof first.text !== 'string') {
+    throw new Error('Expected text MCP content');
+  }
+  return first.text;
+}
+
+function recordActor<T extends ServiceResult>(actors: VaultActor[], actor: VaultActor, result: T): T {
+  actors.push(actor);
+  return result;
+}
+
+function audit(actor: VaultActor, operation: string) {
+  return {
+    id: `${operation}-1`,
+    ts: '2026-06-11T00:00:00.000Z',
+    actor,
+    operation,
+    entityKind: 'file' as const,
+    path: 'note.md',
+    summary: operation
+  };
+}

--- a/packages/local-mcp/src/server.test.ts
+++ b/packages/local-mcp/src/server.test.ts
@@ -5,6 +5,30 @@ import { createLocalMcpEndpoint } from './server.js';
 import type { LocalMcpVaultService, ServiceResult, VaultActor } from './types.js';
 
 describe('local MCP server', () => {
+  it('rejects requests that do not carry or initialize a valid MCP session', async () => {
+    const endpoint = createLocalMcpEndpoint(emptyService());
+
+    const getResponse = await endpoint.handleRequest(new Request('http://127.0.0.1/mcp'));
+    expect(getResponse.status).toBe(400);
+    await expect(getResponse.json()).resolves.toMatchObject({
+      jsonrpc: '2.0',
+      error: {
+        code: -32000,
+        message: 'Bad Request: No valid MCP session id provided'
+      },
+      id: null
+    });
+
+    const postResponse = await endpoint.handleRequest(new Request('http://127.0.0.1/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 1 })
+    }));
+    expect(postResponse.status).toBe(400);
+
+    await endpoint.close();
+  });
+
   it('registers every tier-1 tool and forwards calls to the injected service with initialize attribution', async () => {
     const mutationActors: VaultActor[] = [];
     const service: LocalMcpVaultService = {
@@ -106,5 +130,24 @@ function audit(actor: VaultActor, operation: string) {
     entityKind: 'file' as const,
     path: 'note.md',
     summary: operation
+  };
+}
+
+function emptyService(): LocalMcpVaultService {
+  const ok = async (): Promise<ServiceResult> => ({ ok: true });
+  return {
+    vaultInfo: ok,
+    listFiles: ok,
+    readNote: ok,
+    createNote: ok,
+    editNote: ok,
+    appendNote: ok,
+    prependNote: ok,
+    deleteNote: ok,
+    moveNote: ok,
+    createFolder: ok,
+    deleteFolder: ok,
+    moveFolder: ok,
+    search: ok
   };
 }

--- a/packages/local-mcp/src/server.ts
+++ b/packages/local-mcp/src/server.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from 'node:crypto';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod/v4';
+
+import type { LocalMcpActor, LocalMcpVaultService, ServiceFailure } from './types.js';
+
+const unknownActor: LocalMcpActor = { kind: 'mcp_client', client: 'unknown local caller' };
+
+export interface LocalMcpEndpoint {
+  handleRequest(request: Request): Promise<Response>;
+  close(): Promise<void>;
+}
+
+interface SessionRecord {
+  server: McpServer;
+  transport: WebStandardStreamableHTTPServerTransport;
+}
+
+export function createLocalMcpEndpoint(service: LocalMcpVaultService): LocalMcpEndpoint {
+  const sessions = new Map<string, SessionRecord>();
+
+  return {
+    async handleRequest(request) {
+      const sessionId = request.headers.get('mcp-session-id') ?? undefined;
+      const existing = sessionId ? sessions.get(sessionId) : undefined;
+      if (existing) {
+        return existing.transport.handleRequest(request);
+      }
+
+      const parsedBody = request.method === 'POST' ? await request.clone().json().catch(() => undefined) : undefined;
+      if (request.method !== 'POST' || !isInitializeRequest(parsedBody)) {
+        return jsonRpcError('Bad Request: No valid MCP session id provided', 400);
+      }
+
+      let assignedSessionId: string | undefined;
+      const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (nextSessionId) => {
+          assignedSessionId = nextSessionId;
+        }
+      });
+      const server = createLocalMcpServer(service);
+
+      transport.onclose = () => {
+        const id = transport.sessionId ?? assignedSessionId;
+        if (id) sessions.delete(id);
+      };
+
+      await server.connect(transport);
+      const response = await transport.handleRequest(request, { parsedBody });
+      const id = transport.sessionId ?? assignedSessionId;
+      if (id) {
+        sessions.set(id, { server, transport });
+      }
+      return response;
+    },
+    async close() {
+      const records = [...sessions.values()];
+      sessions.clear();
+      await Promise.all(records.map(({ server }) => server.close()));
+    }
+  };
+}
+
+export function createLocalMcpServer(service: LocalMcpVaultService): McpServer {
+  const server = new McpServer({
+    name: 'kb-2-local-daemon',
+    version: '0.0.0'
+  });
+
+  const actor = (): LocalMcpActor => {
+    const client = server.server.getClientVersion()?.name?.trim();
+    return client ? { kind: 'mcp_client', client } : unknownActor;
+  };
+
+  registerTool(server, 'vault_info', {
+    description: 'Return the vault root name plus file and folder counts. Read-only; writes no audit row.',
+    inputSchema: {}
+  }, async () => service.vaultInfo());
+
+  registerTool(server, 'list_files', {
+    description: 'List files and folders under a vault folder. Depth and entry caps mirror the daemon API. Read-only; writes no audit row.',
+    inputSchema: {
+      under: z.string().optional().describe('Folder path to list under. Omit for the vault root.'),
+      depth: z.number().int().nonnegative().optional().describe('Maximum recursive depth to return.')
+    }
+  }, async (input) => service.listFiles(input));
+
+  registerTool(server, 'read_note', {
+    description: 'Read a Markdown note and return content, stat fields, and baseline. Use baseline for edit_note retry loops. Read-only; writes no audit row.',
+    inputSchema: {
+      path: z.string().describe('Vault-relative Markdown file path.')
+    }
+  }, async (input) => service.readNote(input));
+
+  registerTool(server, 'create_note', {
+    description: 'Create a Markdown note without clobbering by default. Set overwrite to replace existing content. Mutations are audited as mcp_client.',
+    inputSchema: {
+      path: z.string().describe('Vault-relative Markdown file path to create.'),
+      content: z.string().default('').describe('Full note content.'),
+      overwrite: z.boolean().optional().describe('Replace an existing note when true.')
+    }
+  }, async (input) => service.createNote({ ...input, actor: actor() }));
+
+  registerTool(server, 'edit_note', {
+    description: 'Apply the Chunk 008 anchored splice contract verbatim. Requires a read_note baseline plus old_text/new_text and optional before/after/occurrence anchors. Rejected results are returned intact: stale_doc includes current_content and fresh baseline; ambiguous includes match_count; size rejects include limits; persist_failed means the edit was not durably saved and has no success audit row.',
+    inputSchema: {
+      path: z.string().describe('Vault-relative Markdown file path to edit.'),
+      baseline: z.string().describe('Baseline returned by read_note.'),
+      old_text: z.string().describe('Text to replace, LF-normalized.'),
+      new_text: z.string().describe('Replacement text, LF-normalized.'),
+      before: z.string().optional().describe('Optional text immediately before old_text for disambiguation.'),
+      after: z.string().optional().describe('Optional text immediately after old_text for disambiguation.'),
+      occurrence: z.number().int().positive().optional().describe('1-based match occurrence to edit when anchors still match multiple ranges.')
+    }
+  }, async (input) => service.editNote({
+    path: input.path,
+    baseline: input.baseline,
+    oldText: input.old_text,
+    newText: input.new_text,
+    before: input.before,
+    after: input.after,
+    occurrence: input.occurrence,
+    actor: actor()
+  }));
+
+  registerTool(server, 'append_note', {
+    description: 'Append content to a note, creating it when missing. Mutations flow through live sessions and are audited as mcp_client.',
+    inputSchema: {
+      path: z.string().describe('Vault-relative Markdown file path.'),
+      content: z.string().describe('Content to append.')
+    }
+  }, async (input) => service.appendNote({ ...input, actor: actor() }));
+
+  registerTool(server, 'prepend_note', {
+    description: 'Prepend content to an existing note after frontmatter when present. Mutations flow through live sessions and are audited as mcp_client.',
+    inputSchema: {
+      path: z.string().describe('Vault-relative Markdown file path.'),
+      content: z.string().describe('Content to prepend.')
+    }
+  }, async (input) => service.prependNote({ ...input, actor: actor() }));
+
+  registerTool(server, 'delete_note', {
+    description: 'Delete a note. By default it is moved into .kb2/trash; set permanent for an irreversible delete. Mutations are audited as mcp_client.',
+    inputSchema: {
+      path: z.string().describe('Vault-relative Markdown file path.'),
+      permanent: z.boolean().optional().describe('Permanently remove instead of moving to trash.')
+    }
+  }, async (input) => service.deleteNote({ ...input, actor: actor() }));
+
+  registerTool(server, 'move_note', {
+    description: 'Move or rename a note and rekey any live session. Wikilinks are not rewritten. Mutations are audited as mcp_client.',
+    inputSchema: {
+      from_path: z.string().describe('Current vault-relative Markdown file path.'),
+      to_path: z.string().describe('Destination vault-relative Markdown file path.')
+    }
+  }, async (input) => service.moveNote({ fromPath: input.from_path, toPath: input.to_path, actor: actor() }));
+
+  registerTool(server, 'create_folder', {
+    description: 'Create a folder. Mutations are audited as mcp_client when a folder is newly created.',
+    inputSchema: {
+      path: z.string().describe('Vault-relative folder path.')
+    }
+  }, async (input) => service.createFolder({ ...input, actor: actor() }));
+
+  registerTool(server, 'delete_folder', {
+    description: 'Delete a folder. Non-empty folders require recursive=true. By default deletion moves to .kb2/trash; permanent removes directly. Mutations are audited as mcp_client.',
+    inputSchema: {
+      path: z.string().describe('Vault-relative folder path.'),
+      recursive: z.boolean().optional().describe('Allow deleting a non-empty folder.'),
+      permanent: z.boolean().optional().describe('Permanently remove instead of moving to trash.')
+    }
+  }, async (input) => service.deleteFolder({ ...input, actor: actor() }));
+
+  registerTool(server, 'move_folder', {
+    description: 'Move or rename a folder and rekey any live sessions below it. Wikilinks are not rewritten. Mutations are audited as mcp_client.',
+    inputSchema: {
+      from_path: z.string().describe('Current vault-relative folder path.'),
+      to_path: z.string().describe('Destination vault-relative folder path.')
+    }
+  }, async (input) => service.moveFolder({ fromPath: input.from_path, toPath: input.to_path, actor: actor() }));
+
+  registerTool(server, 'search', {
+    description: 'Search vault notes with optional folder scope, context lines, and pagination. Read-only; writes no audit row.',
+    inputSchema: {
+      query: z.string().describe('Search query.'),
+      under: z.string().optional().describe('Folder path to search under.'),
+      context: z.number().int().nonnegative().optional().describe('Context lines around each match.'),
+      limit: z.number().int().positive().optional().describe('Maximum hits to return.'),
+      offset: z.number().int().nonnegative().optional().describe('Pagination offset.')
+    }
+  }, async (input) => service.search(input));
+
+  return server;
+}
+
+function registerTool(
+  server: McpServer,
+  name: string,
+  config: { description: string; inputSchema: Record<string, z.ZodType> },
+  handler: (input: any) => Promise<unknown>
+): void {
+  server.registerTool(name, config, async (input) => {
+    const result = await handler(input);
+    if (isServiceFailure(result)) {
+      return {
+        isError: true,
+        content: [{ type: 'text', text: `${name} rejected: ${JSON.stringify(result)}` }]
+      };
+    }
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }]
+    };
+  });
+}
+
+function isServiceFailure(value: unknown): value is ServiceFailure {
+  return Boolean(value && typeof value === 'object' && 'ok' in value && (value as { ok?: unknown }).ok === false);
+}
+
+function jsonRpcError(message: string, status: number): Response {
+  return new Response(JSON.stringify({
+    jsonrpc: '2.0',
+    error: {
+      code: -32000,
+      message
+    },
+    id: null
+  }), {
+    status,
+    headers: {
+      'content-type': 'application/json'
+    }
+  });
+}

--- a/packages/local-mcp/src/types.ts
+++ b/packages/local-mcp/src/types.ts
@@ -1,0 +1,65 @@
+export interface VaultActor {
+  kind: 'user' | 'mcp_client' | 'integration' | 'system';
+  client?: string;
+}
+
+export interface AuditEntry {
+  id: string;
+  ts: string;
+  actor: VaultActor;
+  operation: string;
+  entityKind: 'file' | 'folder';
+  path: string;
+  fromPath?: string;
+  toPath?: string;
+  summary: string;
+}
+
+export interface VaultEntry {
+  path: string;
+  kind: 'file' | 'folder';
+  size: number;
+  mtimeMs: number;
+}
+
+export type LocalMcpActor = { kind: 'mcp_client'; client: string };
+
+export type ServiceResult<T extends object = object> = { ok: true } & T | ServiceFailure;
+
+export type ServiceFailure =
+  | { ok: false; error: string; message: string }
+  | ({ ok: false; rejected: string } & Record<string, unknown>);
+
+export interface ReadNoteValue {
+  path: string;
+  content: string;
+  baseline: string;
+  size: number;
+  mtimeMs: number;
+}
+
+export interface EditNoteInput {
+  path: string;
+  baseline: string;
+  oldText: string;
+  newText: string;
+  before?: string;
+  after?: string;
+  occurrence?: number;
+}
+
+export interface LocalMcpVaultService {
+  vaultInfo(): Promise<ServiceResult>;
+  listFiles(input: { under?: string; depth?: number }): Promise<ServiceResult>;
+  readNote(input: { path: string }): Promise<ServiceResult>;
+  createNote(input: { path: string; content: string; overwrite?: boolean; actor: VaultActor }): Promise<ServiceResult>;
+  editNote(input: EditNoteInput & { actor: VaultActor }): Promise<ServiceResult>;
+  appendNote(input: { path: string; content: string; actor: VaultActor }): Promise<ServiceResult>;
+  prependNote(input: { path: string; content: string; actor: VaultActor }): Promise<ServiceResult>;
+  deleteNote(input: { path: string; permanent?: boolean; actor: VaultActor }): Promise<ServiceResult>;
+  moveNote(input: { fromPath: string; toPath: string; actor: VaultActor }): Promise<ServiceResult>;
+  createFolder(input: { path: string; actor: VaultActor }): Promise<ServiceResult>;
+  deleteFolder(input: { path: string; recursive?: boolean; permanent?: boolean; actor: VaultActor }): Promise<ServiceResult>;
+  moveFolder(input: { fromPath: string; toPath: string; actor: VaultActor }): Promise<ServiceResult>;
+  search(input: { query: string; under?: string; context?: number; limit?: number; offset?: number }): Promise<ServiceResult>;
+}

--- a/packages/local-mcp/tsconfig.build.json
+++ b/packages/local-mcp/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "dist/tsconfig.build.tsbuildinfo",
+    "types": ["node"]
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/local-mcp/tsconfig.json
+++ b/packages/local-mcp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/local-mcp/vitest.config.ts
+++ b/packages/local-mcp/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts'],
+      thresholds: {
+        lines: 95
+      }
+    }
+  }
+});

--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -22,6 +22,7 @@ import {
   writeVaultFile,
   type VaultContext
 } from './index.js';
+import { anchoredSpliceContractCases } from './splice-contract-cases.test-support.js';
 
 describe('vault path validation', () => {
   const validSegment = fc.stringMatching(/^[A-Za-z0-9_-]{1,24}$/).filter((segment) =>
@@ -299,6 +300,10 @@ describe('vault-core filesystem operations', () => {
 });
 
 describe('anchored splice and positioned content helpers', () => {
+  it.each(anchoredSpliceContractCases)('satisfies shared splice contract: $name', ({ initialContent, request, expected }) => {
+    expect(applyAnchoredSplice(initialContent, request)).toEqual(expected);
+  });
+
   it('applies exact replacements with anchors, occurrence, LF normalization, and surrogate pairs', () => {
     expect(applyAnchoredSplice('one two three', {
       oldText: 'two',

--- a/packages/vault-core/src/splice-contract-cases.test-support.ts
+++ b/packages/vault-core/src/splice-contract-cases.test-support.ts
@@ -1,0 +1,73 @@
+import {
+  DOCUMENT_BYTES_LIMIT,
+  SPLICE_BYTES_LIMIT,
+  type AnchoredSpliceRequest,
+  type AnchoredSpliceResult
+} from './splice.js';
+
+export interface AnchoredSpliceContractCase {
+  name: string;
+  initialContent: string;
+  request: AnchoredSpliceRequest;
+  expected: AnchoredSpliceResult;
+}
+
+export const anchoredSpliceContractCases: AnchoredSpliceContractCase[] = [
+  {
+    name: 'occurrence anchoring replaces the requested match',
+    initialContent: 'foo bar foo baz foo',
+    request: {
+      oldText: 'foo',
+      newText: 'FOO',
+      occurrence: 2
+    },
+    expected: { ok: true, content: 'foo bar FOO baz foo' }
+  },
+  {
+    name: 'before and after anchors disambiguate the match',
+    initialContent: 'aa aa aa',
+    request: {
+      before: 'aa ',
+      oldText: 'aa',
+      after: ' aa',
+      newText: 'XX'
+    },
+    expected: { ok: true, content: 'aa XX aa' }
+  },
+  {
+    name: 'missing text is reported as not_found',
+    initialContent: 'hello',
+    request: {
+      oldText: 'missing',
+      newText: 'x'
+    },
+    expected: { ok: false, rejected: 'not_found' }
+  },
+  {
+    name: 'oversized splice input is rejected before matching',
+    initialContent: 'x',
+    request: {
+      oldText: 'x'.repeat(SPLICE_BYTES_LIMIT + 1),
+      newText: 'y'
+    },
+    expected: {
+      ok: false,
+      rejected: 'too_large_splice',
+      limit_bytes: SPLICE_BYTES_LIMIT
+    }
+  },
+  {
+    name: 'oversized resulting document is rejected',
+    initialContent: `x${'a'.repeat(DOCUMENT_BYTES_LIMIT - 1)}`,
+    request: {
+      oldText: 'x',
+      newText: 'yy'
+    },
+    expected: {
+      ok: false,
+      rejected: 'too_large_document',
+      current_bytes: DOCUMENT_BYTES_LIMIT + 1,
+      limit_bytes: DOCUMENT_BYTES_LIMIT
+    }
+  }
+];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@kb-2/doc-session':
         specifier: workspace:*
         version: link:../../packages/doc-session
+      '@kb-2/local-mcp':
+        specifier: workspace:*
+        version: link:../../packages/local-mcp
       '@kb-2/vault-core':
         specifier: workspace:*
         version: link:../../packages/vault-core
@@ -105,6 +108,9 @@ importers:
         specifier: 8.21.0
         version: 8.21.0
     devDependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@types/ws':
         specifier: 8.18.1
         version: 8.18.1
@@ -270,6 +276,22 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  packages/local-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.4.3)
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: 4.1.8
+        version: 4.1.8(vitest@4.1.8)
+      vitest:
+        specifier: 4.1.8
+        version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/tunnel-protocol:
     devDependencies:
@@ -757,6 +779,12 @@ packages:
   '@fontsource/source-serif-4@5.2.9':
     resolution: {integrity: sha512-er/Pym9emsEVJNf947umJ4kXarXfsiN6CN7kTYinefKRaHLwiquiiHOZvKvxWgkV8JMCf3pV3g0NcsPFpVCH9w==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hono/node-server@2.0.4':
     resolution: {integrity: sha512-Ut3y0dMMPWy6bZ2kVfx25EOVbZlm15dhF4mOsezMlhpNHy+4MkU1qN9Y6lnruYi4wPmFzimGX2X7LF/FwHli4A==}
     engines: {node: '>=20'}
@@ -818,6 +846,16 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
@@ -1447,10 +1485,25 @@ packages:
     resolution: {integrity: sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==}
     hasBin: true
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -1512,6 +1565,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
@@ -1523,8 +1580,16 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   chai@5.3.3:
@@ -1578,21 +1643,58 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
 
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   dedent-js@1.0.1:
     resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
@@ -1636,6 +1738,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1665,6 +1771,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   ejs@5.0.1:
     resolution: {integrity: sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A==}
     engines: {node: '>=0.12.18'}
@@ -1672,6 +1781,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1720,6 +1833,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -1749,9 +1865,31 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -1761,8 +1899,14 @@ packages:
     resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
     engines: {node: '>=12.17.0'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1776,6 +1920,10 @@ packages:
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   flat@5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
@@ -1793,6 +1941,14 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -1851,6 +2007,14 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -1864,6 +2028,14 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-docker@2.2.1:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
@@ -1892,6 +2064,9 @@ packages:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
@@ -1906,6 +2081,9 @@ packages:
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
@@ -1926,6 +2104,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -1935,6 +2116,12 @@ packages:
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -2137,13 +2324,29 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -2168,10 +2371,17 @@ packages:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -2189,9 +2399,21 @@ packages:
       '@swc/core':
         optional: true
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.2:
     resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
     engines: {node: '>=12.20.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2212,9 +2434,16 @@ packages:
     resolution: {integrity: sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==}
     engines: {node: '>=10'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2239,6 +2468,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2247,12 +2480,28 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
 
   pure-rand@8.4.0:
     resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
@@ -2286,6 +2535,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve.exports@2.0.3:
     resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
     engines: {node: '>=10'}
@@ -2304,6 +2557,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -2314,6 +2571,9 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2330,8 +2590,43 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2360,6 +2655,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -2471,6 +2770,10 @@ packages:
     resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -2499,6 +2802,10 @@ packages:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -2512,6 +2819,10 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
@@ -2523,6 +2834,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@7.3.5:
     resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
@@ -2665,6 +2980,11 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -2725,6 +3045,14 @@ packages:
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -3042,6 +3370,10 @@ snapshots:
 
   '@fontsource/source-serif-4@5.2.9': {}
 
+  '@hono/node-server@1.19.14(hono@4.12.25)':
+    dependencies:
+      hono: 4.12.25
+
   '@hono/node-server@2.0.4(hono@4.12.25)':
     dependencies:
       hono: 4.12.25
@@ -3119,6 +3451,28 @@ snapshots:
       '@types/mdx': 2.0.14
       '@types/react': 19.2.17
       react: 19.2.7
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.25)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.25
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
@@ -3669,7 +4023,23 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -3727,6 +4097,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.3
@@ -3740,10 +4124,17 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bytes@3.1.2: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@5.3.3:
     dependencies:
@@ -3792,15 +4183,40 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.6.0: {}
 
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   crelt@1.0.6: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
 
   dedent-js@1.0.1: {}
 
@@ -3827,6 +4243,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -3849,9 +4267,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ee-first@1.1.1: {}
+
   ejs@5.0.1: {}
 
   emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -3945,6 +4367,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@1.0.5: {}
 
   esm-env@1.2.2: {}
@@ -3968,7 +4392,53 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend-shallow@2.0.1:
     dependencies:
@@ -3978,7 +4448,11 @@ snapshots:
     dependencies:
       pure-rand: 8.4.0
 
+  fast-deep-equal@3.1.3: {}
+
   fast-diff@1.3.0: {}
+
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3987,6 +4461,17 @@ snapshots:
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   flat@5.0.2: {}
 
@@ -3999,6 +4484,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -4054,6 +4543,18 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@7.0.5: {}
@@ -4061,6 +4562,10 @@ snapshots:
   indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-docker@2.2.1: {}
 
@@ -4076,6 +4581,8 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
+  is-promise@4.0.0: {}
+
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -4089,6 +4596,8 @@ snapshots:
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  isexe@2.0.0: {}
 
   isomorphic.js@0.2.5: {}
 
@@ -4107,6 +4616,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.3: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -4115,6 +4626,10 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
 
@@ -4255,11 +4770,21 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-fn@2.1.0: {}
 
@@ -4275,7 +4800,11 @@ snapshots:
 
   mrmime@2.0.1: {}
 
+  ms@2.1.3: {}
+
   nanoid@3.3.12: {}
+
+  negotiator@1.0.0: {}
 
   npm-run-path@4.0.1:
     dependencies:
@@ -4407,7 +4936,15 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obug@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -4441,7 +4978,11 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
+  parseurl@1.3.3: {}
+
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -4459,6 +5000,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pkce-challenge@5.0.1: {}
+
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
@@ -4471,9 +5014,27 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@2.1.0: {}
 
   pure-rand@8.4.0: {}
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.1
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
@@ -4506,6 +5067,8 @@ snapshots:
       strip-indent: 3.0.0
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve.exports@2.0.3: {}
 
@@ -4566,6 +5129,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.1.0: {}
 
   sade@1.8.1:
@@ -4573,6 +5146,8 @@ snapshots:
       mri: 1.2.0
 
   safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
 
@@ -4585,7 +5160,68 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@3.1.0: {}
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -4606,6 +5242,8 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 
@@ -4737,6 +5375,8 @@ snapshots:
 
   tmp@0.2.6: {}
 
+  toidentifier@1.0.1: {}
+
   totalist@3.0.1: {}
 
   tree-kill@1.2.2: {}
@@ -4759,11 +5399,19 @@ snapshots:
 
   type-fest@2.19.0: {}
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 
   undici-types@7.24.6: {}
+
+  unpipe@1.0.0: {}
 
   unplugin@2.3.11:
     dependencies:
@@ -4777,6 +5425,8 @@ snapshots:
       react: 19.2.7
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
@@ -4877,6 +5527,10 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -4924,3 +5578,9 @@ snapshots:
   zimmerframe@1.1.2: {}
 
   zimmerframe@1.1.4: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,6 +7,7 @@
       "@kb-2/doc-session": ["./packages/doc-session/src/index.ts"],
       "@kb-2/doc-session/protocol": ["./packages/doc-session/src/protocol.ts"],
       "@kb-2/editor": ["./packages/editor/src/lib/index.ts"],
+      "@kb-2/local-mcp": ["./packages/local-mcp/src/index.ts"],
       "@kb-2/tunnel-protocol": ["./packages/tunnel-protocol/src/index.ts"],
       "@kb-2/vault-core": ["./packages/vault-core/src/index.ts"],
       "@kb-2/ui": ["./packages/ui/src/lib/index.ts"]


### PR DESCRIPTION
## Summary

- Adds `packages/local-mcp` with the official `@modelcontextprotocol/sdk@1.29.0` streamable-HTTP MCP server and 13 tier-1 tools: `vault_info`, `list_files`, `read_note`, `create_note`, `edit_note`, `append_note`, `prepend_note`, `delete_note`, `move_note`, `create_folder`, `delete_folder`, `move_folder`, `search`.
- Mounts stateful MCP sessions at `/mcp` on the daemon's existing loopback port, preserving initialize client attribution for mutation audit rows.
- Refactors daemon vault operations into a shared service object used by both REST routes and MCP tools, so MCP does not self-call HTTP or write the filesystem directly.
- Preserves the Chunk 008 splice contract through MCP: stale_doc returns current content plus fresh baseline, ambiguous returns match_count, persist_failed is a tool error with no success audit row.
- Adds README MCP setup and tool documentation.

## Explicit Deviations

- No functional deviations from the binding plan.
- Manual browser verification used real Google Chrome driven by temporary Playwright because the Codex in-app Browser tool was unavailable in this session. The browser typed into the live CodeMirror editor against the running daemon.

## Verification Evidence

Automated:

- `pnpm check -- --skip-nx-cache` passed: typecheck, tests, and build for all 8 projects.
- `packages/local-mcp` coverage: 96.87% lines, satisfying the >=95% line gate.
- Daemon MCP SDK-client integration test exercises every tier-1 tool end-to-end on a real temp filesystem with dual disk assertions for mutations.
- MCP persist-failure test reproduces a read-only directory failure through `append_note`, returns `persist_failed`, leaves disk unchanged, and verifies no success audit row was added.

Manual SDK client against live daemon:

- Started daemon with `KB2_HOME=$(mktemp -d)` and `KB2_PORT=17992`.
- SDK client `manual-sdk-client` connected to `http://127.0.0.1:17992/mcp` and listed all 13 tools.
- `read_note -> edit_note -> stale retry -> read disk` succeeded.
- Stale response text included `edit_note rejected: {"ok":false,"rejected":"stale_doc","current_content":"one TWO three\n","baseline":"..."}`.
- Disk ended as `one TWO THREE\n`.
- Audit rows for create/splice/splice carried `actor: { kind: "mcp_client", client: "manual-sdk-client" }`.

Manual persist_failed repro through MCP:

- SDK client `manual-persist-client` opened `manual/readonly.md`, chmodded the parent directory read-only, then called `append_note`.
- Tool returned `append_note rejected: {"ok":false,"error":"persist_failed","message":"Document edit could not be durably saved to disk."}`.
- Disk remained `base\n` and audit row count stayed unchanged.

Browser straddle drill:

- Real Chrome opened `http://127.0.0.1:17992/hello-world.md` and typed continuously into `.cm-content`.
- MCP client `browser-straddle-client` called `edit_note` while typing was still active; first attempt hit stale_doc, second attempt landed before typing completed.
- Final disk contained both `MCP-BETA` and full browser text `BROWSER-BEFORE BROWSER-AFTER-000111222333444555666777888999`.
- Latest splice audit row carried `actor: { kind: "mcp_client", client: "browser-straddle-client" }`.
- All started daemon/browser processes were stopped and the temp `KB2_HOME` was removed.
