### PR TITLE
Cloud 005 Phase A: presence cursor anchoring hook in @kb-2/editor

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -32,6 +32,7 @@
     "@lezer/highlight": "1.2.3",
     "@lezer/markdown": "1.6.3",
     "svelte": "catalog:",
+    "y-protocols": "1.0.7",
     "yjs": "13.6.31"
   },
   "devDependencies": {

--- a/packages/editor/src/lib/PlaintextEditor.svelte
+++ b/packages/editor/src/lib/PlaintextEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { Doc } from 'yjs';
+  import type { Awareness } from 'y-protocols/awareness';
   import * as Y from 'yjs';
   import {
     EditorState,
@@ -32,12 +33,20 @@
   import { plaintextMentionKeymap } from './plaintext-mention-keymap';
   import { plaintextListKeymap } from './plaintext-list-keymap';
   import { plaintextLinkPaste } from './plaintext-link-paste';
+  import {
+    plaintextCursorConsumer,
+    plaintextCursorProducer,
+  } from './plaintext-awareness';
 
   interface Props {
     /** Shared Y.Doc supplied by the host app/provider. */
     ydoc: Doc;
     /** Bound Y.Text supplied by the host app/provider. */
     ytext: Y.Text;
+    /** Stable document identity for host-supplied collaborative awareness. */
+    noteId?: string;
+    /** Host-supplied Yjs awareness. The editor package never creates transport. */
+    awareness?: Awareness;
     /** Disables typing. Mirror of MarkdownEditor's prop. */
     readOnly?: boolean;
     /** Accessibility label for the editor host. */
@@ -95,6 +104,8 @@
   let {
     ydoc,
     ytext,
+    noteId = '',
+    awareness,
     readOnly = false,
     ariaLabel = 'Markdown editor',
     class: className,
@@ -159,6 +170,8 @@
       handler(encoded, event);
     };
     const stableText = ytext;
+    const stableNoteId = noteId;
+    const stableAwareness = awareness;
 
     // --- Sync plugin (replaces y-codemirror.next's `ySync`) ---------
     //
@@ -368,6 +381,12 @@
       editableCompartment.of(EditorView.editable.of(!readOnly)),
       documentTheme,
       plaintextSync,
+      ...(stableAwareness
+        ? [
+            plaintextCursorProducer(stableAwareness, stableText, stableNoteId),
+            plaintextCursorConsumer(stableAwareness, stableText, stableNoteId),
+          ]
+        : []),
       // Live-preview-style markdown decorations. They are document +
       // selection driven and compose through EditorView.decorations:
       // line decos wrap the line element, mark decos wrap their range,

--- a/packages/editor/src/lib/index.ts
+++ b/packages/editor/src/lib/index.ts
@@ -4,4 +4,15 @@ export {
   PLAINTEXT_USER_ORIGIN,
 } from './content-format';
 export type { LivePath, OrgPerson } from './markdown-core';
-
+export {
+  buildPlaintextCursorDecorations,
+  decodePlaintextCursor,
+  encodePlaintextRelativePosition,
+  plaintextCursorConsumer,
+  plaintextCursorProducer,
+  resolvePlaintextRelativePosition,
+  snapshotRemotePlaintextCursors,
+  type EncodedRelPos,
+  type PlaintextAwarenessCursor,
+  type RemotePlaintextCursor,
+} from './plaintext-awareness';

--- a/packages/editor/src/lib/plaintext-awareness.test.ts
+++ b/packages/editor/src/lib/plaintext-awareness.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+import type { DecorationSet } from '@codemirror/view';
+import { Awareness, applyAwarenessUpdate, encodeAwarenessUpdate } from 'y-protocols/awareness';
+import * as Y from 'yjs';
+import {
+  buildPlaintextCursorDecorations,
+  encodePlaintextRelativePosition,
+  resolvePlaintextRelativePosition,
+  snapshotRemotePlaintextCursors,
+  type PlaintextAwarenessCursor,
+} from './plaintext-awareness';
+
+function seedDoc(text: string) {
+  const doc = new Y.Doc();
+  const ytext = doc.getText('markdown');
+  ytext.insert(0, text);
+  return { doc, ytext };
+}
+
+function syncedPeer(initial: string) {
+  const local = seedDoc(initial);
+  const remoteDoc = new Y.Doc();
+  Y.applyUpdate(remoteDoc, Y.encodeStateAsUpdate(local.doc));
+  const remoteText = remoteDoc.getText('markdown');
+  const localAwareness = new Awareness(local.doc);
+  const remoteAwareness = new Awareness(remoteDoc);
+  remoteAwareness.setLocalStateField('user', {
+    userId: 'peer-1',
+    name: 'Peer One',
+    color: '#3366ff',
+  });
+  return { ...local, localAwareness, remoteDoc, remoteText, remoteAwareness };
+}
+
+function applyRemoteAwareness(
+  localAwareness: Awareness,
+  remoteAwareness: Awareness,
+): void {
+  applyAwarenessUpdate(
+    localAwareness,
+    encodeAwarenessUpdate(remoteAwareness, [remoteAwareness.clientID]),
+    'test',
+  );
+}
+
+function publishRemoteCursor(args: {
+  localAwareness: Awareness;
+  remoteAwareness: Awareness;
+  remoteText: Y.Text;
+  noteId: string;
+  anchor: number;
+  head: number;
+}): void {
+  const cursor: PlaintextAwarenessCursor = {
+    kind: 'plaintext',
+    noteId: args.noteId,
+    anchor: encodePlaintextRelativePosition(args.remoteText, args.anchor),
+    head: encodePlaintextRelativePosition(args.remoteText, args.head),
+  };
+  args.remoteAwareness.setLocalStateField('cursor', cursor);
+  applyRemoteAwareness(args.localAwareness, args.remoteAwareness);
+}
+
+function decorationRanges(decos: DecorationSet): {
+  from: number;
+  to: number;
+  className: string | undefined;
+  hasWidget: boolean;
+}[] {
+  const ranges: {
+    from: number;
+    to: number;
+    className: string | undefined;
+    hasWidget: boolean;
+  }[] = [];
+  const cursor = decos.iter();
+  while (cursor.value !== null) {
+    const spec = cursor.value.spec as {
+      class?: string;
+      widget?: unknown;
+    };
+    ranges.push({
+      from: cursor.from,
+      to: cursor.to,
+      className: spec.class,
+      hasWidget: spec.widget !== undefined,
+    });
+    cursor.next();
+  }
+  return ranges;
+}
+
+describe('plaintext awareness relative positions', () => {
+  it('round-trips a Y.RelativePosition through JSON against a real Y.Text', () => {
+    const { ytext } = seedDoc('abcdef');
+    const encoded = encodePlaintextRelativePosition(ytext, 3);
+
+    expect(resolvePlaintextRelativePosition(ytext, encoded)).toBe(3);
+  });
+
+  it('keeps a remote caret anchored to the same logical character after an insert before it', () => {
+    const ctx = syncedPeer('abcdef');
+    publishRemoteCursor({
+      localAwareness: ctx.localAwareness,
+      remoteAwareness: ctx.remoteAwareness,
+      remoteText: ctx.remoteText,
+      noteId: 'note-a',
+      anchor: 3,
+      head: 3,
+    });
+
+    ctx.ytext.insert(0, 'XYZ');
+
+    const peers = snapshotRemotePlaintextCursors(
+      ctx.localAwareness,
+      ctx.ytext,
+      'note-a',
+    );
+    expect(peers).toHaveLength(1);
+    expect(peers[0]?.head).toBe(6);
+    expect(ctx.ytext.toString()[peers[0]?.head ?? -1]).toBe('d');
+
+    const decos = buildPlaintextCursorDecorations(
+      ctx.localAwareness,
+      ctx.ytext,
+      ctx.ytext.length,
+      'note-a',
+    );
+    expect(decorationRanges(decos)).toEqual([
+      {
+        from: 6,
+        to: 6,
+        className: undefined,
+        hasWidget: true,
+      },
+    ]);
+  });
+
+  it('renders a translucent selection mark plus a caret widget for a remote range', () => {
+    const ctx = syncedPeer('abcdef');
+    publishRemoteCursor({
+      localAwareness: ctx.localAwareness,
+      remoteAwareness: ctx.remoteAwareness,
+      remoteText: ctx.remoteText,
+      noteId: 'note-a',
+      anchor: 2,
+      head: 5,
+    });
+
+    const decos = buildPlaintextCursorDecorations(
+      ctx.localAwareness,
+      ctx.ytext,
+      ctx.ytext.length,
+      'note-a',
+    );
+
+    expect(decorationRanges(decos)).toEqual([
+      {
+        from: 2,
+        to: 5,
+        className: 'cm-plaintext-peer-selection',
+        hasWidget: false,
+      },
+      {
+        from: 5,
+        to: 5,
+        className: undefined,
+        hasWidget: true,
+      },
+    ]);
+  });
+
+  it('filters remote plaintext cursors by noteId', () => {
+    const ctx = syncedPeer('abcdef');
+    publishRemoteCursor({
+      localAwareness: ctx.localAwareness,
+      remoteAwareness: ctx.remoteAwareness,
+      remoteText: ctx.remoteText,
+      noteId: 'note-b',
+      anchor: 3,
+      head: 3,
+    });
+
+    expect(
+      snapshotRemotePlaintextCursors(ctx.localAwareness, ctx.ytext, 'note-a'),
+    ).toEqual([]);
+    expect(
+      snapshotRemotePlaintextCursors(ctx.localAwareness, ctx.ytext, 'note-b'),
+    ).toHaveLength(1);
+  });
+
+  it('drops a malformed remote RelPos without throwing', () => {
+    const ctx = syncedPeer('abcdef');
+    ctx.remoteAwareness.setLocalStateField('cursor', {
+      kind: 'plaintext',
+      noteId: 'note-a',
+      anchor: { malformed: true },
+      head: encodePlaintextRelativePosition(ctx.remoteText, 3),
+    });
+    applyRemoteAwareness(ctx.localAwareness, ctx.remoteAwareness);
+
+    expect(() =>
+      buildPlaintextCursorDecorations(
+        ctx.localAwareness,
+        ctx.ytext,
+        ctx.ytext.length,
+        'note-a',
+      ),
+    ).not.toThrow();
+    expect(
+      snapshotRemotePlaintextCursors(ctx.localAwareness, ctx.ytext, 'note-a'),
+    ).toEqual([]);
+  });
+});

--- a/packages/editor/src/lib/plaintext-awareness.ts
+++ b/packages/editor/src/lib/plaintext-awareness.ts
@@ -1,0 +1,427 @@
+import {
+  Decoration,
+  EditorView,
+  ViewPlugin,
+  WidgetType,
+  type DecorationSet,
+  type PluginValue,
+  type ViewUpdate,
+} from '@codemirror/view';
+import {
+  RangeSetBuilder,
+  StateEffect,
+  StateField,
+  type Extension,
+} from '@codemirror/state';
+import { accentHexForId } from '@kb-2/ui';
+import type { Awareness } from 'y-protocols/awareness';
+import * as Y from 'yjs';
+
+export type EncodedRelPos = unknown;
+
+export interface PlaintextAwarenessCursor {
+  kind: 'plaintext';
+  noteId: string;
+  anchor: EncodedRelPos;
+  head: EncodedRelPos;
+}
+
+interface DecodedPlaintextCursor {
+  noteId: string | null;
+  anchor: EncodedRelPos;
+  head: EncodedRelPos;
+}
+
+export interface RemotePlaintextCursor {
+  clientID: number;
+  userId: string | null;
+  color: string;
+  name: string | null;
+  anchor: number;
+  head: number;
+}
+
+function isDevEnvironment(): boolean {
+  const meta = import.meta as ImportMeta & {
+    env?: { DEV?: boolean; MODE?: string };
+  };
+  return meta.env?.DEV === true || meta.env?.MODE === 'development';
+}
+
+function warnMalformedPlaintextCursor(clientID: number, reason: string): void {
+  if (!isDevEnvironment()) return;
+  console.warn(
+    `[kb-2/editor] dropped malformed plaintext awareness cursor for client ${clientID}: ${reason}`,
+  );
+}
+
+export function encodePlaintextRelativePosition(
+  ytext: Y.Text,
+  index: number,
+): EncodedRelPos {
+  const clamped = Math.max(0, Math.min(index, ytext.length));
+  return Y.relativePositionToJSON(
+    Y.createRelativePositionFromTypeIndex(ytext, clamped),
+  );
+}
+
+export function resolvePlaintextRelativePosition(
+  ytext: Y.Text,
+  encoded: EncodedRelPos,
+): number | null {
+  const doc = ytext.doc;
+  if (!doc) return null;
+  let relPos: Y.RelativePosition;
+  try {
+    relPos = Y.createRelativePositionFromJSON(
+      encoded as Parameters<typeof Y.createRelativePositionFromJSON>[0],
+    );
+  } catch {
+    return null;
+  }
+  let abs: ReturnType<typeof Y.createAbsolutePositionFromRelativePosition>;
+  try {
+    abs = Y.createAbsolutePositionFromRelativePosition(relPos, doc);
+  } catch {
+    return null;
+  }
+  if (abs === null) return null;
+  if (abs.type !== ytext) return null;
+  if (!Number.isInteger(abs.index) || abs.index < 0) return null;
+  return abs.index;
+}
+
+export function decodePlaintextCursor(
+  raw: unknown,
+): DecodedPlaintextCursor | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as {
+    kind?: unknown;
+    noteId?: unknown;
+    anchor?: unknown;
+    head?: unknown;
+  };
+  if (obj.kind !== 'plaintext') return null;
+  if (!obj.anchor || typeof obj.anchor !== 'object') return null;
+  if (!obj.head || typeof obj.head !== 'object') return null;
+  return {
+    noteId: typeof obj.noteId === 'string' ? obj.noteId : null,
+    anchor: obj.anchor,
+    head: obj.head,
+  };
+}
+
+function resolvePlaintextCursor(
+  ytext: Y.Text,
+  encoded: { anchor: EncodedRelPos; head: EncodedRelPos },
+): { anchor: number; head: number } | null {
+  const anchor = resolvePlaintextRelativePosition(ytext, encoded.anchor);
+  const head = resolvePlaintextRelativePosition(ytext, encoded.head);
+  if (anchor === null || head === null) return null;
+  return { anchor, head };
+}
+
+function focusNoteId(state: { focus?: unknown }): string | null {
+  const focus = state.focus;
+  if (!focus || typeof focus !== 'object') return null;
+  const f = focus as { kind?: unknown; noteId?: unknown };
+  if (f.kind !== 'note') return null;
+  return typeof f.noteId === 'string' ? f.noteId : null;
+}
+
+export function snapshotRemotePlaintextCursors(
+  awareness: Awareness,
+  ytext: Y.Text,
+  noteId: string,
+): RemotePlaintextCursor[] {
+  const rows: RemotePlaintextCursor[] = [];
+  const localId = awareness.clientID;
+
+  for (const [clientID, state] of awareness.getStates()) {
+    if (clientID === localId) continue;
+    const s = state as {
+      user?: {
+        userId?: string;
+        id?: string;
+        color?: string;
+        name?: string;
+      };
+      color?: string;
+      name?: string;
+      cursor?: unknown;
+      focus?: unknown;
+    };
+    const encoded = decodePlaintextCursor(s.cursor);
+    if (encoded === null) continue;
+
+    const peerNoteId = encoded.noteId ?? focusNoteId(s);
+    if (peerNoteId !== noteId) continue;
+
+    const resolved = resolvePlaintextCursor(ytext, encoded);
+    if (resolved === null) {
+      warnMalformedPlaintextCursor(clientID, 'relative position did not resolve');
+      continue;
+    }
+
+    const userId =
+      typeof s.user?.userId === 'string'
+        ? s.user.userId
+        : typeof s.user?.id === 'string'
+          ? s.user.id
+          : null;
+    const name =
+      typeof s.user?.name === 'string'
+        ? s.user.name
+        : typeof s.name === 'string'
+          ? s.name
+          : null;
+    const color =
+      typeof s.user?.color === 'string'
+        ? s.user.color
+        : typeof s.color === 'string'
+          ? s.color
+          : accentHexForId(userId ?? String(clientID));
+
+    rows.push({
+      clientID,
+      userId,
+      color,
+      name,
+      anchor: resolved.anchor,
+      head: resolved.head,
+    });
+  }
+
+  return rows;
+}
+
+export function plaintextCursorProducer(
+  awareness: Awareness,
+  ytext: Y.Text,
+  noteId: string,
+): Extension {
+  return ViewPlugin.fromClass(
+    class implements PluginValue {
+      constructor(view: EditorView) {
+        this.publish(view);
+      }
+
+      update(update: ViewUpdate): void {
+        if (update.selectionSet || update.docChanged) {
+          this.publish(update.view);
+        }
+      }
+
+      destroy(): void {
+        awareness.setLocalStateField('cursor', null);
+      }
+
+      private publish(view: EditorView): void {
+        const sel = view.state.selection.main;
+        const payload: PlaintextAwarenessCursor = {
+          kind: 'plaintext',
+          noteId,
+          anchor: encodePlaintextRelativePosition(ytext, sel.anchor),
+          head: encodePlaintextRelativePosition(ytext, sel.head),
+        };
+        awareness.setLocalStateField('cursor', payload);
+      }
+    },
+  );
+}
+
+class PlaintextCaretWidget extends WidgetType {
+  constructor(
+    readonly color: string,
+    readonly userId: string | null,
+    readonly name: string | null,
+  ) {
+    super();
+  }
+
+  eq(other: WidgetType): boolean {
+    return (
+      other instanceof PlaintextCaretWidget &&
+      other.color === this.color &&
+      other.userId === this.userId &&
+      other.name === this.name
+    );
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement('span');
+    el.className = 'cm-plaintext-peer-caret';
+    el.setAttribute(
+      'style',
+      `position:relative;display:inline-block;width:0;border-left:2px solid ${this.color};margin-left:-1px;height:1.2em;vertical-align:text-bottom;pointer-events:none;`,
+    );
+    if (this.userId) el.dataset.userId = this.userId;
+    if (this.name) {
+      const label = document.createElement('span');
+      label.className = 'cm-plaintext-peer-label';
+      label.setAttribute(
+        'style',
+        `position:absolute;left:-2px;top:-1.4em;background:${this.color};color:white;padding:1px 4px;border-radius:3px;font-size:11px;font-weight:500;white-space:nowrap;pointer-events:none;line-height:1.2;font-family:system-ui,sans-serif;`,
+      );
+      label.textContent = this.name;
+      el.appendChild(label);
+    }
+    return el;
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+export function buildPlaintextCursorDecorations(
+  awareness: Awareness,
+  ytext: Y.Text,
+  docLength: number,
+  noteId: string,
+): DecorationSet {
+  const peers = snapshotRemotePlaintextCursors(awareness, ytext, noteId);
+  type DecoItem =
+    | { kind: 'mark'; from: number; to: number; color: string }
+    | {
+        kind: 'widget';
+        pos: number;
+        color: string;
+        userId: string | null;
+        name: string | null;
+      };
+  const items: DecoItem[] = [];
+
+  for (const peer of peers) {
+    const anchor = Math.max(0, Math.min(peer.anchor, docLength));
+    const head = Math.max(0, Math.min(peer.head, docLength));
+    if (anchor !== head) {
+      items.push({
+        kind: 'mark',
+        from: Math.min(anchor, head),
+        to: Math.max(anchor, head),
+        color: peer.color,
+      });
+    }
+    items.push({
+      kind: 'widget',
+      pos: head,
+      color: peer.color,
+      userId: peer.userId,
+      name: peer.name,
+    });
+  }
+
+  items.sort((a, b) => {
+    const aPos = a.kind === 'mark' ? a.from : a.pos;
+    const bPos = b.kind === 'mark' ? b.from : b.pos;
+    if (aPos !== bPos) return aPos - bPos;
+    if (a.kind === 'widget' && b.kind === 'mark') return -1;
+    if (a.kind === 'mark' && b.kind === 'widget') return 1;
+    return 0;
+  });
+
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const item of items) {
+    if (item.kind === 'mark') {
+      builder.add(
+        item.from,
+        item.to,
+        Decoration.mark({
+          class: 'cm-plaintext-peer-selection',
+          attributes: { style: `background-color: ${item.color}33;` },
+        }),
+      );
+      continue;
+    }
+    builder.add(
+      item.pos,
+      item.pos,
+      Decoration.widget({
+        widget: new PlaintextCaretWidget(item.color, item.userId, item.name),
+        side: 1,
+      }),
+    );
+  }
+  return builder.finish();
+}
+
+const setPlaintextCursorDecorations = StateEffect.define<DecorationSet>();
+
+function plaintextCursorDecorationsField(
+  awareness: Awareness,
+  ytext: Y.Text,
+  noteId: string,
+): StateField<DecorationSet> {
+  return StateField.define<DecorationSet>({
+    create(state) {
+      return buildPlaintextCursorDecorations(
+        awareness,
+        ytext,
+        state.doc.length,
+        noteId,
+      );
+    },
+    update(value, tr) {
+      for (const effect of tr.effects) {
+        if (effect.is(setPlaintextCursorDecorations)) {
+          return effect.value;
+        }
+      }
+      if (tr.docChanged) {
+        return buildPlaintextCursorDecorations(
+          awareness,
+          ytext,
+          tr.state.doc.length,
+          noteId,
+        );
+      }
+      return value;
+    },
+    provide: (f) => EditorView.decorations.from(f),
+  });
+}
+
+export function plaintextCursorConsumer(
+  awareness: Awareness,
+  ytext: Y.Text,
+  noteId: string,
+): Extension {
+  return [
+    plaintextCursorDecorationsField(awareness, ytext, noteId),
+    ViewPlugin.fromClass(
+      class implements PluginValue {
+        private off: (() => void) | null = null;
+
+        constructor(view: EditorView) {
+          let destroyed = false;
+          const handler = (): void => {
+            queueMicrotask(() => {
+              if (destroyed) return;
+              view.dispatch({
+                effects: setPlaintextCursorDecorations.of(
+                  buildPlaintextCursorDecorations(
+                    awareness,
+                    ytext,
+                    view.state.doc.length,
+                    noteId,
+                  ),
+                ),
+              });
+            });
+          };
+          awareness.on('change', handler);
+          this.off = () => {
+            destroyed = true;
+            awareness.off('change', handler);
+          };
+        }
+
+        destroy(): void {
+          this.off?.();
+          this.off = null;
+        }
+      },
+    ),
+  ];
+}

--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       formats: ['es']
     },
     rollupOptions: {
-      external: ['svelte', 'yjs', '@kb-2/ui']
+      external: ['svelte', 'yjs', 'y-protocols/awareness', '@kb-2/ui']
     }
   },
   test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,9 @@ importers:
       svelte:
         specifier: 'catalog:'
         version: 5.55.5
+      y-protocols:
+        specifier: 1.0.7
+        version: 1.0.7(yjs@13.6.31)
       yjs:
         specifier: 13.6.31
         version: 13.6.31


### PR DESCRIPTION
## Summary
- Add @kb-2/editor plaintext awareness producer/consumer using Yjs relative positions and CM6 decorations.
- Wire optional PlaintextEditor awareness/noteId props without changing behavior when awareness is omitted.
- Add real Yjs/y-protocols unit tests for RelPos round-trip, insert-before anchoring, noteId filtering, selection decoration, and malformed peer cursor drops.

## Verification
- pnpm --filter @kb-2/editor test
- pnpm --filter @kb-2/editor typecheck
- pnpm --filter @kb-2/editor build
- pnpm nx run-many -t typecheck,test,build --skip-nx-cache