### PR TITLE
Chunk 011C: No Create-On-Visit, Not-Found State, History Navigation

### DIFF
--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -3,7 +3,9 @@ import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AddressInfo } from 'node:net';
+import { WebSocket } from 'ws';
 
+import { DOCUMENT_SESSION_FAILURE_CLOSE_CODE } from '@kb-2/doc-session';
 import { startDaemon } from './main.js';
 
 describe('daemon startup', () => {
@@ -59,6 +61,31 @@ describe('daemon startup', () => {
     expect(typeof body.content).toBe('string');
     expect(body.content).toContain('Hello KB-2');
     await expect(readFile(join(started.config.vaultRoot, 'hello-world.md'), 'utf8')).resolves.toBe(body.content);
+
+    await started.close();
+  });
+
+  it('rejects missing document WebSocket opens without creating typo folders', async () => {
+    const port = await reservePort();
+    process.env = {
+      ...originalEnv,
+      KB2_HOME: kb2Home,
+      KB2_HOST: '127.0.0.1',
+      KB2_PORT: String(port)
+    };
+
+    const started = await startDaemon();
+    const socket = new WebSocket(`ws://127.0.0.1:${port}/api/files/typo/missing.md/yjs`);
+    const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+      socket.once('close', (code, reason) => resolve({ code, reason: reason.toString() }));
+    });
+
+    await expect(closed).resolves.toEqual({
+      code: DOCUMENT_SESSION_FAILURE_CLOSE_CODE,
+      reason: JSON.stringify({ ok: false, error: 'not_found', message: 'file not found' })
+    });
+    await expect(access(join(started.config.vaultRoot, 'typo'))).rejects.toBeTruthy();
+    await expect(readFile(join(started.config.vaultRoot, 'hello-world.md'), 'utf8')).resolves.toContain('Hello KB-2');
 
     await started.close();
   });

--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -65,6 +65,45 @@ describe('daemon startup', () => {
     await started.close();
   });
 
+  it('seeds the demo document only for a first boot of an empty vault', async () => {
+    const port = await reservePort();
+    process.env = {
+      ...originalEnv,
+      KB2_HOME: kb2Home,
+      KB2_HOST: '127.0.0.1',
+      KB2_PORT: String(port)
+    };
+
+    const firstBoot = await startDaemon();
+    await expect(readFile(join(firstBoot.config.vaultRoot, 'hello-world.md'), 'utf8')).resolves.toContain('Hello KB-2');
+
+    const deleted = await fetch(`http://127.0.0.1:${port}/api/files/hello-world.md`, { method: 'DELETE' });
+    expect(deleted.status).toBe(200);
+    await expect(access(join(firstBoot.config.vaultRoot, 'hello-world.md'))).rejects.toBeTruthy();
+    await firstBoot.close();
+
+    const restartedAfterDelete = await startDaemon();
+    await expect(access(join(restartedAfterDelete.config.vaultRoot, 'hello-world.md'))).rejects.toBeTruthy();
+    await restartedAfterDelete.close();
+
+    const populatedHome = await mkdtemp(join(tmpdir(), 'kb2-populated-startup-'));
+    process.env = {
+      ...originalEnv,
+      KB2_HOME: populatedHome,
+      KB2_HOST: '127.0.0.1',
+      KB2_PORT: String(port)
+    };
+    const populatedVault = join(populatedHome, 'demo-vault');
+    await mkdir(join(populatedVault, 'notes'), { recursive: true });
+    await writeFile(join(populatedVault, 'notes', 'preexisting.md'), 'already here\n', 'utf8');
+
+    const populatedBoot = await startDaemon();
+    await expect(access(join(populatedBoot.config.vaultRoot, 'hello-world.md'))).rejects.toBeTruthy();
+    await expect(readFile(join(populatedBoot.config.vaultRoot, 'notes', 'preexisting.md'), 'utf8')).resolves.toBe('already here\n');
+    await populatedBoot.close();
+    await rm(populatedHome, { force: true, recursive: true });
+  });
+
   it('rejects missing document WebSocket opens without creating typo folders', async () => {
     const port = await reservePort();
     process.env = {
@@ -86,6 +125,38 @@ describe('daemon startup', () => {
     });
     await expect(access(join(started.config.vaultRoot, 'typo'))).rejects.toBeTruthy();
     await expect(readFile(join(started.config.vaultRoot, 'hello-world.md'), 'utf8')).resolves.toContain('Hello KB-2');
+
+    await started.close();
+  });
+
+  it('allows an immediate create after a missing document WebSocket bind fails', async () => {
+    const port = await reservePort();
+    process.env = {
+      ...originalEnv,
+      KB2_HOME: kb2Home,
+      KB2_HOST: '127.0.0.1',
+      KB2_PORT: String(port)
+    };
+
+    const started = await startDaemon();
+    const socket = new WebSocket(`ws://127.0.0.1:${port}/api/files/typo/missing.md/yjs`);
+    const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+      socket.once('close', (code, reason) => resolve({ code, reason: reason.toString() }));
+    });
+
+    await expect(closed).resolves.toEqual({
+      code: DOCUMENT_SESSION_FAILURE_CLOSE_CODE,
+      reason: JSON.stringify({ ok: false, error: 'not_found', message: 'file not found' })
+    });
+
+    const created = await fetch(`http://127.0.0.1:${port}/api/files/typo/missing.md`, {
+      method: 'PUT',
+      headers: { 'content-type': 'text/plain' },
+      body: 'created immediately\n'
+    });
+    expect(created.status).toBe(201);
+    await expect(created.json()).resolves.toMatchObject({ ok: true, path: 'typo/missing.md' });
+    await expect(readFile(join(started.config.vaultRoot, 'typo', 'missing.md'), 'utf8')).resolves.toBe('created immediately\n');
 
     await started.close();
   });

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -2,7 +2,7 @@
 import { serve } from '@hono/node-server';
 import { DocumentSessionManager, bindYjsWebSocket } from '@kb-2/doc-session';
 import { createLocalMcpEndpoint } from '@kb-2/local-mcp';
