### PR TITLE
Chunk 014: REST Actor Attribution

### DIFF
--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -8,12 +8,13 @@ import {
   createVaultService,
   type ServiceErrorCode,
   type ServiceResult,
+  type VaultActor,
   type VaultChangeEvent,
   type VaultService
 } from '@kb-2/vault-service';
 import { resolve } from 'node:path';
 
-import { SERVICE_NAME } from './config.js';
+import { SERVICE_NAME, type ActorDefault } from './config.js';
 import {
   filePathParam,
   queryNumber,
@@ -27,6 +28,8 @@ import { readDaemonStatus } from './status.js';
 import { missingUiBuildResponse, proxyUi, serveUi } from './ui-static.js';
 
 const DEMO_DOCUMENT_PATH = 'demo-vault/hello-world.md';
+const ACTOR_HEADER = 'x-kb2-actor';
+const MAX_ACTOR_HEADER_BYTES = 1024;
 
 export interface CreateAppOptions {
   statusFile: string;
@@ -37,6 +40,7 @@ export interface CreateAppOptions {
   mcpEndpoint?: LocalMcpEndpoint;
   webBuildDir?: string;
   webProxyTarget?: string;
+  actorDefault?: ActorDefault;
 }
 
 export function createApp(options: CreateAppOptions): Hono {
@@ -82,6 +86,7 @@ export function createApp(options: CreateAppOptions): Hono {
       documentSessions: options.documentSessions ?? new DocumentSessionManager({ root: options.vaultRoot })
     });
     const mcpEndpoint = options.mcpEndpoint ?? createLocalMcpEndpoint(vaultService);
+    const actorDefault = options.actorDefault ?? 'user';
 
     api.post('/ops/flush', async (context) => {
       return mapServiceResult(context, await vaultService.flushDirtySessions());
@@ -121,6 +126,8 @@ export function createApp(options: CreateAppOptions): Hono {
 
     api.put('/files/*', async (context) => {
       const filePath = filePathParam(context.req.path, '/api/files/');
+      const actor = actorFromRequest(context, actorDefault);
+      if (!actor.ok) return mapServiceResult(context, actor);
       const content = await requestTextContent(context.req.raw);
       if (!content.ok) return mapServiceResult(context, content);
       const overwrite = context.req.query('overwrite') === 'true';
@@ -128,22 +135,26 @@ export function createApp(options: CreateAppOptions): Hono {
         path: filePath,
         content: content.content,
         overwrite,
-        actor: { kind: 'user' }
+        actor: actor.actor
       }), overwrite ? 200 : 201);
     });
 
     api.delete('/files/*', async (context) => {
       const filePath = filePathParam(context.req.path, '/api/files/');
+      const actor = actorFromRequest(context, actorDefault);
+      if (!actor.ok) return mapServiceResult(context, actor);
       const permanent = context.req.query('permanent') === 'true';
       return mapServiceResult(context, await vaultService.deleteNote({
         path: filePath,
         permanent,
-        actor: { kind: 'user' }
+        actor: actor.actor
       }));
     });
 
     api.post('/files/*', async (context) => {
       if (context.req.path.endsWith('/splice')) {
+        const actor = actorFromRequest(context, actorDefault);
+        if (!actor.ok) return mapServiceResult(context, actor);
         const filePath = filePathParam(context.req.path, '/api/files/', '/splice');
         const body = await readJsonObject(context.req.raw);
         if (!body.ok) return mapServiceResult(context, body);
@@ -157,11 +168,13 @@ export function createApp(options: CreateAppOptions): Hono {
           before: splice.request.before,
           after: splice.request.after,
           occurrence: splice.request.occurrence,
-          actor: { kind: 'user' }
+          actor: actor.actor
         }));
       }
 
       if (context.req.path.endsWith('/append')) {
+        const actor = actorFromRequest(context, actorDefault);
+        if (!actor.ok) return mapServiceResult(context, actor);
         const filePath = filePathParam(context.req.path, '/api/files/', '/append');
         const body = await readJsonObject(context.req.raw);
         if (!body.ok) return mapServiceResult(context, body);
@@ -170,11 +183,13 @@ export function createApp(options: CreateAppOptions): Hono {
         return mapServiceResult(context, await vaultService.appendNote({
           path: filePath,
           content: content.value,
-          actor: { kind: 'user' }
+          actor: actor.actor
         }));
       }
 
       if (context.req.path.endsWith('/prepend')) {
+        const actor = actorFromRequest(context, actorDefault);
+        if (!actor.ok) return mapServiceResult(context, actor);
         const filePath = filePathParam(context.req.path, '/api/files/', '/prepend');
         const body = await readJsonObject(context.req.raw);
         if (!body.ok) return mapServiceResult(context, body);
@@ -183,7 +198,7 @@ export function createApp(options: CreateAppOptions): Hono {
         return mapServiceResult(context, await vaultService.prependNote({
           path: filePath,
           content: content.value,
-          actor: { kind: 'user' }
+          actor: actor.actor
         }));
       }
 
@@ -192,6 +207,8 @@ export function createApp(options: CreateAppOptions): Hono {
       }
 
       const fromPath = filePathParam(context.req.path, '/api/files/', '/move');
+      const actor = actorFromRequest(context, actorDefault);
+      if (!actor.ok) return mapServiceResult(context, actor);
       const body = await readJsonObject(context.req.raw);
       if (!body.ok) return mapServiceResult(context, body);
       const to = readRequiredString(body.body, 'to');
@@ -200,17 +217,19 @@ export function createApp(options: CreateAppOptions): Hono {
       return mapServiceResult(context, await vaultService.moveNote({
         fromPath,
         toPath: to.value,
-        actor: { kind: 'user' }
+        actor: actor.actor
       }));
     });
 
     api.post('/folders', async (context) => {
+      const actor = actorFromRequest(context, actorDefault);
+      if (!actor.ok) return mapServiceResult(context, actor);
       const body = await readJsonObject(context.req.raw);
       if (!body.ok) return mapServiceResult(context, body);
       const folderPath = typeof body.body.path === 'string' ? body.body.path : '';
       return mapServiceResult(context, await vaultService.createFolder({
         path: folderPath,
-        actor: { kind: 'user' }
+        actor: actor.actor
       }), 201);
     });
 
@@ -228,6 +247,8 @@ export function createApp(options: CreateAppOptions): Hono {
         return context.json({ ok: false, error: 'Not found' }, 404);
       }
 
+      const actor = actorFromRequest(context, actorDefault);
+      if (!actor.ok) return mapServiceResult(context, actor);
       const folderPath = filePathParam(context.req.path, '/api/folders/', '/metadata');
       const body = await readJsonObject(context.req.raw);
       if (!body.ok) return mapServiceResult(context, body);
@@ -236,19 +257,21 @@ export function createApp(options: CreateAppOptions): Hono {
       return mapServiceResult(context, await vaultService.setFolderMetadata({
         path: folderPath,
         metadata: metadata.metadata,
-        actor: { kind: 'user' }
+        actor: actor.actor
       }));
     });
 
     api.delete('/folders/*', async (context) => {
       const folderPath = filePathParam(context.req.path, '/api/folders/');
+      const actor = actorFromRequest(context, actorDefault);
+      if (!actor.ok) return mapServiceResult(context, actor);
       const recursive = context.req.query('recursive') === 'true';
       const permanent = context.req.query('permanent') === 'true';
       return mapServiceResult(context, await vaultService.deleteFolder({
         path: folderPath,
         recursive,
         permanent,
-        actor: { kind: 'user' }
+        actor: actor.actor
       }));
     });
 
@@ -257,6 +280,8 @@ export function createApp(options: CreateAppOptions): Hono {
         return context.json({ ok: false, error: 'Not found' }, 404);
       }
 
+      const actor = actorFromRequest(context, actorDefault);
+      if (!actor.ok) return mapServiceResult(context, actor);
       const fromPath = filePathParam(context.req.path, '/api/folders/', '/move');
       const body = await readJsonObject(context.req.raw);
       if (!body.ok) return mapServiceResult(context, body);
@@ -266,7 +291,7 @@ export function createApp(options: CreateAppOptions): Hono {
       return mapServiceResult(context, await vaultService.moveFolder({
         fromPath,
         toPath: to.value,
-        actor: { kind: 'user' }
+        actor: actor.actor
       }));
     });
 
@@ -345,6 +370,7 @@ function mapServiceResult(
 
 function statusForServiceError(error: ServiceErrorCode): 400 | 404 | 409 | 413 | 500 {
   switch (error) {
+    case 'invalid_actor':
     case 'invalid_path':
     case 'invalid_metadata':
     case 'invalid_request':
@@ -367,6 +393,70 @@ function statusForServiceError(error: ServiceErrorCode): 400 | 404 | 409 | 413 |
     case 'ambiguous':
       return 409;
   }
+}
+
+function actorFromRequest(context: Context, actorDefault: ActorDefault): ServiceResult<{ actor: VaultActor }> {
+  const rawActor = context.req.header(ACTOR_HEADER);
+
+  if (rawActor === undefined) {
+    return { ok: true, actor: { kind: actorDefault } };
+  }
+
+  if (new TextEncoder().encode(rawActor).byteLength > MAX_ACTOR_HEADER_BYTES) {
+    return invalidActor(`${ACTOR_HEADER} must be 1 KiB or smaller`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawActor);
+  } catch {
+    return invalidActor(`${ACTOR_HEADER} must be valid JSON`);
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return invalidActor(`${ACTOR_HEADER} must be a JSON object`);
+  }
+
+  const actor = parsed as Record<string, unknown>;
+  if (actor.kind !== 'user' && actor.kind !== 'integration') {
+    return invalidActor(`${ACTOR_HEADER}.kind must be "user" or "integration"`);
+  }
+
+  const id = readOptionalActorString(actor, 'id');
+  if (!id.ok) return id;
+  const name = readOptionalActorString(actor, 'name');
+  if (!name.ok) return name;
+  const client = readOptionalActorString(actor, 'client');
+  if (!client.ok) return client;
+
+  return {
+    ok: true,
+    actor: {
+      kind: actor.kind,
+      ...(id.value !== undefined ? { id: id.value } : {}),
+      ...(name.value !== undefined ? { name: name.value } : {}),
+      ...(client.value !== undefined ? { client: client.value } : {})
+    }
+  };
+}
+
+function readOptionalActorString(
+  actor: Record<string, unknown>,
+  key: 'id' | 'name' | 'client'
+): ServiceResult<{ value?: string }> {
+  if (!Object.prototype.hasOwnProperty.call(actor, key)) {
+    return { ok: true };
+  }
+
+  if (typeof actor[key] !== 'string') {
+    return invalidActor(`${ACTOR_HEADER}.${key} must be a string when provided`);
+  }
+
+  return { ok: true, value: actor[key] };
+}
+
+function invalidActor(message: string): ServiceResult<never> {
+  return { ok: false, error: 'invalid_actor', message };
 }
 
 function readFolderMetadataBody(body: Record<string, unknown>): ServiceResult<{ metadata: { color?: string | null; icon?: string | null } }> {

--- a/apps/daemon/src/config.test.ts
+++ b/apps/daemon/src/config.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_HOST,
   DEFAULT_PORT,
   createDaemonConfig,
+  resolveActorDefault,
   resolveKb2Home,
   resolvePort,
   resolveRelayConfig,
@@ -54,6 +55,7 @@ describe('daemon config', () => {
         relayUrl: 'http://127.0.0.1:9920/t/dev1',
         token: 'test-token'
       },
+      actorDefault: 'user',
       kb2Home,
       daemonHome: join(kb2Home, 'daemon'),
       vaultRoot: join(kb2Home, 'demo-vault'),
@@ -68,6 +70,7 @@ describe('daemon config', () => {
 
     expect(config.host).toBe(DEFAULT_HOST);
     expect(config.port).toBe(DEFAULT_PORT);
+    expect(config.actorDefault).toBe('user');
   });
 
   it('rejects invalid ports', () => {
@@ -98,5 +101,12 @@ describe('daemon config', () => {
       relayUrl: 'http://127.0.0.1:9920/t/dev1',
       token: 'test-token'
     });
+  });
+
+  it('resolves the REST actor default mode', () => {
+    expect(resolveActorDefault({})).toBe('user');
+    expect(resolveActorDefault({ KB2_ACTOR_DEFAULT: ' unknown ' })).toBe('unknown');
+    expect(resolveActorDefault({ KB2_ACTOR_DEFAULT: 'user' })).toBe('user');
+    expect(() => resolveActorDefault({ KB2_ACTOR_DEFAULT: 'system' })).toThrow(/KB2_ACTOR_DEFAULT/);
   });
 });

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -4,6 +4,9 @@ import { join, resolve } from 'node:path';
 export const SERVICE_NAME = 'kb2d';
 export const DEFAULT_PORT = 7382;
 export const DEFAULT_HOST = '127.0.0.1';
+export const DEFAULT_ACTOR_DEFAULT = 'user';
+
+export type ActorDefault = 'user' | 'unknown';
 
 export interface DaemonConfig {
   serviceName: typeof SERVICE_NAME;
@@ -11,6 +14,7 @@ export interface DaemonConfig {
   port: number;
   webProxyTarget?: string;
   relay?: DaemonRelayConfig;
+  actorDefault: ActorDefault;
   kb2Home: string;
   daemonHome: string;
   vaultRoot: string;
@@ -86,6 +90,20 @@ export function resolveRelayConfig(env: NodeJS.ProcessEnv = process.env): Daemon
   };
 }
 
+export function resolveActorDefault(env: NodeJS.ProcessEnv = process.env): ActorDefault {
+  const configuredDefault = env.KB2_ACTOR_DEFAULT?.trim();
+
+  if (!configuredDefault) {
+    return DEFAULT_ACTOR_DEFAULT;
+  }
+
+  if (configuredDefault === 'user' || configuredDefault === 'unknown') {
+    return configuredDefault;
+  }
+
+  throw new Error(`KB2_ACTOR_DEFAULT must be "user" or "unknown". Received: ${configuredDefault}`);
+}
+
 export function createDaemonConfig(options: ResolveConfigOptions = {}): DaemonConfig {
   const env = options.env ?? process.env;
   const homeDir = options.homeDir ?? homedir();
@@ -99,6 +117,7 @@ export function createDaemonConfig(options: ResolveConfigOptions = {}): DaemonCo
     port: resolvePort(env),
     webProxyTarget: resolveWebProxyTarget(env),
     relay: resolveRelayConfig(env),
+    actorDefault: resolveActorDefault(env),
     kb2Home,
     daemonHome,
     vaultRoot,

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -49,7 +49,8 @@ export async function startDaemon(): Promise<StartedDaemon> {
     demoDocumentSession,
     mcpEndpoint,
     webBuildDir: fileURLToPath(new URL('../../web/build', import.meta.url)),
-    webProxyTarget: config.webProxyTarget
+    webProxyTarget: config.webProxyTarget,
+    actorDefault: config.actorDefault
   });
 
   return new Promise((resolve, reject) => {

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -211,6 +211,113 @@ describe('daemon routing', () => {
     expect(audit[1]).toMatchObject({ operation: 'write', path: 'notes/a.md' });
   });
 
+  it('attributes REST writes from the x-kb2-actor header in responses and audit JSONL', async () => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const app = createApp({
+      statusFile: config.statusFile,
+      vaultRoot: config.vaultRoot,
+      actorDefault: config.actorDefault
+    });
+    const suppliedActor = {
+      kind: 'integration',
+      id: 'user-123',
+      name: 'Ada Lovelace',
+      client: 'kb-1-cloud'
+    };
+
+    const created = await app.request('/api/files/notes/attributed.md', {
+      method: 'PUT',
+      headers: {
+        'content-type': 'text/plain',
+        'x-kb2-actor': JSON.stringify(suppliedActor)
+      },
+      body: 'attributed\n'
+    });
+
+    expect(created.status).toBe(201);
+    await expect(created.json()).resolves.toMatchObject({
+      ok: true,
+      path: 'notes/attributed.md',
+      audit: { actor: suppliedActor }
+    });
+    await expect(readFile(join(config.vaultRoot, 'notes/attributed.md'), 'utf8')).resolves.toBe('attributed\n');
+
+    const audit = await readAuditRows(config.vaultRoot);
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({
+      operation: 'create',
+      entityKind: 'file',
+      path: 'notes/attributed.md',
+      actor: suppliedActor
+    });
+  });
+
+  it.each([
+    { name: 'default user mode', env: {}, expectedActor: { kind: 'user' } },
+    { name: 'configured unknown mode', env: { KB2_ACTOR_DEFAULT: 'unknown' }, expectedActor: { kind: 'unknown' } }
+  ])('uses $name for REST writes without an actor header', async ({ env, expectedActor }) => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home, ...env } });
+    const app = createApp({
+      statusFile: config.statusFile,
+      vaultRoot: config.vaultRoot,
+      actorDefault: config.actorDefault
+    });
+
+    const created = await app.request('/api/files/notes/defaulted.md', {
+      method: 'PUT',
+      headers: { 'content-type': 'text/plain' },
+      body: 'defaulted\n'
+    });
+
+    expect(created.status).toBe(201);
+    await expect(created.json()).resolves.toMatchObject({
+      ok: true,
+      audit: { actor: expectedActor }
+    });
+    await expect(readFile(join(config.vaultRoot, 'notes/defaulted.md'), 'utf8')).resolves.toBe('defaulted\n');
+
+    const audit = await readAuditRows(config.vaultRoot);
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({
+      operation: 'create',
+      path: 'notes/defaulted.md',
+      actor: expectedActor
+    });
+  });
+
+  it.each([
+    { name: 'bad JSON', header: '{' },
+    { name: 'spoofed system kind', header: JSON.stringify({ kind: 'system' }) },
+    { name: 'reserved mcp_client kind', header: JSON.stringify({ kind: 'mcp_client' }) },
+    { name: 'unknown kind', header: JSON.stringify({ kind: 'service' }) },
+    { name: 'oversized payload', header: JSON.stringify({ kind: 'user', name: 'x'.repeat(1025) }) },
+    { name: 'non-string identity field', header: JSON.stringify({ kind: 'user', id: 123 }) }
+  ])('rejects malformed REST actor header: $name', async ({ header }) => {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const app = createApp({
+      statusFile: config.statusFile,
+      vaultRoot: config.vaultRoot,
+      actorDefault: config.actorDefault
+    });
+
+    const response = await app.request('/api/files/notes/rejected.md', {
+      method: 'PUT',
+      headers: {
+        'content-type': 'text/plain',
+        'x-kb2-actor': header
+      },
+      body: 'must not write\n'
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: 'invalid_actor'
+    });
+    await expect(stat(join(config.vaultRoot, 'notes/rejected.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(stat(join(config.vaultRoot, '.kb2/audit/changes.jsonl'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('moves and deletes live file sessions through the API with doc events and trash', async () => {
     const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
     const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });

--- a/packages/vault-core/src/audit.ts
+++ b/packages/vault-core/src/audit.ts
@@ -2,7 +2,9 @@ import { mkdir, appendFile } from 'node:fs/promises';
 import path from 'node:path';
 
 export interface VaultActor {
-  kind: 'user' | 'mcp_client' | 'integration' | 'system';
+  kind: 'user' | 'mcp_client' | 'integration' | 'system' | 'unknown';
+  id?: string;
+  name?: string;
   client?: string;
 }
 

--- a/packages/vault-service/src/index.ts
+++ b/packages/vault-service/src/index.ts
@@ -37,9 +37,10 @@ export type ServiceErrorCode =
   | 'too_large_splice'
   | 'too_large_document'
   | 'persist_failed'
-  | 'invalid_request';
+  | 'invalid_request'
+  | 'invalid_actor';
 
-type SimpleServiceErrorCode = VaultErrorCode | 'persist_failed' | 'invalid_request';
+type SimpleServiceErrorCode = VaultErrorCode | 'persist_failed' | 'invalid_request' | 'invalid_actor';
 
 export type ServiceFailure =
   | { ok: false; error: SimpleServiceErrorCode; message: string }
@@ -48,7 +49,8 @@ export type ServiceFailure =
   | { ok: false; error: 'too_large_splice'; message: string; limit_bytes: number }
   | { ok: false; error: 'too_large_document'; message: string; current_bytes: number; limit_bytes: number }
   | { ok: false; error: 'persist_failed'; message: string }
-  | { ok: false; error: 'invalid_request'; message: string };
+  | { ok: false; error: 'invalid_request'; message: string }
+  | { ok: false; error: 'invalid_actor'; message: string };
 
 export type ServiceResult<T extends object = object> = ({ ok: true } & T) | ServiceFailure;
 


### PR DESCRIPTION
## Summary

Implements the binding Chunk 014 daemon plan:

- Adds one shared REST `x-kb2-actor` parser/helper in `apps/daemon/src/app.ts`.
- Threads parsed REST actors through all audited REST write routes.
- Adds `KB2_ACTOR_DEFAULT=user|unknown` config, defaulting to `user`.
- Extends `VaultActor` with `unknown`, `id`, and `name` while keeping MCP actor derivation unchanged.
- Adds canonical `invalid_actor` service failure mapping to HTTP 400.

## Plan Criteria Checklist

- [x] Every REST route that passes an actor derives it through the shared helper.
- [x] Zero `actor: { kind: 'user' }` literals remain in `apps/daemon/src/app.ts`.
- [x] Valid header actor appears in the API response audit object and audit JSONL on disk.
- [x] Missing header defaults to `user`, or `unknown` with `KB2_ACTOR_DEFAULT=unknown`.
- [x] Bad JSON, spoofed `system`, reserved `mcp_client`, unknown kind, oversized payload, and non-string identity fields return `400 invalid_actor` with no write/audit row.
- [x] MCP behavior remains `mcp_client` and is regression-covered by existing daemon/local-mcp tests.
- [x] New helper remains under the existing `apps/daemon/src/app.ts` coverage gate.
- [x] Full `pnpm check` is green.

## Local Verification

- `pnpm --filter @kb-2/daemon test`: passed, 84 tests, daemon coverage gate green.
- `pnpm check`: passed.
- `rg "actor: { kind: 'user' }" apps/daemon/src/app.ts`: no matches.

Manual curl matrix, visible observations:

- Default daemon: `KB2_HOME=/var/folders/vp/ynhnsrb1693_4_gg5l2_kgw80000gn/T/tmp.uZITtSSZmj`, port `9890`.
- Full actor header write returned `201`; response audit and audit JSONL recorded `{ "kind":"integration", "id":"user-9", "name":"Manual User", "client":"curl-matrix" }`.
- No header in default mode returned `201`; response audit and audit JSONL recorded `{ "kind":"user" }`.
- Garbage header returned `400` with `{ "ok":false, "error":"invalid_actor" }`; `manual/garbage.md` did not exist and no audit row was written for it.
- Unknown-default daemon: `KB2_HOME=/var/folders/vp/ynhnsrb1693_4_gg5l2_kgw80000gn/T/tmp.qg9BO0J15m`, port `9890`, `KB2_ACTOR_DEFAULT=unknown`.
- No header in unknown mode returned `201`; response audit and audit JSONL recorded `{ "kind":"unknown" }`.

## Independent Verification

Fresh verifier worktree: `/tmp/kb2-chunk014-audit-81057`, branch `origin/chunk-014-actor-attribution` at `de028b3601dc5aa60a58d941bc9d9aeb7fe7de77`.

- `pnpm install --frozen-lockfile`: passed.
- `pnpm check`: passed.
- `pnpm check --skip-nx-cache`: passed.
- Fresh curl matrix passed on allowed ports `9890` and `9891`.
- Fresh audit JSONL reads confirmed integration, default user, and default unknown actor rows.
- Garbage header returned `400 invalid_actor`; audit line count stayed unchanged and target file was not created.
- Verifier confirmed exactly one shared REST helper pattern and no functional gaps.

Warnings observed were existing build/tooling warnings only: `NO_COLOR` ignored due to `FORCE_COLOR`, Svelte nested-class warnings in `PlaintextEditor.svelte`, one Svelte config overwrite warning, and Vite chunk-size warnings.