### PR TITLE
Cloud 004 Demo Polish: shared editor status dot

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -87,6 +87,15 @@
           ? 'Daemon · error'
           : 'Daemon · closed',
   );
+  const daemonStatus = $derived<'open' | 'connecting' | 'closed' | 'error'>(
+    persistFailureActive || status === 'error'
+      ? 'error'
+      : status === 'open'
+        ? 'open'
+        : status === 'connecting' || status === 'syncing'
+          ? 'connecting'
+          : 'closed',
+  );
 
   function handleSessionEvent(event: DocumentSessionEvent): void {
     if (event.kind === 'doc-moved') {
@@ -499,6 +508,7 @@
 <LocalEditorShell
   {vaultName}
   {daemonLabel}
+  {daemonStatus}
   {documentPath}
   {colorMode}
   {tree}

--- a/docs/architecture/invariants/product/edits-save-or-fail-loudly.md
+++ b/docs/architecture/invariants/product/edits-save-or-fail-loudly.md
@@ -34,6 +34,13 @@ now because offline detection, reconnect, and read-only-on-disconnect have
 not been built. This exception expires when those ship (see horizons); it
 must not be used to justify any new silent-failure path.
 
+Cloud 004 demo polish: the cloud editor may suppress successful/idle and
+recovered save banners, and may render save-failure warnings as non-layout-
+shifting chrome (the connection dot turns red, with an overlay warning) instead
+of an in-flow banner. This is only for the live staging demo polish pass and
+must be reverted or reworked into a full non-reflowing loud-save design before
+any real use.
+
 ## Violations
 
 - A failed materialization that only writes a daemon log line.

--- a/packages/ui/src/lib/local-editor/FilesPanel.svelte
+++ b/packages/ui/src/lib/local-editor/FilesPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import IconButton from '../primitives/IconButton.svelte';
   import Icon from '../primitives/Icon.svelte';
-  import LiveStatusChip from '../primitives/LiveStatusChip.svelte';
+  import LiveDot from '../primitives/LiveDot.svelte';
   import SearchInput from '../primitives/SearchInput.svelte';
   import FileNode from './FileNode.svelte';
   import FolderNode from './FolderNode.svelte';
@@ -11,6 +11,7 @@
   interface Props {
     vaultName: string;
     daemonLabel: string;
+    daemonStatus?: 'open' | 'connecting' | 'closed' | 'error';
     colorMode?: 'light' | 'dark';
     searchValue?: string;
     tree: LocalTreeNode[];
@@ -31,6 +32,7 @@
   let {
     vaultName,
     daemonLabel,
+    daemonStatus = 'open',
     colorMode = 'light',
     searchValue = '',
     tree,
@@ -49,6 +51,14 @@
   }: Props = $props();
 
   const searching = $derived(searchValue.trim().length > 0);
+  const dotColor = $derived(
+    daemonStatus === 'open'
+      ? '#1f8a4d'
+      : daemonStatus === 'connecting'
+        ? '#c27a14'
+        : '#c74436',
+  );
+  const dotPulse = $derived(daemonStatus === 'connecting');
 </script>
 
 <aside class="files-panel" aria-label="Vault files">
@@ -56,7 +66,10 @@
     <div class="title-row">
       <div class="vault-title">
         <span>Vault</span>
-        <strong>{vaultName}</strong>
+        <div class="vault-name">
+          <strong>{vaultName}</strong>
+          <LiveDot size={8} color={dotColor} pulse={dotPulse} title={daemonLabel} />
+        </div>
       </div>
       <IconButton
         title={colorMode === 'dark' ? 'Use light mode' : 'Use dark mode'}
@@ -67,7 +80,6 @@
         <Icon name={colorMode === 'dark' ? 'sun' : 'moon'} size={14} />
       </IconButton>
     </div>
-    <LiveStatusChip label={daemonLabel} />
     <SearchInput
       value={searchValue}
       placeholder="Search files"
@@ -156,6 +168,13 @@
     font-weight: 650;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .vault-name {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    gap: 7px;
   }
 
   .panel-body {

--- a/packages/ui/src/lib/local-editor/LocalEditorShell.svelte
+++ b/packages/ui/src/lib/local-editor/LocalEditorShell.svelte
@@ -6,6 +6,7 @@
   interface Props {
     vaultName: string;
     daemonLabel: string;
+    daemonStatus?: 'open' | 'connecting' | 'closed' | 'error';
     documentPath: string;
     colorMode?: 'light' | 'dark';
     searchValue?: string;
@@ -27,6 +28,7 @@
   let {
     vaultName,
     daemonLabel,
+    daemonStatus = 'open',
     documentPath,
     colorMode = 'light',
     searchValue = '',
@@ -50,6 +52,7 @@
   <FilesPanel
     {vaultName}
     {daemonLabel}
+    {daemonStatus}
     {colorMode}
     {searchValue}
     {tree}

--- a/packages/ui/src/lib/primitives/LiveDot.svelte
+++ b/packages/ui/src/lib/primitives/LiveDot.svelte
@@ -15,6 +15,7 @@
   style="width: {size}px; height: {size}px; background: {color};"
   role={title ? 'img' : undefined}
   aria-label={title}
+  title={title}
 ></span>
 
 <style>

--- a/packages/ui/src/lib/stories/LocalEditorShellDemo.svelte
+++ b/packages/ui/src/lib/stories/LocalEditorShellDemo.svelte
@@ -12,6 +12,7 @@
 <LocalEditorShell
   vaultName="demo-vault"
   daemonLabel="Daemon · live"
+  daemonStatus="open"
   documentPath={localEditorDocumentPath}
   colorMode="light"
   tree={localEditorTreeFixture}


### PR DESCRIPTION
## Changes

- Replaces the shared local editor status text pill with a minimal status dot near the vault name.
- Adds accessible title/aria text to the dot while keeping the visible chrome text-free.
- Passes the dot status from the local daemon editor so local parity matches the cloud editor.
- Documents the Cloud 004 demo no-reflow save exception in the edits-save-or-fail-loudly invariant with an explicit expiry before real use.

## Verification

- pnpm --filter @kb-2/ui typecheck
- pnpm --filter @kb-2/web build
- Also consumed by metatheoryinc/kb-1-cloud#18 as a submodule pointer.