-import { validateVaultPath } from '@kb-2/vault-core';
+import { readVaultFile, validateVaultPath, writeVaultFile } from '@kb-2/vault-core';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { WebSocketServer } from 'ws';
 
@@ -29,7 +29,8 @@ export interface StartedDaemon {
 export async function startDaemon(): Promise<StartedDaemon> {
   const config = createDaemonConfig();
   const documentSessions = new DocumentSessionManager({ root: config.vaultRoot });
-  const demoDocumentSession = documentSessions.getSession(DEMO_DOCUMENT_PATH, { defaultContent: DEFAULT_DEMO_DOCUMENT_CONTENT });
+  await seedDemoDocument(config.vaultRoot);
+  const demoDocumentSession = documentSessions.getSession(DEMO_DOCUMENT_PATH);
   await demoDocumentSession.open();
   const vaultService = createVaultService({
     vaultRoot: config.vaultRoot,
@@ -123,6 +124,22 @@ export async function startDaemon(): Promise<StartedDaemon> {
 
     server.once('error', fail);
   });
+}
+
+async function seedDemoDocument(vaultRoot: string): Promise<void> {
+  const existing = await readVaultFile({ root: vaultRoot }, DEMO_DOCUMENT_PATH);
+  if (existing.ok) return;
+  if (existing.error !== 'not_found') {
+    throw new Error(existing.message);
+  }
+
+  const seeded = await writeVaultFile(
+    { root: vaultRoot, actor: { kind: 'system' } },
+    { path: DEMO_DOCUMENT_PATH, content: DEFAULT_DEMO_DOCUMENT_CONTENT }
+  );
+  if (!seeded.ok) {
+    throw new Error(seeded.message);
+  }
 }
 
 function documentPathFromWebSocketPath(pathname: string): string | undefined {

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -2,6 +2,8 @@
 import { serve } from '@hono/node-server';
 import { DocumentSessionManager, bindYjsWebSocket } from '@kb-2/doc-session';
 import { createLocalMcpEndpoint } from '@kb-2/local-mcp';
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
 import { readVaultFile, validateVaultPath, writeVaultFile } from '@kb-2/vault-core';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { WebSocketServer } from 'ws';
@@ -29,9 +31,9 @@ export interface StartedDaemon {
 export async function startDaemon(): Promise<StartedDaemon> {
   const config = createDaemonConfig();
   const documentSessions = new DocumentSessionManager({ root: config.vaultRoot });
-  await seedDemoDocument(config.vaultRoot);
-  const demoDocumentSession = documentSessions.getSession(DEMO_DOCUMENT_PATH);
-  await demoDocumentSession.open();
+  const hasDemoDocument = await seedDemoDocument(config.vaultRoot);
+  const demoDocumentSession = hasDemoDocument ? documentSessions.getSession(DEMO_DOCUMENT_PATH) : undefined;
+  await demoDocumentSession?.open();
   const vaultService = createVaultService({
     vaultRoot: config.vaultRoot,
     documentSessions
@@ -126,11 +128,15 @@ export async function startDaemon(): Promise<StartedDaemon> {
   });
 }
 
-async function seedDemoDocument(vaultRoot: string): Promise<void> {
+async function seedDemoDocument(vaultRoot: string): Promise<boolean> {
   const existing = await readVaultFile({ root: vaultRoot }, DEMO_DOCUMENT_PATH);
-  if (existing.ok) return;
+  if (existing.ok) return true;
   if (existing.error !== 'not_found') {
     throw new Error(existing.message);
+  }
+
+  if (await hasMarkdownFiles(vaultRoot) || await hasKb2State(vaultRoot)) {
+    return false;
   }
 
   const seeded = await writeVaultFile(
@@ -140,6 +146,49 @@ async function seedDemoDocument(vaultRoot: string): Promise<void> {
   if (!seeded.ok) {
     throw new Error(seeded.message);
   }
+  return true;
+}
+
+async function hasKb2State(vaultRoot: string): Promise<boolean> {
+  try {
+    await readdir(join(vaultRoot, '.kb2'), { withFileTypes: true });
+    return true;
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function hasMarkdownFiles(directory: string): Promise<boolean> {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) {
+      return false;
+    }
+    throw error;
+  }
+
+  for (const entry of entries) {
+    if (entry.name === '.kb2') {
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.md')) {
+      return true;
+    }
+    if (entry.isDirectory() && await hasMarkdownFiles(join(directory, entry.name))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isNodeErrorCode(error: unknown, code: string): boolean {
+  return error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === code;
 }
 
 function documentPathFromWebSocketPath(pathname: string): string | undefined {

--- a/apps/web/src/lib/yjs/demo-document-provider.test.ts
+++ b/apps/web/src/lib/yjs/demo-document-provider.test.ts
@@ -9,7 +9,7 @@ import * as encoding from 'lib0/encoding';
 import { WebSocket, WebSocketServer } from 'ws';
 import * as syncProtocol from 'y-protocols/sync';
 import * as Y from 'yjs';
-import { afterEach, beforeEach, describe, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   bindYjsWebSocket,
@@ -21,6 +21,7 @@ import {
   createDemoDocumentProvider,
   DEMO_DOCUMENT_TEXT_NAME,
   DEMO_DOCUMENT_YJS_PATH,
+  isDemoDocumentProviderOpenError,
 } from './demo-document-provider';
 
 const messageSync = 0;
@@ -138,6 +139,38 @@ describe('demo document provider', () => {
     await waitUntil(() => events.some((event) => event.kind === 'external-merge'), () =>
       `Timed out waiting for provider session event: ${JSON.stringify(events)}`
     );
+
+    provider.destroy();
+  });
+
+  it('surfaces canonical not_found session-open failures from the WebSocket close reason', async () => {
+    const errors: unknown[] = [];
+
+    server = createServer();
+    webSocketServer = new WebSocketServer({ noServer: true });
+    server.on('upgrade', (request, socket, head) => {
+      if (request.url !== DEMO_DOCUMENT_YJS_PATH) {
+        socket.destroy();
+        return;
+      }
+
+      webSocketServer!.handleUpgrade(request, socket, head, (webSocket) => {
+        webSocket.close(1008, JSON.stringify({ ok: false, error: 'not_found', message: 'file not found' }));
+      });
+    });
+    await listen(server);
+    const port = (server.address() as AddressInfo).port;
+
+    const provider = createDemoDocumentProvider({
+      url: `ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`,
+      onError: (error) => errors.push(error),
+    });
+
+    await waitUntil(() => errors.some(isDemoDocumentProviderOpenError), () =>
+      `Timed out waiting for provider open failure: ${String(errors[0])}`
+    );
+    const failure = errors.find(isDemoDocumentProviderOpenError)?.failure;
+    expect(failure).toEqual({ ok: false, error: 'not_found', message: 'file not found' });
 
     provider.destroy();
   });

--- a/apps/web/src/lib/yjs/demo-document-provider.ts
+++ b/apps/web/src/lib/yjs/demo-document-provider.ts
@@ -26,6 +26,19 @@ export interface DemoDocumentProvider {
   destroy: () => void;
 }
 
+export interface DemoDocumentProviderOpenFailure {
+  ok: false;
+  error: 'not_found';
+  message: string;
+}
+
+export class DemoDocumentProviderOpenError extends Error {
+  constructor(readonly failure: DemoDocumentProviderOpenFailure) {
+    super(failure.message);
+    this.name = 'DemoDocumentProviderOpenError';
+  }
+}
+
 export interface DemoDocumentProviderOptions {
   url?: string;
   path?: string;
@@ -110,8 +123,13 @@ export function createDemoDocumentProvider(
     options.onError?.(event);
   });
 
-  socket.addEventListener('close', () => {
+  socket.addEventListener('close', (event) => {
     options.onStatus?.('closed');
+    if (destroyed) return;
+    const failure = parseOpenFailure(event.reason);
+    if (failure) {
+      options.onError?.(new DemoDocumentProviderOpenError(failure));
+    }
   });
 
   return {
@@ -125,6 +143,10 @@ export function createDemoDocumentProvider(
       options.onStatus?.('closed');
     },
   };
+}
+
+export function isDemoDocumentProviderOpenError(error: unknown): error is DemoDocumentProviderOpenError {
+  return error instanceof DemoDocumentProviderOpenError;
 }
 
 function yjsWebSocketUrl(documentPath = 'hello-world.md'): string {
@@ -141,5 +163,26 @@ function toUint8Array(data: unknown): Uint8Array | undefined {
   if (data instanceof ArrayBuffer) return new Uint8Array(data);
   if (data instanceof Uint8Array) return data;
   if (data instanceof Blob) return undefined;
+  return undefined;
+}
+
+function parseOpenFailure(reason: string): DemoDocumentProviderOpenFailure | undefined {
+  if (!reason) return undefined;
+  try {
+    const parsed = JSON.parse(reason) as Partial<DemoDocumentProviderOpenFailure>;
+    if (
+      parsed.ok === false &&
+      parsed.error === 'not_found' &&
+      typeof parsed.message === 'string'
+    ) {
+      return {
+        ok: false,
+        error: 'not_found',
+        message: parsed.message
+      };
+    }
+  } catch {
+    return undefined;
+  }
   return undefined;
 }

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
-  import { createDemoDocumentProvider, encodeVaultPath } from '$lib/yjs/demo-document-provider';
+  import { afterNavigate, goto } from '$app/navigation';
+  import {
+    createDemoDocumentProvider,
+    encodeVaultPath,
+    isDemoDocumentProviderOpenError,
+  } from '$lib/yjs/demo-document-provider';
   import type {
     DemoDocumentProvider,
     DemoDocumentProviderStatus,
   } from '$lib/yjs/demo-document-provider';
   import { PlaintextEditor, type LivePath, type OrgPerson } from '@kb-2/editor';
   import {
+    DocumentNotFoundState,
     DocumentSaveBanner,
     LocalEditorShell,
     type AccentName,
@@ -49,6 +54,7 @@
   let persistFailureActive = $state(false);
   let persistRecoveredVisible = $state(false);
   let docDeleted = $state(false);
+  let notFoundPath = $state<string | null>(null);
   let documentPath = $state('hello-world.md');
   let vaultName = $state('Vault');
   let tree = $state<LocalTreeNode[]>([]);
@@ -151,6 +157,7 @@
     providerSynced = false;
     status = 'connecting';
     error = null;
+    notFoundPath = null;
     docDeleted = false;
     const nextProvider = createDemoDocumentProvider({
       path,
@@ -160,6 +167,12 @@
       },
       onError: (caught) => {
         if (generation !== providerGeneration) return;
+        if (isDemoDocumentProviderOpenError(caught)) {
+          notFoundPath = path;
+          providerSynced = false;
+          error = null;
+          return;
+        }
         error = caught instanceof Error ? caught.message : String(caught);
       },
       onSessionEvent: (event) => {
@@ -175,14 +188,20 @@
   }
 
   async function openDocument(path: string): Promise<void> {
-    if (path === documentPath) return;
+    if (path === documentPath && notFoundPath !== path) return;
+    rebindDocument(path, { resetSearch: true });
+    await goto(`/${encodeVaultPath(path)}`, { noScroll: true, keepFocus: true });
+  }
+
+  function rebindDocument(path: string, options: { resetSearch?: boolean } = {}): void {
     documentPath = path;
     openProvider(path);
-    searchValue = '';
-    searchResults = [];
-    searchTotal = 0;
-    searchTruncated = false;
-    await goto(`/${encodeVaultPath(path)}`, { noScroll: true, keepFocus: true });
+    if (options.resetSearch === true) {
+      searchValue = '';
+      searchResults = [];
+      searchTotal = 0;
+      searchTruncated = false;
+    }
   }
 
   function toggleFolder(path: string): void {
@@ -420,14 +439,28 @@
     return value.slice(0, 1).toUpperCase() + value.slice(1);
   }
 
+  function documentPathFromUrl(url: URL): string {
+    if (url.pathname === '/') {
+      return 'hello-world.md';
+    }
+    return decodeURIComponent(url.pathname.replace(/^\/+/, ''));
+  }
+
+  afterNavigate((navigation) => {
+    if (!mounted || !navigation.to?.url) return;
+    const nextPath = documentPathFromUrl(navigation.to.url);
+    if (nextPath === documentPath) return;
+    rebindDocument(nextPath, { resetSearch: true });
+  });
+
   onMount(() => {
     mounted = true;
-    const pathname = window.location.pathname;
-    if (pathname === '/') {
+    const initialPath = documentPathFromUrl(new URL(window.location.href));
+    if (window.location.pathname === '/') {
       documentPath = 'hello-world.md';
       void goto('/hello-world.md', { replaceState: true, noScroll: true, keepFocus: true });
     } else {
-      documentPath = decodeURIComponent(pathname.replace(/^\/+/, ''));
+      documentPath = initialPath;
     }
 
     colorMode = document.documentElement.dataset.rdMode === 'dark' || document.documentElement.classList.contains('dark')
@@ -539,7 +572,9 @@
   {/if}
 
   <section class="document-shell" aria-label="Markdown document">
-    {#if provider && providerSynced}
+    {#if notFoundPath === documentPath}
+      <DocumentNotFoundState path={documentPath} />
+    {:else if provider && providerSynced}
       {#key provider}
         <PlaintextEditor
           ydoc={provider.doc}
@@ -582,6 +617,7 @@
   }
 
   .document-shell :global(.kb2-editor-shell),
+  .document-shell :global(.document-not-found),
   .loading {
     grid-column: 2;
     min-width: 0;

--- a/apps/web/src/test/local-editor-route.test.ts
+++ b/apps/web/src/test/local-editor-route.test.ts
@@ -1,16 +1,23 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as Y from 'yjs';
 import Page from '../routes/+page.svelte';
 
 const mocks = vi.hoisted(() => ({
   goto: vi.fn(),
+  afterNavigateCallbacks: [] as Array<(navigation: { to: { url: URL } | null; type: string }) => void>,
   destroyProvider: vi.fn(),
   providers: [] as Array<{ path: string; doc: Y.Doc; text: Y.Text }>,
 }));
 
 vi.mock('$app/navigation', () => ({
   goto: mocks.goto,
+  afterNavigate: vi.fn((callback) => {
+    mocks.afterNavigateCallbacks.push(callback);
+    return () => {
+      mocks.afterNavigateCallbacks = mocks.afterNavigateCallbacks.filter((candidate) => candidate !== callback);
+    };
+  }),
 }));
 
 vi.mock('@kb-2/editor', async () => {
@@ -29,10 +36,19 @@ vi.mock('$lib/yjs/demo-document-provider', async () => {
       options.onStatus?.('syncing');
       const doc = new Y.Doc();
       const text = doc.getText('markdown');
-      text.insert(0, `content:${path}`);
+      if (path === 'projects/missing.md' || path === 'deleted-later.md') {
+        options.onStatus?.('closed');
+        options.onError?.(new actual.DemoDocumentProviderOpenError({
+          ok: false,
+          error: 'not_found',
+          message: 'file not found',
+        }));
+      } else {
+        text.insert(0, `content:${path}`);
+        options.onStatus?.('open');
+        options.onSynced?.();
+      }
       mocks.providers.push({ path, doc, text });
-      options.onStatus?.('open');
-      options.onSynced?.();
       return {
         doc,
         text,
@@ -45,6 +61,7 @@ vi.mock('$lib/yjs/demo-document-provider', async () => {
 describe('local editor route', () => {
   beforeEach(() => {
     mocks.goto.mockReset();
+    mocks.afterNavigateCallbacks = [];
     mocks.destroyProvider.mockReset();
     mocks.providers = [];
     window.history.pushState(null, '', '/hello-world.md');
@@ -93,9 +110,10 @@ describe('local editor route', () => {
     expect(initialEditor.value).toBe('content:hello-world.md');
     const initialDocGuid = initialEditor.dataset.docGuid;
 
-    await fireEvent.click(screen.getByText('projects'));
-    await fireEvent.click(screen.getByText('active'));
-    await fireEvent.click(screen.getByText('editor-shell.md'));
+    const filesPanel = within(screen.getByRole('complementary', { name: 'Vault files' }));
+    await fireEvent.click(await filesPanel.findByText('projects'));
+    await fireEvent.click(await filesPanel.findByText('active'));
+    await fireEvent.click(filesPanel.getByText('editor-shell.md'));
 
     await waitFor(() => {
       expect(mocks.goto).toHaveBeenCalledWith('/projects/active/editor-shell.md', {
@@ -140,6 +158,51 @@ describe('local editor route', () => {
     expect(searchProvider?.path).toBe('research/search-hit.md');
     expect(searchProvider?.text.toString()).toBe('typed into search-opened file');
   });
+
+  it('renders an in-shell not-found state for missing document navigation without creating it', async () => {
+    window.history.pushState(null, '', '/projects/missing.md');
+
+    render(Page);
+
+    expect(await screen.findByText('Document not found')).toBeTruthy();
+    expect((await screen.findAllByText('projects/missing.md')).length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText('Markdown editor')).toBeNull();
+    expect(vi.mocked(fetch).mock.calls.some(([, init]) => init?.method === 'PUT')).toBe(false);
+
+    const filesPanel = within(screen.getByRole('complementary', { name: 'Vault files' }));
+    await fireEvent.click(await filesPanel.findByText('projects'));
+    await fireEvent.click(await filesPanel.findByText('active'));
+    await fireEvent.click(filesPanel.getByText('editor-shell.md'));
+
+    const editor = await waitForBoundEditor('content:projects/active/editor-shell.md');
+    expect(editor.value).toBe('content:projects/active/editor-shell.md');
+  });
+
+  it('rebinds the editor on history navigation and can land on a deleted document path', async () => {
+    render(Page);
+
+    const initialEditor = await screen.findByLabelText('Markdown editor') as HTMLTextAreaElement;
+    expect(initialEditor.value).toBe('content:hello-world.md');
+    const initialDocGuid = initialEditor.dataset.docGuid;
+
+    await simulateNavigation('/projects/active/editor-shell.md');
+    const nextEditor = await waitForBoundEditor('content:projects/active/editor-shell.md');
+    expect(nextEditor.dataset.docGuid).not.toBe(initialDocGuid);
+    await fireEvent.input(nextEditor, { target: { value: 'history marker for active doc' } });
+    expect(mocks.providers.at(-1)?.path).toBe('projects/active/editor-shell.md');
+    expect(mocks.providers.at(-1)?.text.toString()).toBe('history marker for active doc');
+
+    await simulateNavigation('/hello-world.md');
+    const backEditor = await waitForBoundEditor('content:hello-world.md');
+    expect(backEditor.dataset.docGuid).not.toBe(nextEditor.dataset.docGuid);
+    expect(mocks.providers.find((provider) => provider.path === 'projects/active/editor-shell.md')?.text.toString())
+      .toBe('history marker for active doc');
+
+    await simulateNavigation('/deleted-later.md');
+    expect(await screen.findByText('Document not found')).toBeTruthy();
+    expect((await screen.findAllByText('deleted-later.md')).length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText('Markdown editor')).toBeNull();
+  });
 });
 
 async function waitForBoundEditor(content: string): Promise<HTMLTextAreaElement> {
@@ -156,4 +219,15 @@ function json(body: unknown, status = 200): Response {
     status,
     headers: { 'content-type': 'application/json' },
   });
+}
+
+async function simulateNavigation(pathname: string): Promise<void> {
+  window.history.pushState(null, '', pathname);
+  for (const callback of mocks.afterNavigateCallbacks) {
+    callback({
+      to: { url: new URL(window.location.href) },
+      type: 'popstate',
+    });
+  }
+  await Promise.resolve();
 }

--- a/packages/doc-session/src/index.ts
+++ b/packages/doc-session/src/index.ts
@@ -1,6 +1,10 @@
 export {
+  DOCUMENT_SESSION_FAILURE_CLOSE_CODE,
+  DOCUMENT_SESSION_NOT_FOUND_FAILURE,
+  DocumentSessionNotFoundError,
   OneFileDocumentSession,
   PersistFailedError,
+  type DocumentSessionFailure,
   type DocumentSessionEventHandler,
   type DocumentSessionWarning,
   type OneFileDocumentSessionOptions,

--- a/packages/doc-session/src/manager.ts
+++ b/packages/doc-session/src/manager.ts
@@ -103,7 +103,9 @@ export class DocumentSessionManager {
   }
 
   getOpenSession(vaultPath: string): OneFileDocumentSession | undefined {
-    return this.sessions.get(vaultPath);
+    const session = this.sessions.get(vaultPath);
+    if (!session?.isOpened()) return undefined;
+    return session;
   }
 
   getOpenSessionCount(): number {
@@ -230,6 +232,10 @@ export class DocumentSessionManager {
   private scheduleIdleClose(vaultPath: string): void {
     if (this.hasClients(vaultPath) || !this.sessions.has(vaultPath)) return;
     this.cancelIdleClose(vaultPath);
+    if (!this.sessions.get(vaultPath)?.isOpened()) {
+      this.sessions.delete(vaultPath);
+      return;
+    }
     const timer = setTimeout(() => {
       void this.closeSession(vaultPath).catch((error: unknown) => {
         console.warn(`KB-2 failed to close idle document session for ${vaultPath}.`, error);

--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -82,6 +82,19 @@ describe('OneFileDocumentSession', () => {
     await expect(readFile(filePath, 'utf8')).resolves.toBe('seed\n');
     await expect(session.getContent()).resolves.toBe('seed\n');
     await session.close();
+  });
+
+  it('rejects missing document opens with not_found and leaves parent folders untouched', async () => {
+    const session = new OneFileDocumentSession(filePath);
+
+    await expect(session.open()).rejects.toMatchObject({
+      failure: {
+        ok: false,
+        error: 'not_found',
+        message: 'file not found'
+      }
+    });
+    await expect(readdir(kb2Home)).resolves.toEqual([]);
   });
 
   it('cold boots the Yjs document from the materialized Markdown file', async () => {

--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -600,6 +600,30 @@ describe('OneFileDocumentSession', () => {
     await manager.close();
   });
 
+  it('evicts a never-opened client session whose missing-file open failed', async () => {
+    const manager = new DocumentSessionManager({
+      root: join(kb2Home, 'demo-vault'),
+      idleSessionGraceMs: 80
+    });
+    const lease = manager.attachClientSession('typo/missing.md');
+
+    await expect(lease.session.open({ createIfMissing: false })).rejects.toMatchObject({
+      failure: {
+        ok: false,
+        error: 'not_found',
+        message: 'file not found'
+      }
+    });
+    expect(manager.getOpenSession('typo/missing.md')).toBeUndefined();
+    expect(manager.getOpenSessionCount()).toBe(1);
+
+    lease.release();
+
+    expect(manager.getOpenSessionCount()).toBe(0);
+    await expect(readdir(kb2Home)).resolves.toEqual([]);
+    await manager.close();
+  });
+
   it('keeps a session open until every simultaneous client lease is released', async () => {
     const manager = new DocumentSessionManager({
       root: join(kb2Home, 'demo-vault'),

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -32,6 +32,29 @@ export interface OneFileDocumentSessionOptions {
 
 export type DocumentSessionEventHandler = (event: DocumentSessionEvent) => void;
 
+export interface DocumentSessionFailure {
+  ok: false;
+  error: 'not_found';
+  message: string;
+}
+
+export const DOCUMENT_SESSION_NOT_FOUND_FAILURE: DocumentSessionFailure = {
+  ok: false,
+  error: 'not_found',
+  message: 'file not found'
+};
+
+export const DOCUMENT_SESSION_FAILURE_CLOSE_CODE = 1008;
+
+export class DocumentSessionNotFoundError extends Error {
+  readonly failure = DOCUMENT_SESSION_NOT_FOUND_FAILURE;
+
+  constructor(readonly filePath: string) {
+    super(DOCUMENT_SESSION_NOT_FOUND_FAILURE.message);
+    this.name = 'DocumentSessionNotFoundError';
+  }
+}
+
 export type SessionContentEditReject =
   | { ok: false; rejected: 'not_found' }
   | { ok: false; rejected: 'ambiguous'; match_count: number }
@@ -65,6 +88,7 @@ export class OneFileDocumentSession {
   filePath: string;
 
   private readonly defaultContent: string;
+  private readonly createMissingOnOpen: boolean;
   private eventPath: string;
   private readonly warn: (warning: DocumentSessionWarning) => void;
   private readonly watchDebounceMs: number;
@@ -94,6 +118,7 @@ export class OneFileDocumentSession {
     this.filePath = filePath;
     this.eventPath = options.eventPath ?? filePath;
     this.defaultContent = options.defaultContent ?? '';
+    this.createMissingOnOpen = options.defaultContent !== undefined;
     this.watchDebounceMs = options.watchDebounceMs ?? WATCH_DEBOUNCE_MS;
     this.watchPollMs = options.watchPollMs ?? WATCH_POLL_MS;
     this.warn = options.warn ?? ((warning) => {
@@ -105,13 +130,13 @@ export class OneFileDocumentSession {
     return this.doc;
   }
 
-  async open(): Promise<void> {
+  async open(options: { createIfMissing?: boolean } = {}): Promise<void> {
     if (this.opened) {
       return;
     }
 
     if (!this.openPromise) {
-      this.openPromise = this.loadFromFile().finally(() => {
+      this.openPromise = this.loadFromFile(options.createIfMissing ?? this.createMissingOnOpen).finally(() => {
         this.openPromise = undefined;
       });
     }
@@ -119,8 +144,8 @@ export class OneFileDocumentSession {
     await this.openPromise;
   }
 
-  private async loadFromFile(): Promise<void> {
-    const content = await this.readOrCreateFile();
+  private async loadFromFile(createIfMissing: boolean): Promise<void> {
+    const content = await this.readFile({ createIfMissing });
     this.text.insert(0, content);
     this.lastWrittenHash = hashContent(content);
     this.lastWrittenContent = content;
@@ -415,10 +440,14 @@ export class OneFileDocumentSession {
     }
   }
 
-  private async readOrCreateFile(): Promise<string> {
+  private async readFile(options: { createIfMissing: boolean }): Promise<string> {
     const existing = await readOptionalFile(this.filePath);
     if (existing !== undefined) {
       return existing;
+    }
+
+    if (!options.createIfMissing) {
+      throw new DocumentSessionNotFoundError(this.filePath);
     }
 
     await atomicWriteFile(this.filePath, this.defaultContent);

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -32,6 +32,7 @@ export interface OneFileDocumentSessionOptions {
 
 export type DocumentSessionEventHandler = (event: DocumentSessionEvent) => void;
 
+// Deliberately re-declared at the doc-session boundary to keep this package decoupled from service/transport mappers while preserving the closed one-failure-dialect shape.
 export interface DocumentSessionFailure {
   ok: false;
   error: 'not_found';
@@ -128,6 +129,10 @@ export class OneFileDocumentSession {
 
   get ydoc(): Y.Doc {
     return this.doc;
+  }
+
+  isOpened(): boolean {
+    return this.opened && !this.deleted;
   }
 
   async open(options: { createIfMissing?: boolean } = {}): Promise<void> {

--- a/packages/doc-session/src/websocket.test.ts
+++ b/packages/doc-session/src/websocket.test.ts
@@ -16,7 +16,8 @@ import {
   MESSAGE_SYNC,
   OneFileDocumentSession,
   decodeSessionEvent,
-  type DocumentSessionEvent
+  type DocumentSessionEvent,
+  type YjsWebSocketLike
 } from './index.js';
 import { bindYjsWebSocket } from './websocket.js';
 
@@ -321,6 +322,42 @@ describe('Yjs WebSocket session', () => {
     await closeServer(server);
     await session.close();
   });
+
+  it('handles alternate message payload shapes and skips sends to closed sockets', async () => {
+    const filePath = join(kb2Home, 'demo-vault', 'hello-world.md');
+    await mkdir(join(kb2Home, 'demo-vault'), { recursive: true });
+    await writeFile(filePath, 'socket shapes\n', 'utf8');
+    const session = new OneFileDocumentSession(filePath);
+    const socket = new FakeSocket();
+    socket.readyState = WebSocket.CLOSED;
+
+    const binding = await bindYjsWebSocket(session, socket);
+    expect(socket.sent).toEqual([]);
+
+    socket.emitMessage('not bytes');
+    socket.emitMessage(new Uint8Array([99]).buffer);
+    socket.emitMessage([Buffer.from([99])]);
+    expect(socket.closed).toEqual([]);
+
+    socket.emitClose();
+    await binding.closed;
+    await session.close();
+  });
+
+  it('propagates unexpected session open failures', async () => {
+    const socket = new FakeSocket();
+    const session = {
+      ydoc: new Y.Doc(),
+      open: async () => {
+        throw new Error('unexpected open failure');
+      },
+      flush: async () => undefined,
+      onEvent: () => () => undefined,
+      getActivePersistFailureEvent: () => undefined
+    } as unknown as OneFileDocumentSession;
+
+    await expect(bindYjsWebSocket(session, socket)).rejects.toThrow('unexpected open failure');
+  });
 });
 
 interface YjsClient {
@@ -328,6 +365,43 @@ interface YjsClient {
   text: Y.Text;
   events: DocumentSessionEvent[];
   close: () => void;
+}
+
+class FakeSocket implements YjsWebSocketLike {
+  readyState: number = WebSocket.OPEN;
+  readonly sent: Uint8Array[] = [];
+  readonly closed: Array<{ code: number | undefined; reason: string | undefined }> = [];
+  private readonly listeners = {
+    message: [] as Array<(data: unknown) => void>,
+    close: [] as Array<() => void>,
+    error: [] as Array<() => void>
+  };
+
+  send(data: Uint8Array): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closed.push({ code, reason });
+    this.readyState = WebSocket.CLOSED;
+  }
+
+  on(event: 'message' | 'close' | 'error', listener: ((data: unknown) => void) | (() => void)): this {
+    this.listeners[event].push(listener as never);
+    return this;
+  }
+
+  emitMessage(data: unknown): void {
+    for (const listener of this.listeners.message) {
+      listener(data);
+    }
+  }
+
+  emitClose(): void {
+    for (const listener of this.listeners.close) {
+      listener();
+    }
+  }
 }
 
 async function connectYjsClient(url: string): Promise<YjsClient> {

--- a/packages/doc-session/src/websocket.test.ts
+++ b/packages/doc-session/src/websocket.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -11,6 +11,7 @@ import * as syncProtocol from 'y-protocols/sync';
 import * as Y from 'yjs';
 
 import {
+  DOCUMENT_SESSION_FAILURE_CLOSE_CODE,
   MESSAGE_SESSION_EVENT,
   MESSAGE_SYNC,
   OneFileDocumentSession,
@@ -113,6 +114,39 @@ describe('Yjs WebSocket session', () => {
     await closeWebSocketServer(webSocketServer);
     await closeServer(server);
     await session.close();
+  });
+
+  it('fails missing document binds with canonical not_found and does not create parent folders', async () => {
+    const filePath = join(kb2Home, 'demo-vault', 'typo', 'missing.md');
+    const session = new OneFileDocumentSession(filePath);
+    const server = createServer();
+    const webSocketServer = new WebSocketServer({ noServer: true });
+    server.on('upgrade', (request, socket, head) => {
+      if (request.url !== DEMO_DOCUMENT_YJS_PATH) {
+        socket.destroy();
+        return;
+      }
+
+      webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
+        void bindYjsWebSocket(session, webSocket);
+      });
+    });
+    await listen(server);
+
+    const port = (server.address() as AddressInfo).port;
+    const socket = new WebSocket(`ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`);
+    const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+      socket.once('close', (code, reason) => resolve({ code, reason: reason.toString() }));
+    });
+
+    await expect(closed).resolves.toEqual({
+      code: DOCUMENT_SESSION_FAILURE_CLOSE_CODE,
+      reason: JSON.stringify({ ok: false, error: 'not_found', message: 'file not found' })
+    });
+    await expect(readdir(kb2Home)).resolves.toEqual([]);
+
+    await closeWebSocketServer(webSocketServer);
+    await closeServer(server);
   });
 
   it('reconciles idle external file changes and broadcasts the quiet merge event to every client', async () => {

--- a/packages/doc-session/src/websocket.ts
+++ b/packages/doc-session/src/websocket.ts
@@ -2,7 +2,12 @@ import * as decoding from 'lib0/decoding';
 import * as encoding from 'lib0/encoding';
 import * as syncProtocol from 'y-protocols/sync';
 
-import { PersistFailedError, type OneFileDocumentSession } from './session.js';
+import {
+  DOCUMENT_SESSION_FAILURE_CLOSE_CODE,
+  DocumentSessionNotFoundError,
+  PersistFailedError,
+  type OneFileDocumentSession
+} from './session.js';
 import { MESSAGE_SYNC, encodeSessionEvent, encodeSyncedMessage } from './protocol.js';
 
 const socketOpen = 1;
@@ -101,7 +106,16 @@ export async function bindYjsWebSocket(
   socket.on('close', cleanup);
   socket.on('error', cleanup);
 
-  await session.open();
+  try {
+    await session.open({ createIfMissing: false });
+  } catch (error) {
+    if (error instanceof DocumentSessionNotFoundError) {
+      socket.close(DOCUMENT_SESSION_FAILURE_CLOSE_CODE, JSON.stringify(error.failure));
+      resolveClosed();
+      return { closed };
+    }
+    throw error;
+  }
   sessionReady = true;
 
   session.ydoc.on('update', updateHandler);

--- a/packages/doc-session/vitest.config.ts
+++ b/packages/doc-session/vitest.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text'],
-      include: ['src/manager.ts', 'src/protocol.ts', 'src/session.ts'],
+      include: ['src/manager.ts', 'src/protocol.ts', 'src/session.ts', 'src/websocket.ts'],
       thresholds: {
         'src/manager.ts': {
           lines: 95
@@ -35,6 +35,9 @@ export default defineConfig({
           lines: 95
         },
         'src/session.ts': {
+          lines: 90
+        },
+        'src/websocket.ts': {
           lines: 90
         }
       }

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -24,6 +24,7 @@ export { default as LocalStatusShell } from './layout/LocalStatusShell.svelte';
 export type { DaemonStatus, HealthResponse } from './layout/LocalStatusShell.svelte';
 export { default as DocumentSaveBanner } from './notifications/DocumentSaveBanner.svelte';
 export { default as DocumentHeader } from './local-editor/DocumentHeader.svelte';
+export { default as DocumentNotFoundState } from './local-editor/DocumentNotFoundState.svelte';
 export { default as FileNode } from './local-editor/FileNode.svelte';
 export { default as FilesPanel } from './local-editor/FilesPanel.svelte';
 export { default as FilesSearchResults } from './local-editor/FilesSearchResults.svelte';

--- a/packages/ui/src/lib/local-editor/DocumentNotFoundState.stories.ts
+++ b/packages/ui/src/lib/local-editor/DocumentNotFoundState.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import DocumentNotFoundStateDemo from '../stories/DocumentNotFoundStateDemo.svelte';
+
+const meta = {
+  title: 'App/Local Editor/DocumentNotFoundState',
+  component: DocumentNotFoundStateDemo,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    path: 'projects/typo/missing-note.md',
+    mode: 'light'
+  }
+} satisfies Meta<typeof DocumentNotFoundStateDemo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Light: Story = {};
+
+export const Dark: Story = {
+  args: {
+    mode: 'dark'
+  }
+};

--- a/packages/ui/src/lib/local-editor/DocumentNotFoundState.svelte
+++ b/packages/ui/src/lib/local-editor/DocumentNotFoundState.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  interface Props {
+    path: string;
+  }
+
+  let { path }: Props = $props();
+</script>
+
+<section class="document-not-found" aria-label="Document not found">
+  <p class="eyebrow">404</p>
+  <h2>Document not found</h2>
+  <p class="message">
+    <code>{path}</code> does not exist in this vault.
+  </p>
+</section>
+
+<style>
+  .document-not-found {
+    grid-column: 2;
+    min-width: 0;
+    min-height: 100%;
+    border-left: 1px solid var(--rd-rule);
+    border-right: 1px solid var(--rd-rule);
+    background: var(--rd-panel);
+    color: var(--rd-ink-2);
+    padding: 56px 48px;
+    font-family: var(--rd-ui);
+  }
+
+  .eyebrow {
+    margin: 0 0 12px;
+    color: var(--rd-ink-4);
+    font-size: 12px;
+    font-weight: 750;
+    letter-spacing: 0;
+    text-transform: uppercase;
+  }
+
+  h2 {
+    margin: 0 0 12px;
+    color: var(--rd-ink-1);
+    font-size: 28px;
+    line-height: 1.15;
+    font-weight: 700;
+    letter-spacing: 0;
+  }
+
+  .message {
+    max-width: 34rem;
+    margin: 0;
+    color: var(--rd-ink-3);
+    font-size: 14px;
+    line-height: 1.6;
+  }
+
+  code {
+    border: 1px solid var(--rd-rule);
+    border-radius: 5px;
+    background: var(--rd-bg);
+    color: var(--rd-ink-1);
+    padding: 2px 5px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    font-size: 0.92em;
+    overflow-wrap: anywhere;
+  }
+</style>

--- a/packages/ui/src/lib/stories/DocumentNotFoundStateDemo.svelte
+++ b/packages/ui/src/lib/stories/DocumentNotFoundStateDemo.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import DocumentNotFoundState from '../local-editor/DocumentNotFoundState.svelte';
+
+  interface Props {
+    path: string;
+    mode?: 'light' | 'dark';
+  }
+
+  let { path, mode = 'light' }: Props = $props();
+</script>
+
+<div class:dark={mode === 'dark'} data-rd-mode={mode} class="preview">
+  <div class="document-grid">
+    <DocumentNotFoundState {path} />
+  </div>
+</div>
+
+<style>
+  .preview {
+    min-height: 100vh;
+    background: var(--rd-bg);
+  }
+
+  .document-grid {
+    min-height: 100vh;
+    display: grid;
+    grid-template-columns: minmax(24px, 1fr) minmax(0, 760px) minmax(24px, 1fr);
+  }
+</style>


### PR DESCRIPTION
## Summary
- make missing WebSocket document opens fail with the canonical not_found failure without creating parent directories
- seed hello-world.md explicitly at daemon startup so fresh vault boot still works
- render a transport-free in-shell not-found state from apps/web and rebind providers on browser history navigation

## Tests
- pnpm --filter @kb-2/doc-session test
- pnpm --filter @kb-2/daemon test
- pnpm --filter @kb-2/web test
- pnpm check

## Browser walkthrough
Headless Chrome against fresh KB2_HOME on port 9891:
- typo URL showed in-shell not-found for typo/missing.md; find showed no typo parent under the temp demo-vault
- tree click from not-found loaded projects/alpha.md with Alpha original visible
- context-menu New Note created projects/new-note.md, auto-opened it, and accepted typing
- browser back/forward rebound the editor: beta -> alpha -> beta showed matching visible content
- typed markers landed in the expected alpha, beta, and new-note files on disk
- forward navigation to a deleted history entry rendered in-shell not-found for projects/deleted.md
