### PR TITLE
Chunk 012: Persist Barrier + Change Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,28 @@ pnpm dev     # one command: web UI + API behind one daemon port
 Port/env overrides: `KB2_PORT` (daemon), `KB2_WEB_PORT` (internal Vite dev
 server), `KB2_HOME` (daemon state directory, defaults to `~/.kb2`).
 
+## Local API Primitives
+
+`POST /api/ops/flush` is the backup primitive. It forces every dirty live
+document session through the existing doc-session materialization path and
+returns only after those writes have settled:
+
+```json
+{ "ok": true, "flushed": 1, "durableAsOf": "2026-06-12T09:00:00.000Z" }
+```
+
+Call it before snapshotting or syncing the vault. A clean vault returns
+`flushed: 0`. If any session cannot persist, the response uses the same
+canonical failure dialect as the rest of the API, and the existing save-warning
+event path still fires.
+
+`GET /api/events` is the tooling primitive. It is a Server-Sent Events stream
+for watchers, backup triggers, and future live tree refresh. Events report
+change kind, vault-relative paths, actor attribution, and timestamps for
+persisted content, file/folder create/delete/move, folder metadata changes,
+external file changes, and persist failure/recovery. Event payloads never carry
+file content; consumers fetch content through the normal read APIs.
+
 ## MCP
 
 The daemon hosts a streamable-HTTP MCP server at `/mcp` on the same loopback

--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -4,7 +4,13 @@ import {
   createLocalMcpEndpoint,
   type LocalMcpEndpoint
 } from '@kb-2/local-mcp';
-import { createVaultService, type LocalMcpVaultService, type ServiceErrorCode, type ServiceResult } from '@kb-2/vault-service';
+import {
+  createVaultService,
+  type ServiceErrorCode,
+  type ServiceResult,
+  type VaultChangeEvent,
+  type VaultService
+} from '@kb-2/vault-service';
 import { resolve } from 'node:path';
 
 import { SERVICE_NAME } from './config.js';
@@ -26,7 +32,7 @@ export interface CreateAppOptions {
   statusFile: string;
   vaultRoot?: string;
   documentSessions?: DocumentSessionManager;
-  vaultService?: LocalMcpVaultService;
+  vaultService?: VaultService;
   demoDocumentSession?: OneFileDocumentSession;
   mcpEndpoint?: LocalMcpEndpoint;
   webBuildDir?: string;
@@ -76,6 +82,14 @@ export function createApp(options: CreateAppOptions): Hono {
       documentSessions: options.documentSessions ?? new DocumentSessionManager({ root: options.vaultRoot })
     });
     const mcpEndpoint = options.mcpEndpoint ?? createLocalMcpEndpoint(vaultService);
+
+    api.post('/ops/flush', async (context) => {
+      return mapServiceResult(context, await vaultService.flushDirtySessions());
+    });
+
+    api.get('/events', () => {
+      return eventStreamResponse(vaultService);
+    });
 
     api.get('/vault', async (context) => {
       return mapServiceResult(context, await vaultService.vaultInfo());
@@ -287,6 +301,34 @@ export function createApp(options: CreateAppOptions): Hono {
   }
 
   return app;
+}
+
+function eventStreamResponse(vaultService: VaultService): Response {
+  const encoder = new TextEncoder();
+  let unsubscribe: () => void = () => undefined;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      unsubscribe = vaultService.onEvent((event) => {
+        controller.enqueue(encoder.encode(formatServerSentEvent(event)));
+      });
+    },
+    cancel() {
+      unsubscribe();
+    }
+  });
+
+  return new Response(stream, {
+    headers: {
+      'content-type': 'text/event-stream; charset=utf-8',
+      'cache-control': 'no-cache, no-transform',
+      connection: 'keep-alive'
+    }
+  });
+}
+
+function formatServerSentEvent(event: VaultChangeEvent): string {
+  return `event: change\ndata: ${JSON.stringify(event)}\n\n`;
 }
 
 function mapServiceResult(

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -2,6 +2,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/pr
 import { DocumentSessionManager, OneFileDocumentSession, type DocumentSessionEvent } from '@kb-2/doc-session';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { serve } from '@hono/node-server';
 import type { Hono } from 'hono';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
@@ -10,6 +11,7 @@ import { tmpdir } from 'node:os';
 import * as Y from 'yjs';
 
 import { anchoredSpliceContractCases } from '@kb-2/vault-core';
+import type { VaultChangeEvent } from '@kb-2/vault-service';
 import { createApp } from './app.js';
 import { createDaemonConfig } from './config.js';
 import { writeDaemonStatus } from './status.js';
@@ -970,6 +972,129 @@ describe('daemon routing', () => {
     await sessions.close();
   });
 
+  it('flushes dirty live sessions through a real HTTP barrier with durable file content', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    const session = sessions.getSession('notes/flush.md');
+    await session.open();
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const server = await startHttpApp(app);
+
+    try {
+      session.ydoc.getText('markdown').insert(0, 'flush me now\n');
+      const response = await fetch(`${server.origin}/api/ops/flush`, { method: 'POST' });
+      const body = await response.json() as { ok: boolean; flushed: number; durableAsOf: string };
+
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({ ok: true, flushed: 1 });
+      expect(new Date(body.durableAsOf).toISOString()).toBe(body.durableAsOf);
+      await expect(readFile(join(config.vaultRoot, 'notes/flush.md'), 'utf8')).resolves.toBe('flush me now\n');
+
+      const clean = await fetch(`${server.origin}/api/ops/flush`, { method: 'POST' });
+      await expect(clean.json()).resolves.toMatchObject({ ok: true, flushed: 0 });
+    } finally {
+      await server.close();
+      await sessions.close();
+    }
+  });
+
+  it('maps flush persist failures through the canonical dialect while the loud session event fires', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    await writeFileWithParents(join(config.vaultRoot, 'notes', 'readonly.md'), 'base\n');
+    const session = sessions.getSession('notes/readonly.md');
+    const events: DocumentSessionEvent[] = [];
+    session.onEvent((event) => events.push(event));
+    await session.open();
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const server = await startHttpApp(app);
+    const notesDir = join(config.vaultRoot, 'notes');
+
+    try {
+      await chmod(notesDir, 0o500);
+      session.ydoc.getText('markdown').insert(session.ydoc.getText('markdown').length, 'unsaved\n');
+      await waitUntil(() => events.some((event) => event.kind === 'persist-failure'), () =>
+        `Timed out waiting for persist-failure; events=${JSON.stringify(events)}`
+      );
+
+      const response = await fetch(`${server.origin}/api/ops/flush`, { method: 'POST' });
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: 'persist_failed',
+        message: 'Document edit could not be durably saved to disk.'
+      });
+      await expect(readFile(join(config.vaultRoot, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\n');
+      expect(events).toContainEqual(expect.objectContaining({ kind: 'persist-failure', path: 'notes/readonly.md' }));
+    } finally {
+      await chmod(notesDir, 0o700).catch(() => undefined);
+      if (session.hasActivePersistFailure()) {
+        session.ydoc.getText('markdown').insert(session.ydoc.getText('markdown').length, 'recovered\n');
+        await session.flush().catch(() => undefined);
+      }
+      await server.close();
+      await sessions.close();
+    }
+  });
+
+  it('streams change events over SSE without content bytes and disconnects cleanly', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const server = await startHttpApp(app);
+    const stream = await openSseStream(`${server.origin}/api/events`);
+    const folderPath = 'notes/ユニコード';
+    const notePath = `${folderPath}/stream.md`;
+    const movedPath = `${folderPath}/moved.md`;
+    const secret = 'SECRET_STREAM_BYTES_012';
+
+    try {
+      await expect(fetchJson(`${server.origin}/api/folders`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path: folderPath })
+      })).resolves.toMatchObject({ ok: true, path: folderPath });
+      await expect(fetchText(`${server.origin}/api/files/${encodeVaultPath(notePath)}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'text/plain' },
+        body: 'initial visible content\n'
+      })).resolves.toMatchObject({ ok: true, path: notePath });
+      await expect(fetchJson(`${server.origin}/api/folders/${encodeVaultPath(folderPath)}/metadata`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ color: 'mint', icon: 'folder' })
+      })).resolves.toMatchObject({ ok: true, path: folderPath });
+      await expect(fetchJson(`${server.origin}/api/files/${encodeVaultPath(notePath)}/append`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ content: secret })
+      })).resolves.toMatchObject({ ok: true, path: notePath });
+      await expect(fetchJson(`${server.origin}/api/files/${encodeVaultPath(notePath)}/move`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ to: movedPath })
+      })).resolves.toMatchObject({ ok: true, fromPath: notePath, toPath: movedPath });
+
+      const events = await stream.waitForEvents(5);
+      expect(events.map((event) => event.kind)).toEqual([
+        'folder_created',
+        'file_created',
+        'folder_metadata_changed',
+        'content_persisted',
+        'file_moved'
+      ]);
+      expect(events[0]).toMatchObject({ path: folderPath, actor: { kind: 'user' } });
+      expect(events[3]).toMatchObject({ path: notePath, actor: { kind: 'system' } });
+      expect(events[4]).toMatchObject({ fromPath: notePath, toPath: movedPath, actor: { kind: 'user' } });
+      expect(stream.raw()).not.toContain(secret);
+      await expect(readFile(join(config.vaultRoot, movedPath), 'utf8')).resolves.toBe(`initial visible content\n${secret}`);
+    } finally {
+      await stream.close();
+      await server.close();
+      await sessions.close();
+    }
+  });
+
   it('keeps live move failures classified and resumes old-path watching', async () => {
     const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
     const sessions = new DocumentSessionManager({
@@ -1099,6 +1224,132 @@ describe('daemon routing', () => {
     await rm(webBuildDir, { force: true, recursive: true });
   });
 });
+
+interface StartedHttpApp {
+  origin: string;
+  close: () => Promise<void>;
+}
+
+async function startHttpApp(app: Hono): Promise<StartedHttpApp> {
+  return new Promise((resolve, reject) => {
+    const server = serve({
+      fetch: app.fetch,
+      hostname: '127.0.0.1',
+      port: 0
+    }, (info) => {
+      resolve({
+        origin: `http://${info.address}:${info.port}`,
+        close: () => closeStartedHttpApp(server)
+      });
+    });
+    server.once('error', reject);
+  });
+}
+
+function closeStartedHttpApp(server: ReturnType<typeof serve>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+interface OpenSseStream {
+  waitForEvents: (count: number) => Promise<VaultChangeEvent[]>;
+  raw: () => string;
+  close: () => Promise<void>;
+}
+
+async function openSseStream(url: string): Promise<OpenSseStream> {
+  const abort = new AbortController();
+  const response = await fetch(url, { signal: abort.signal });
+  expect(response.status).toBe(200);
+  expect(response.headers.get('content-type')).toContain('text/event-stream');
+  if (!response.body) {
+    throw new Error('Expected SSE response body');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const events: VaultChangeEvent[] = [];
+  let raw = '';
+  let buffer = '';
+  let notify: (() => void) | undefined;
+
+  const pump = (async () => {
+    try {
+      while (true) {
+        const chunk = await reader.read();
+        if (chunk.done) return;
+        const text = decoder.decode(chunk.value, { stream: true });
+        raw += text;
+        buffer += text;
+        parseSseBuffer();
+        notify?.();
+      }
+    } catch (error) {
+      if (!abort.signal.aborted) throw error;
+    }
+  })();
+
+  function parseSseBuffer(): void {
+    let separator = buffer.indexOf('\n\n');
+    while (separator !== -1) {
+      const frame = buffer.slice(0, separator);
+      buffer = buffer.slice(separator + 2);
+      const data = frame
+        .split('\n')
+        .filter((line) => line.startsWith('data: '))
+        .map((line) => line.slice('data: '.length))
+        .join('\n');
+      if (data) {
+        events.push(JSON.parse(data) as VaultChangeEvent);
+      }
+      separator = buffer.indexOf('\n\n');
+    }
+  }
+
+  return {
+    waitForEvents: async (count) => {
+      const deadline = Date.now() + 3000;
+      while (events.length < count && Date.now() < deadline) {
+        await new Promise<void>((resolve) => {
+          notify = resolve;
+          setTimeout(resolve, 25);
+        });
+      }
+      if (events.length < count) {
+        throw new Error(`Timed out waiting for ${count} SSE events; got ${JSON.stringify(events)}`);
+      }
+      return events.slice(0, count);
+    },
+    raw: () => raw,
+    close: async () => {
+      abort.abort();
+      await reader.cancel().catch(() => undefined);
+      await pump.catch(() => undefined);
+    }
+  };
+}
+
+async function fetchJson(url: string, init: RequestInit): Promise<Record<string, unknown>> {
+  const response = await fetch(url, init);
+  expect(response.ok).toBe(true);
+  return await response.json() as Record<string, unknown>;
+}
+
+async function fetchText(url: string, init: RequestInit): Promise<Record<string, unknown>> {
+  return fetchJson(url, init);
+}
+
+function encodeVaultPath(vaultPath: string): string {
+  return vaultPath.split('/').map((part) => encodeURIComponent(part)).join('/');
+}
 
 function listen(server: ReturnType<typeof createServer>): Promise<void> {
   return new Promise((resolve, reject) => {

--- a/packages/doc-session/src/index.ts
+++ b/packages/doc-session/src/index.ts
@@ -13,6 +13,7 @@ export {
   DEFAULT_IDLE_SESSION_GRACE_MS,
   DocumentSessionManager,
   type ClientDocumentSession,
+  type FlushDocumentSessionsResult,
   type DocumentSessionManagerOptions
 } from './manager.js';
 export {

--- a/packages/doc-session/src/manager.ts
+++ b/packages/doc-session/src/manager.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 
-import { OneFileDocumentSession, type OneFileDocumentSessionOptions } from './session.js';
+import { OneFileDocumentSession, type DocumentSessionEventHandler, type OneFileDocumentSessionOptions } from './session.js';
 
 export const DEFAULT_IDLE_SESSION_GRACE_MS = 30_000;
 
@@ -14,6 +14,10 @@ export interface ClientDocumentSession {
   release: () => void;
 }
 
+export interface FlushDocumentSessionsResult {
+  flushed: number;
+}
+
 export class DocumentSessionManager {
   private readonly root: string;
   private readonly options: Omit<OneFileDocumentSessionOptions, 'eventPath'>;
@@ -21,12 +25,20 @@ export class DocumentSessionManager {
   private readonly sessions = new Map<string, OneFileDocumentSession>();
   private readonly clientCounts = new Map<string, number>();
   private readonly idleCloseTimers = new Map<string, NodeJS.Timeout>();
+  private readonly eventHandlers = new Set<DocumentSessionEventHandler>();
 
   constructor(options: DocumentSessionManagerOptions) {
     this.root = options.root;
     this.idleSessionGraceMs = options.idleSessionGraceMs ?? DEFAULT_IDLE_SESSION_GRACE_MS;
     const { root: _root, idleSessionGraceMs: _idleSessionGraceMs, ...sessionOptions } = options;
     this.options = sessionOptions;
+  }
+
+  onEvent(handler: DocumentSessionEventHandler): () => void {
+    this.eventHandlers.add(handler);
+    return () => {
+      this.eventHandlers.delete(handler);
+    };
   }
 
   getSession(vaultPath: string, overrides: Partial<Pick<OneFileDocumentSessionOptions, 'defaultContent'>> = {}): OneFileDocumentSession {
@@ -48,6 +60,7 @@ export class DocumentSessionManager {
           }
         }
       }
+      this.emitEvent(event);
     });
     return session;
   }
@@ -95,6 +108,16 @@ export class DocumentSessionManager {
 
   getOpenSessionCount(): number {
     return this.sessions.size;
+  }
+
+  async flushDirtySessions(): Promise<FlushDocumentSessionsResult> {
+    const dirtySessions = [...this.sessions.values()].filter((session) => session.hasUnsettledPersist());
+    const results = await Promise.allSettled(dirtySessions.map((session) => session.flush()));
+    const rejected = results.find((result) => result.status === 'rejected');
+    if (rejected) {
+      throw rejected.reason;
+    }
+    return { flushed: dirtySessions.length };
   }
 
   async moveSession(
@@ -177,6 +200,16 @@ export class DocumentSessionManager {
     await Promise.all([...this.sessions.values()].map((session) => session.close()));
     this.sessions.clear();
     this.clientCounts.clear();
+  }
+
+  private emitEvent(event: Parameters<DocumentSessionEventHandler>[0]): void {
+    for (const handler of this.eventHandlers) {
+      try {
+        handler(event);
+      } catch (error) {
+        console.warn('KB-2 document session manager event handler failed.', error);
+      }
+    }
   }
 
   private toFilePath(vaultPath: string): string {

--- a/packages/doc-session/src/protocol.test.ts
+++ b/packages/doc-session/src/protocol.test.ts
@@ -1,0 +1,48 @@
+import * as decoding from 'lib0/decoding';
+import * as encoding from 'lib0/encoding';
+
+import {
+  MESSAGE_SESSION_EVENT,
+  decodeSessionEvent,
+  encodeSessionEvent,
+  type DocumentSessionEvent,
+  type DocumentSessionEventKind
+} from './protocol.js';
+
+describe('document session protocol events', () => {
+  it.each([
+    'content-persisted',
+    'external-merge',
+    'external-change',
+    'persist-failure',
+    'persist-recovered',
+    'doc-moved',
+    'doc-deleted'
+  ] satisfies DocumentSessionEventKind[])('round-trips %s session events', (kind) => {
+    const event: DocumentSessionEvent = {
+      kind,
+      path: 'notes/demo.md',
+      ts: 123,
+      fromPath: 'notes/old.md',
+      toPath: 'notes/demo.md'
+    };
+
+    const decoder = decoding.createDecoder(encodeSessionEvent(event));
+
+    expect(decoding.readVarUint(decoder)).toBe(MESSAGE_SESSION_EVENT);
+    expect(decodeSessionEvent(decoder)).toEqual(event);
+  });
+
+  it.each([
+    { kind: 'unknown', path: 'notes/demo.md', ts: 123 },
+    { kind: 'content-persisted', path: 42, ts: 123 },
+    { kind: 'content-persisted', path: 'notes/demo.md', ts: 'now' },
+    { kind: 'content-persisted', path: 'notes/demo.md', ts: 123, fromPath: 42 },
+    { kind: 'content-persisted', path: 'notes/demo.md', ts: 123, toPath: 42 }
+  ])('rejects malformed session events %#', (payload) => {
+    const encoder = encoding.createEncoder();
+    encoding.writeVarString(encoder, JSON.stringify(payload));
+
+    expect(decodeSessionEvent(decoding.createDecoder(encoding.toUint8Array(encoder)))).toBeUndefined();
+  });
+});

--- a/packages/doc-session/src/protocol.ts
+++ b/packages/doc-session/src/protocol.ts
@@ -5,6 +5,7 @@ export const MESSAGE_SYNC = 0;
 export const MESSAGE_SESSION_EVENT = 1;
 
 export type DocumentSessionEventKind =
+  | 'content-persisted'
   | 'external-merge'
   | 'external-change'
   | 'persist-failure'
@@ -52,7 +53,8 @@ export function decodeSessionEvent(
 }
 
 function isSessionEventKind(kind: unknown): kind is DocumentSessionEventKind {
-  return kind === 'external-merge' ||
+  return kind === 'content-persisted' ||
+    kind === 'external-merge' ||
     kind === 'external-change' ||
     kind === 'persist-failure' ||
     kind === 'persist-recovered' ||

--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -107,6 +107,22 @@ describe('OneFileDocumentSession', () => {
     await session.close();
   });
 
+  it('flushes dirty manager sessions and re-emits content-persisted events', async () => {
+    const manager = new DocumentSessionManager({ root: join(kb2Home, 'demo-vault'), defaultContent: '' });
+    const events: DocumentSessionEvent[] = [];
+    manager.onEvent((event) => events.push(event));
+    const session = manager.getSession('notes/flush.md');
+    await session.open();
+
+    session.ydoc.getText('markdown').insert(0, 'manager flush\n');
+    await expect(manager.flushDirtySessions()).resolves.toEqual({ flushed: 1 });
+
+    await expect(readFile(join(kb2Home, 'demo-vault', 'notes', 'flush.md'), 'utf8')).resolves.toBe('manager flush\n');
+    expect(events).toContainEqual(expect.objectContaining({ kind: 'content-persisted', path: 'notes/flush.md' }));
+    await expect(manager.flushDirtySessions()).resolves.toEqual({ flushed: 0 });
+    await manager.close();
+  });
+
   it('issues baselines, rejects stale baseline edits with current content, and retries with the fresh baseline', async () => {
     const session = new OneFileDocumentSession(filePath, { defaultContent: 'one two three\n' });
     await session.open();
@@ -389,7 +405,7 @@ describe('OneFileDocumentSession', () => {
       return content.includes('external edit\n') && content.includes('client edit\n');
     }, () => `Timed out waiting for external and client edits to persist; content=${session.ydoc.getText('markdown').toString()}`);
 
-    expect(eventKinds(events)).toEqual(['external-merge']);
+    expect(eventKinds(events)).toEqual(['external-merge', 'content-persisted']);
     const finalContent = await readFile(filePath, 'utf8');
     expect(finalContent).toContain('external edit\n');
     expect(finalContent).toContain('client edit\n');

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -235,7 +235,7 @@ export class OneFileDocumentSession {
       await this.persistPromise;
     }
     if (this.persistFailureError) {
-      throw this.persistFailureError;
+      await this.requestPersist();
     }
   }
 

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { watch, type FSWatcher } from 'node:fs';
-import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { mkdir, open, readFile, rename, rm } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 
 import diff from 'fast-diff';
@@ -155,6 +155,10 @@ export class OneFileDocumentSession {
 
   hasActivePersistFailure(): boolean {
     return this.persistFailed;
+  }
+
+  hasUnsettledPersist(): boolean {
+    return this.persistRequested || this.persistPromise !== undefined || this.persistFailureError !== undefined;
   }
 
   async reset(content = this.defaultContent): Promise<string> {
@@ -403,6 +407,7 @@ export class OneFileDocumentSession {
       this.lastWrittenHash = contentHash;
       this.lastWrittenContent = content;
       this.markPersistRecovered();
+      this.emitEvent('content-persisted');
     } finally {
       if (this.pendingWriteHash === contentHash) {
         this.pendingWriteHash = undefined;
@@ -660,11 +665,27 @@ async function atomicWriteFile(filePath: string, content: string): Promise<void>
 
   const temporaryPath = join(directory, `.${process.pid}.${randomUUID()}.tmp`);
   try {
-    await writeFile(temporaryPath, content, 'utf8');
+    const file = await open(temporaryPath, 'w');
+    try {
+      await file.writeFile(content, 'utf8');
+      await file.sync();
+    } finally {
+      await file.close();
+    }
     await rename(temporaryPath, filePath);
+    await fsyncDirectory(directory);
   } catch (error) {
     await rm(temporaryPath, { force: true });
     throw error;
+  }
+}
+
+async function fsyncDirectory(directory: string): Promise<void> {
+  const handle = await open(directory, 'r');
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
   }
 }
 

--- a/packages/doc-session/vitest.config.ts
+++ b/packages/doc-session/vitest.config.ts
@@ -26,9 +26,12 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text'],
-      include: ['src/manager.ts', 'src/session.ts'],
+      include: ['src/manager.ts', 'src/protocol.ts', 'src/session.ts'],
       thresholds: {
         'src/manager.ts': {
+          lines: 95
+        },
+        'src/protocol.ts': {
           lines: 95
         },
         'src/session.ts': {

--- a/packages/vault-core/src/audit.ts
+++ b/packages/vault-core/src/audit.ts
@@ -29,6 +29,10 @@ export interface AuditEntry {
   summary: string;
 }
 
+export interface AuditChangeEventOptions {
+  skipContentPersisted?: boolean;
+}
+
 export interface AuditInput {
   root: string;
   actor?: VaultActor;
@@ -38,10 +42,34 @@ export interface AuditInput {
   fromPath?: string;
   toPath?: string;
   summary: string;
+  changeEvent?: AuditChangeEventOptions;
+}
+
+export type VaultAuditHandler = (audit: AuditEntry, input: AuditInput) => void;
+
+const vaultAuditHandlers = new Set<VaultAuditHandler>();
+
+export function onVaultAudit(handler: VaultAuditHandler): () => void {
+  vaultAuditHandlers.add(handler);
+  return () => {
+    vaultAuditHandlers.delete(handler);
+  };
 }
 
 export async function emitVaultAudit(input: AuditInput): Promise<AuditEntry> {
-  return writeAuditEntry(input);
+  const entry = await writeAuditEntry(input);
+  notifyVaultAuditHandlers(entry, input);
+  return entry;
+}
+
+function notifyVaultAuditHandlers(entry: AuditEntry, input: AuditInput): void {
+  for (const handler of vaultAuditHandlers) {
+    try {
+      handler(entry, input);
+    } catch (error) {
+      console.warn('KB-2 vault audit handler failed.', error);
+    }
+  }
 }
 
 async function writeAuditEntry(input: AuditInput): Promise<AuditEntry> {

--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -26,6 +26,7 @@ import {
   writeVaultFile,
   type VaultContext
 } from './vault-ops.js';
+import { onVaultAudit } from './audit.js';
 import { searchVaultFiles } from './search.js';
 import { validateVaultPath } from './path.js';
 import { anchoredSpliceContractCases } from './splice-contract-cases.test-support.js';
@@ -145,6 +146,34 @@ describe('vault-core filesystem operations', () => {
       operation: 'write',
       path: 'notes/a.md'
     });
+  });
+
+  it('notifies observers from the audit chokepoint without breaking the mutation', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const observed: Array<{ operation: string; root: string }> = [];
+    const unsubscribeThrowing = onVaultAudit(() => {
+      throw new Error('observer failed');
+    });
+    const unsubscribe = onVaultAudit((audit, input) => {
+      observed.push({ operation: audit.operation, root: input.root });
+    });
+
+    try {
+      await expect(writeVaultFile(ctx, { path: 'notes/a.md', content: 'first' }))
+        .resolves.toMatchObject({ ok: true });
+      expect(observed).toEqual([{ operation: 'create', root }]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('vault audit handler failed'), expect.any(Error));
+
+      unsubscribe();
+      unsubscribeThrowing();
+      await expect(writeVaultFile(ctx, { path: 'notes/b.md', content: 'second' }))
+        .resolves.toMatchObject({ ok: true });
+      expect(observed).toEqual([{ operation: 'create', root }]);
+    } finally {
+      unsubscribe();
+      unsubscribeThrowing();
+      warnSpy.mockRestore();
+    }
   });
 
   it('creates folders idempotently and lists trees excluding .kb2 trash/audit', async () => {

--- a/packages/vault-core/src/index.ts
+++ b/packages/vault-core/src/index.ts
@@ -1,4 +1,12 @@
-export { emitVaultAudit, type AuditEntry, type VaultActor } from './audit.js';
+export {
+  emitVaultAudit,
+  onVaultAudit,
+  type AuditChangeEventOptions,
+  type AuditEntry,
+  type AuditInput,
+  type VaultActor,
+  type VaultAuditHandler
+} from './audit.js';
 export {
   folderMetadataColorNames,
   folderMetadataIconNames,

--- a/packages/vault-service/src/index.test.ts
+++ b/packages/vault-service/src/index.test.ts
@@ -513,6 +513,46 @@ describe('vault service failure mapping', () => {
     });
   });
 
+  it('re-drives a failed flush after disk permissions recover', async () => {
+    await writeFileWithParents(join(root, 'notes', 'retry.md'), 'base\n');
+    const service = createVaultService({ vaultRoot: root, documentSessions: sessions });
+    const events: VaultChangeEvent[] = [];
+    service.onEvent((event) => events.push(event));
+
+    await service.readNote({ path: 'notes/retry.md' });
+    const session = sessions.getOpenSession('notes/retry.md');
+    if (!session) throw new Error('expected live session');
+    const notesDir = join(root, 'notes');
+
+    try {
+      await chmod(notesDir, 0o500);
+      session.ydoc.getText('markdown').insert(session.ydoc.getText('markdown').length, 'stuck edit\n');
+
+      await expect(service.flushDirtySessions()).resolves.toEqual({
+        ok: false,
+        error: 'persist_failed',
+        message: 'Document edit could not be durably saved to disk.'
+      });
+      await expect(readFile(join(root, 'notes', 'retry.md'), 'utf8')).resolves.toBe('base\n');
+
+      await chmod(notesDir, 0o700);
+      await expect(service.flushDirtySessions()).resolves.toMatchObject({
+        ok: true,
+        flushed: 1,
+        durableAsOf: expect.any(String)
+      });
+
+      await expect(readFile(join(root, 'notes', 'retry.md'), 'utf8')).resolves.toBe('base\nstuck edit\n');
+      expect(events).toContainEqual(expect.objectContaining({
+        kind: 'persist_recovered',
+        path: 'notes/retry.md',
+        actor: { kind: 'system' }
+      }));
+    } finally {
+      await chmod(notesDir, 0o700).catch(() => undefined);
+    }
+  });
+
   it('maps live move and folder subtree failures from vault operations', async () => {
     await writeFileWithParents(join(root, 'notes', 'live.md'), 'live\n');
     await writeFileWithParents(join(root, 'notes', 'target.md'), 'target\n');

--- a/packages/vault-service/src/index.test.ts
+++ b/packages/vault-service/src/index.test.ts
@@ -3,7 +3,7 @@ import { DocumentSessionManager } from '@kb-2/doc-session';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
-import { createVaultService, type ServiceResult } from './index.js';
+import { createVaultService, type ServiceResult, type VaultChangeEvent } from './index.js';
 
 describe('vault service failure mapping', () => {
   let root: string;
@@ -226,6 +226,124 @@ describe('vault service failure mapping', () => {
     ]);
   });
 
+  it('flushes dirty sessions and emits normalized change events without content bytes', async () => {
+    const service = createVaultService({ vaultRoot: root, documentSessions: sessions });
+    const events: VaultChangeEvent[] = [];
+    service.onEvent((event) => events.push(event));
+
+    await expect(service.createFolder({ path: 'notes', actor: { kind: 'user' } })).resolves.toMatchObject({
+      ok: true,
+      path: 'notes'
+    });
+    await expect(service.createNote({
+      path: 'notes/a.md',
+      content: 'initial\n',
+      actor: { kind: 'integration', client: 'test' }
+    })).resolves.toMatchObject({
+      ok: true,
+      path: 'notes/a.md'
+    });
+    await expect(service.createNote({
+      path: 'notes/a.md',
+      content: 'overwritten\n',
+      overwrite: true,
+      actor: { kind: 'user' }
+    })).resolves.toMatchObject({
+      ok: true,
+      path: 'notes/a.md'
+    });
+    await expect(service.setFolderMetadata({
+      path: 'notes',
+      metadata: { color: 'mint' },
+      actor: { kind: 'user' }
+    })).resolves.toMatchObject({
+      ok: true,
+      path: 'notes'
+    });
+
+    const session = sessions.getSession('notes/a.md');
+    await session.open();
+    session.ydoc.getText('markdown').insert(session.ydoc.getText('markdown').length, 'SECRET_SERVICE_EVENT');
+    await expect(service.flushDirtySessions()).resolves.toMatchObject({
+      ok: true,
+      flushed: 1,
+      durableAsOf: expect.any(String)
+    });
+    await expect(readFile(join(root, 'notes', 'a.md'), 'utf8')).resolves.toBe('overwritten\nSECRET_SERVICE_EVENT');
+
+    await expect(service.moveNote({
+      fromPath: 'notes/a.md',
+      toPath: 'notes/moved.md',
+      actor: { kind: 'user' }
+    })).resolves.toMatchObject({
+      ok: true,
+      fromPath: 'notes/a.md',
+      toPath: 'notes/moved.md'
+    });
+    await expect(service.deleteNote({
+      path: 'notes/moved.md',
+      actor: { kind: 'user' }
+    })).resolves.toMatchObject({
+      ok: true,
+      path: 'notes/moved.md'
+    });
+
+    expect(events.map((event) => event.kind)).toEqual([
+      'folder_created',
+      'file_created',
+      'content_persisted',
+      'folder_metadata_changed',
+      'content_persisted',
+      'file_moved',
+      'file_deleted'
+    ]);
+    expect(events[1]).toMatchObject({
+      path: 'notes/a.md',
+      actor: { kind: 'integration', client: 'test' }
+    });
+    expect(events[2]).toMatchObject({
+      path: 'notes/a.md',
+      actor: { kind: 'user' }
+    });
+    expect(events[4]).toMatchObject({
+      path: 'notes/a.md',
+      actor: { kind: 'system' }
+    });
+    expect(events[5]).toMatchObject({
+      path: 'notes/moved.md',
+      fromPath: 'notes/a.md',
+      toPath: 'notes/moved.md'
+    });
+    expect(JSON.stringify(events)).not.toContain('SECRET_SERVICE_EVENT');
+  });
+
+  it('emits external change events from the document-session spine', async () => {
+    sessions = new DocumentSessionManager({
+      root,
+      defaultContent: '',
+      watchDebounceMs: 10,
+      watchPollMs: 50
+    });
+    const service = createVaultService({ vaultRoot: root, documentSessions: sessions });
+    const events: VaultChangeEvent[] = [];
+    service.onEvent((event) => events.push(event));
+    await writeFileWithParents(join(root, 'notes', 'external.md'), 'base\n');
+    const session = sessions.getSession('notes/external.md');
+    await session.open();
+
+    await writeFile(join(root, 'notes', 'external.md'), 'external\n', 'utf8');
+
+    await waitUntil(() => events.some((event) => event.kind === 'external_change_detected'), () =>
+      `Timed out waiting for external change event; events=${JSON.stringify(events)}`
+    );
+    expect(events).toContainEqual(expect.objectContaining({
+      kind: 'external_change_detected',
+      path: 'notes/external.md',
+      actor: { kind: 'system' }
+    }));
+    await expect(session.getContent()).resolves.toBe('external\n');
+  });
+
   it('uses cold disk paths for file move and delete when no session is open', async () => {
     await writeFileWithParents(join(root, 'cold', 'move.md'), 'move\n');
     await writeFileWithParents(join(root, 'cold', 'delete.md'), 'delete\n');
@@ -286,6 +404,16 @@ describe('vault service failure mapping', () => {
       ok: false,
       error: 'ambiguous',
       match_count: 2
+    });
+    await expect(service.editNote({
+      path: 'notes/edit.md',
+      baseline,
+      oldText: 'missing',
+      newText: 'x',
+      actor: { kind: 'user' }
+    })).resolves.toMatchObject({
+      ok: false,
+      error: 'not_found'
     });
     await expect(service.editNote({
       path: 'notes/edit.md',
@@ -433,4 +561,16 @@ function requireBaseline(result: ServiceResult): string {
     throw new Error('Expected result to include a live document baseline');
   }
   return value.baseline;
+}
+
+async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  errorMessage: () => string,
+): Promise<void> {
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(errorMessage());
 }

--- a/packages/vault-service/src/index.ts
+++ b/packages/vault-service/src/index.ts
@@ -12,6 +12,7 @@ import {
   listVaultTree,
   makeVaultFolder,
   moveVaultPath,
+  onVaultAudit,
   prependContent,
   readVaultFile,
   searchVaultFiles,
@@ -19,6 +20,7 @@ import {
   validateVaultPath,
   writeVaultFile,
   type AnchoredSpliceRequest,
+  type AuditChangeEventOptions,
   type AuditEntry,
   type FolderMetadataInput,
   type VaultActor,
@@ -125,6 +127,19 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       }
     }
   };
+  let unsubscribeAudit: (() => void) | undefined;
+  const ensureAuditSubscription = () => {
+    if (unsubscribeAudit) return;
+    unsubscribeAudit = onVaultAudit((audit, input) => {
+      if (input.root !== options.vaultRoot) return;
+      emitAuditChange(emitChange, audit, input.changeEvent);
+    });
+  };
+  const releaseAuditSubscription = () => {
+    if (eventHandlers.size > 0) return;
+    unsubscribeAudit?.();
+    unsubscribeAudit = undefined;
+  };
   options.documentSessions.onEvent((event) => {
     const change = changeEventFromDocumentSessionEvent(event);
     if (change) emitChange(change);
@@ -133,8 +148,10 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
   return {
     onEvent(handler) {
       eventHandlers.add(handler);
+      ensureAuditSubscription();
       return () => {
         eventHandlers.delete(handler);
+        releaseAuditSubscription();
       };
     },
 
@@ -166,7 +183,6 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
 
     async setFolderMetadata(input) {
       const result = serviceResult(await setVaultFolderMetadata(ctx(input.actor), input.path, input.metadata));
-      if (result.ok && result.audit) emitAuditChange(emitChange, result.audit);
       return result;
     },
 
@@ -201,9 +217,9 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
           operation: 'write',
           entityKind: 'file',
           path: input.path,
-          summary: `Wrote ${input.path}`
+          summary: `Wrote ${input.path}`,
+          changeEvent: { skipContentPersisted: true }
         });
-        emitAuditChange(emitChange, audit, { skipContentPersisted: true });
         return {
           ok: true,
           path: input.path,
@@ -218,7 +234,6 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
         content: input.content,
         overwrite: input.overwrite
       }));
-      if (result.ok) emitAuditChange(emitChange, result.audit);
       return result;
     },
 
@@ -244,9 +259,9 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
         operation: 'splice',
         entityKind: 'file',
         path: input.path,
-        summary: `Spliced ${input.path}`
+        summary: `Spliced ${input.path}`,
+        changeEvent: { skipContentPersisted: true }
       });
-      emitAuditChange(emitChange, audit, { skipContentPersisted: true });
       return {
         ok: true,
         path: input.path,
@@ -271,9 +286,9 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
         operation: 'append',
         entityKind: 'file',
         path: input.path,
-        summary: `Appended to ${input.path}`
+        summary: `Appended to ${input.path}`,
+        changeEvent: { skipContentPersisted: true }
       });
-      emitAuditChange(emitChange, audit, { skipContentPersisted: true });
       return {
         ok: true,
         path: input.path,
@@ -296,9 +311,9 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
         operation: 'prepend',
         entityKind: 'file',
         path: input.path,
-        summary: `Prepended to ${input.path}`
+        summary: `Prepended to ${input.path}`,
+        changeEvent: { skipContentPersisted: true }
       });
-      emitAuditChange(emitChange, audit, { skipContentPersisted: true });
       return {
         ok: true,
         path: input.path,
@@ -319,14 +334,12 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       const deletedLive = await mapVaultFailure(() => options.documentSessions.deleteSession(input.path, deleteOnDisk));
       if (!deletedLive.ok) return deletedLive;
       if (deletedLive.value) {
-        emitAuditChange(emitChange, deleted!.audit);
         return { ok: true, ...deleted!, live: true };
       }
       const result = serviceResult(await deleteVaultFile(ctx(input.actor), {
         path: input.path,
         permanent: input.permanent
       }));
-      if (result.ok) emitAuditChange(emitChange, result.audit);
       return result;
     },
 
@@ -342,7 +355,6 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       const movedLive = await mapVaultFailure(() => options.documentSessions.moveSession(input.fromPath, input.toPath, moveOnDisk));
       if (!movedLive.ok) return movedLive;
       if (movedLive.value) {
-        emitAuditChange(emitChange, moved!.audit);
         return { ok: true, ...moved!, live: true };
       }
       const result = serviceResult(await moveVaultPath(ctx(input.actor), {
@@ -350,13 +362,11 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
         fromPath: input.fromPath,
         toPath: input.toPath
       }));
-      if (result.ok) emitAuditChange(emitChange, result.audit);
       return result;
     },
 
     async createFolder(input) {
       const result = serviceResult(await makeVaultFolder(ctx(input.actor), input.path));
-      if (result.ok && result.audit) emitAuditChange(emitChange, result.audit);
       return result;
     },
 
@@ -371,7 +381,6 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       };
       const deletedLive = await mapVaultFailure(() => options.documentSessions.deleteSessionSubtree(input.path, deleteOnDisk));
       if (!deletedLive.ok) return deletedLive;
-      emitAuditChange(emitChange, deleted!.audit);
       return { ok: true, ...deleted!, liveDeleted: deletedLive.value };
     },
 
@@ -386,7 +395,6 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       };
       const movedLive = await mapVaultFailure(() => options.documentSessions.moveSessionSubtree(input.fromPath, input.toPath, moveOnDisk));
       if (!movedLive.ok) return movedLive;
-      emitAuditChange(emitChange, moved!.audit);
       return { ok: true, ...moved!, liveMoved: movedLive.value };
     },
 
@@ -454,7 +462,7 @@ function changeEventFromDocumentSessionEvent(event: DocumentSessionEvent): Vault
 function emitAuditChange(
   emit: VaultChangeEventHandler,
   audit: AuditEntry,
-  options: { skipContentPersisted?: boolean } = {}
+  options: AuditChangeEventOptions = {}
 ): void {
   const kind = auditChangeEventKind(audit, options);
   if (!kind) return;
@@ -471,7 +479,7 @@ function emitAuditChange(
 
 function auditChangeEventKind(
   audit: AuditEntry,
-  options: { skipContentPersisted?: boolean }
+  options: AuditChangeEventOptions
 ): VaultChangeEventKind | undefined {
   switch (audit.operation) {
     case 'create':

--- a/packages/vault-service/src/index.ts
+++ b/packages/vault-service/src/index.ts
@@ -1,4 +1,4 @@
-import { PersistFailedError, type DocumentSessionManager, type SessionSpliceReject } from '@kb-2/doc-session';
+import { PersistFailedError, type DocumentSessionEvent, type DocumentSessionManager, type SessionSpliceReject } from '@kb-2/doc-session';
 import {
   InvalidPathError,
   appendContent,
@@ -50,6 +50,30 @@ export type ServiceFailure =
 
 export type ServiceResult<T extends object = object> = ({ ok: true } & T) | ServiceFailure;
 
+export type VaultChangeEventKind =
+  | 'content_persisted'
+  | 'file_created'
+  | 'folder_created'
+  | 'file_deleted'
+  | 'folder_deleted'
+  | 'file_moved'
+  | 'folder_moved'
+  | 'folder_metadata_changed'
+  | 'external_change_detected'
+  | 'persist_failure'
+  | 'persist_recovered';
+
+export interface VaultChangeEvent {
+  kind: VaultChangeEventKind;
+  path: string;
+  actor: VaultActor;
+  ts: string;
+  fromPath?: string;
+  toPath?: string;
+}
+
+export type VaultChangeEventHandler = (event: VaultChangeEvent) => void;
+
 export interface EditNoteInput {
   path: string;
   baseline: string;
@@ -79,15 +103,51 @@ export interface LocalMcpVaultService {
   search(input: { query: string; under?: string; context?: number; limit?: number; offset?: number }): Promise<ServiceResult>;
 }
 
+export interface VaultService extends LocalMcpVaultService {
+  flushDirtySessions(): Promise<ServiceResult<{ flushed: number; durableAsOf: string }>>;
+  onEvent(handler: VaultChangeEventHandler): () => void;
+}
+
 export interface VaultServiceOptions {
   vaultRoot: string;
   documentSessions: DocumentSessionManager;
 }
 
-export function createVaultService(options: VaultServiceOptions): LocalMcpVaultService {
+export function createVaultService(options: VaultServiceOptions): VaultService {
   const ctx = (actor?: VaultActor) => ({ root: options.vaultRoot, ...(actor ? { actor } : {}) });
+  const eventHandlers = new Set<VaultChangeEventHandler>();
+  const emitChange = (event: VaultChangeEvent) => {
+    for (const handler of eventHandlers) {
+      try {
+        handler(event);
+      } catch (error) {
+        console.warn('KB-2 vault change event handler failed.', error);
+      }
+    }
+  };
+  options.documentSessions.onEvent((event) => {
+    const change = changeEventFromDocumentSessionEvent(event);
+    if (change) emitChange(change);
+  });
 
   return {
+    onEvent(handler) {
+      eventHandlers.add(handler);
+      return () => {
+        eventHandlers.delete(handler);
+      };
+    },
+
+    async flushDirtySessions() {
+      const result = await mapWriteFailure(() => options.documentSessions.flushDirtySessions());
+      if (!result.ok) return result;
+      return {
+        ok: true,
+        flushed: result.value.flushed,
+        durableAsOf: new Date().toISOString()
+      };
+    },
+
     async vaultInfo() {
       return serviceResult(await getVaultInfo(ctx()));
     },
@@ -105,7 +165,9 @@ export function createVaultService(options: VaultServiceOptions): LocalMcpVaultS
     },
 
     async setFolderMetadata(input) {
-      return serviceResult(await setVaultFolderMetadata(ctx(input.actor), input.path, input.metadata));
+      const result = serviceResult(await setVaultFolderMetadata(ctx(input.actor), input.path, input.metadata));
+      if (result.ok && result.audit) emitAuditChange(emitChange, result.audit);
+      return result;
     },
 
     async readNote(input) {
@@ -141,6 +203,7 @@ export function createVaultService(options: VaultServiceOptions): LocalMcpVaultS
           path: input.path,
           summary: `Wrote ${input.path}`
         });
+        emitAuditChange(emitChange, audit, { skipContentPersisted: true });
         return {
           ok: true,
           path: input.path,
@@ -150,11 +213,13 @@ export function createVaultService(options: VaultServiceOptions): LocalMcpVaultS
         };
       }
 
-      return serviceResult(await writeVaultFile(ctx(input.actor), {
+      const result = serviceResult(await writeVaultFile(ctx(input.actor), {
         path: input.path,
         content: input.content,
         overwrite: input.overwrite
       }));
+      if (result.ok) emitAuditChange(emitChange, result.audit);
+      return result;
     },
 
     async editNote(input) {
@@ -181,6 +246,7 @@ export function createVaultService(options: VaultServiceOptions): LocalMcpVaultS
         path: input.path,
         summary: `Spliced ${input.path}`
       });
+      emitAuditChange(emitChange, audit, { skipContentPersisted: true });
       return {
         ok: true,
         path: input.path,
@@ -207,6 +273,7 @@ export function createVaultService(options: VaultServiceOptions): LocalMcpVaultS
         path: input.path,
         summary: `Appended to ${input.path}`
       });
+      emitAuditChange(emitChange, audit, { skipContentPersisted: true });
       return {
         ok: true,
         path: input.path,
@@ -231,6 +298,7 @@ export function createVaultService(options: VaultServiceOptions): LocalMcpVaultS
         path: input.path,
         summary: `Prepended to ${input.path}`
       });
+      emitAuditChange(emitChange, audit, { skipContentPersisted: true });
       return {
         ok: true,
         path: input.path,
@@ -251,12 +319,15 @@ export function createVaultService(options: VaultServiceOptions): LocalMcpVaultS
       const deletedLive = await mapVaultFailure(() => options.documentSessions.deleteSession(input.path, deleteOnDisk));
       if (!deletedLive.ok) return deletedLive;
       if (deletedLive.value) {
+        emitAuditChange(emitChange, deleted!.audit);
         return { ok: true, ...deleted!, live: true };
       }
-      return serviceResult(await deleteVaultFile(ctx(input.actor), {
+      const result = serviceResult(await deleteVaultFile(ctx(input.actor), {
         path: input.path,
         permanent: input.permanent
       }));
+      if (result.ok) emitAuditChange(emitChange, result.audit);
+      return result;
     },
 
     async moveNote(input) {
@@ -271,17 +342,22 @@ export function createVaultService(options: VaultServiceOptions): LocalMcpVaultS
       const movedLive = await mapVaultFailure(() => options.documentSessions.moveSession(input.fromPath, input.toPath, moveOnDisk));
       if (!movedLive.ok) return movedLive;
       if (movedLive.value) {
+        emitAuditChange(emitChange, moved!.audit);
         return { ok: true, ...moved!, live: true };
       }
-      return serviceResult(await moveVaultPath(ctx(input.actor), {
+      const result = serviceResult(await moveVaultPath(ctx(input.actor), {
         kind: 'file',
         fromPath: input.fromPath,
         toPath: input.toPath
       }));
+      if (result.ok) emitAuditChange(emitChange, result.audit);
+      return result;
     },
 
     async createFolder(input) {
-      return serviceResult(await makeVaultFolder(ctx(input.actor), input.path));
+      const result = serviceResult(await makeVaultFolder(ctx(input.actor), input.path));
+      if (result.ok && result.audit) emitAuditChange(emitChange, result.audit);
+      return result;
     },
 
     async deleteFolder(input) {
@@ -295,6 +371,7 @@ export function createVaultService(options: VaultServiceOptions): LocalMcpVaultS
       };
       const deletedLive = await mapVaultFailure(() => options.documentSessions.deleteSessionSubtree(input.path, deleteOnDisk));
       if (!deletedLive.ok) return deletedLive;
+      emitAuditChange(emitChange, deleted!.audit);
       return { ok: true, ...deleted!, liveDeleted: deletedLive.value };
     },
 
@@ -309,6 +386,7 @@ export function createVaultService(options: VaultServiceOptions): LocalMcpVaultS
       };
       const movedLive = await mapVaultFailure(() => options.documentSessions.moveSessionSubtree(input.fromPath, input.toPath, moveOnDisk));
       if (!movedLive.ok) return movedLive;
+      emitAuditChange(emitChange, moved!.audit);
       return { ok: true, ...moved!, liveMoved: movedLive.value };
     },
 
@@ -345,6 +423,80 @@ function serviceResult<T extends object>(result: VaultResult<T>): ServiceResult<
 
 function failure(error: SimpleServiceErrorCode, message: string): ServiceFailure {
   return { ok: false, error, message };
+}
+
+function changeEventFromDocumentSessionEvent(event: DocumentSessionEvent): VaultChangeEvent | undefined {
+  const actor: VaultActor = { kind: 'system' };
+  const base = {
+    path: event.path,
+    actor,
+    ts: new Date(event.ts).toISOString()
+  };
+
+  switch (event.kind) {
+    case 'content-persisted':
+      return { ...base, kind: 'content_persisted' };
+    case 'external-merge':
+    case 'external-change':
+      return { ...base, kind: 'external_change_detected' };
+    case 'persist-failure':
+      return { ...base, kind: 'persist_failure' };
+    case 'persist-recovered':
+      return { ...base, kind: 'persist_recovered' };
+    case 'doc-moved':
+    case 'doc-deleted':
+      return undefined;
+  }
+  /* v8 ignore next -- Exhaustive switch guard for future document-session event codes. */
+  return assertNever(event.kind);
+}
+
+function emitAuditChange(
+  emit: VaultChangeEventHandler,
+  audit: AuditEntry,
+  options: { skipContentPersisted?: boolean } = {}
+): void {
+  const kind = auditChangeEventKind(audit, options);
+  if (!kind) return;
+
+  emit({
+    kind,
+    path: audit.toPath ?? audit.path,
+    actor: audit.actor,
+    ts: audit.ts,
+    ...(audit.fromPath !== undefined ? { fromPath: audit.fromPath } : {}),
+    ...(audit.toPath !== undefined ? { toPath: audit.toPath } : {})
+  });
+}
+
+function auditChangeEventKind(
+  audit: AuditEntry,
+  options: { skipContentPersisted?: boolean }
+): VaultChangeEventKind | undefined {
+  switch (audit.operation) {
+    case 'create':
+      return audit.entityKind === 'file' ? 'file_created' : 'folder_created';
+    case 'mkdir':
+      return 'folder_created';
+    case 'write':
+      if (audit.entityKind === 'folder') return 'folder_metadata_changed';
+      return options.skipContentPersisted === true ? undefined : 'content_persisted';
+    case 'splice':
+    case 'append':
+    case 'prepend':
+      return options.skipContentPersisted === true ? undefined : 'content_persisted';
+    case 'delete':
+      return audit.entityKind === 'file' ? 'file_deleted' : 'folder_deleted';
+    case 'move':
+      return audit.entityKind === 'file' ? 'file_moved' : 'folder_moved';
+  }
+  /* v8 ignore next -- Exhaustive switch guard for future audit operation codes. */
+  return assertNever(audit.operation);
+}
+
+/* v8 ignore next -- Called only by exhaustive guards when a future union member is missing above. */
+function assertNever(value: never): never {
+  throw new Error(`Unhandled event code: ${String(value)}`);
 }
 
 function validateServiceFilePath(filePath: string): ServiceResult<{ path: string }> {


### PR DESCRIPTION
## Summary
- Add POST /api/ops/flush as a durability barrier over existing doc-session materialization.
- Add GET /api/events as an SSE subscriber over normalized doc-session events and audit-backed vault change events.
- Document flush/events as local-first backup/tooling primitives in README.

## Verification
- pnpm --filter @kb-2/doc-session test
- pnpm --filter @kb-2/vault-service test
- pnpm --filter @kb-2/daemon test
- pnpm typecheck
- pnpm check
- Manual kill-after-flush drill on temp KB2_HOME and allowed port: flush returned, daemon killed with SIGKILL, file content remained on disk.
- Independent Engineer audit found no acceptance-criteria or invariant violations.

## Notes
- Event payloads include kind, vault-relative paths, actor attribution, and timestamps; tests assert raw SSE payloads do not carry content bytes.
- No UI consumption, MCP tools, webhooks, replay, filtering, or debounce changes included.