### PR TITLE
Cloud 006: shared editor save-notifications in @kb-2/ui (no-reflow) + parity invariant

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -12,7 +12,7 @@
   import { PlaintextEditor, type LivePath, type OrgPerson } from '@kb-2/editor';
   import {
     DocumentNotFoundState,
-    DocumentSaveBanner,
+    EditorSaveNotifications,
     LocalEditorShell,
     type AccentName,
     type LocalSearchResult,
@@ -75,6 +75,25 @@
   ]);
 
   const orgPeople: OrgPerson[] = [];
+
+  const editorSaveNotificationCopy = {
+    externalMerge: {
+      title: 'External edit merged',
+      message: 'Merged an edit made outside KB-2.',
+    },
+    externalChange: {
+      title: 'File changed outside KB-2',
+      message: 'This file changed outside KB-2 and was reloaded from disk.',
+    },
+    persistFailure: {
+      title: 'Changes are NOT saving to disk.',
+      message: 'Keep this tab open. KB-2 will keep retrying until saving recovers.',
+    },
+    docDeleted: {
+      title: 'Document deleted',
+      message: 'This file was deleted or moved to trash. The editor is read-only.',
+    },
+  };
 
   const daemonLabel = $derived(
     status === 'open'
@@ -529,57 +548,24 @@
     void handleTreeAction(action);
   }}
 >
-  {#if externalMergeVisible || externalChangeVisible || persistFailureActive || persistRecoveredVisible || docDeleted}
-    <section class="banner-strip" aria-label="Document save notifications">
-      {#if externalMergeVisible}
-        <DocumentSaveBanner
-          variant="external-merge"
-          title="External edit merged"
-          message="Merged an edit made outside KB-2."
-          ondismiss={() => {
-            externalMergeVisible = false;
-            if (externalMergeTimer) {
-              clearTimeout(externalMergeTimer);
-              externalMergeTimer = undefined;
-            }
-          }}
-        />
-      {/if}
-
-      {#if externalChangeVisible}
-        <DocumentSaveBanner
-          variant="external-change"
-          title="File changed outside KB-2"
-          message="This file changed outside KB-2 and was reloaded from disk."
-          ondismiss={() => {
-            externalChangeVisible = false;
-          }}
-        />
-      {/if}
-
-      {#if persistFailureActive}
-        <DocumentSaveBanner
-          variant="persist-failure"
-          title="Changes are NOT saving to disk."
-          message="Keep this tab open. KB-2 will keep retrying until saving recovers."
-        />
-      {:else if persistRecoveredVisible}
-        <DocumentSaveBanner
-          variant="persist-recovered"
-          title="Saving restored"
-          message="KB-2 is saving changes to disk again."
-        />
-      {/if}
-
-      {#if docDeleted}
-        <DocumentSaveBanner
-          variant="doc-deleted"
-          title="Document deleted"
-          message="This file was deleted or moved to trash. The editor is read-only."
-        />
-      {/if}
-    </section>
-  {/if}
+  <EditorSaveNotifications
+    externalMergeVisible={externalMergeVisible}
+    externalChangeVisible={externalChangeVisible}
+    persistFailureActive={persistFailureActive}
+    persistRecoveredVisible={persistRecoveredVisible}
+    docDeleted={docDeleted}
+    copy={editorSaveNotificationCopy}
+    onDismissExternalMerge={() => {
+      externalMergeVisible = false;
+      if (externalMergeTimer) {
+        clearTimeout(externalMergeTimer);
+        externalMergeTimer = undefined;
+      }
+    }}
+    onDismissExternalChange={() => {
+      externalChangeVisible = false;
+    }}
+  />
 
   <section class="document-shell" aria-label="Markdown document">
     {#if notFoundPath === documentPath}
@@ -606,18 +592,6 @@
 </LocalEditorShell>
 
 <style>
-  .banner-strip {
-    display: grid;
-    gap: 8px;
-    padding: 12px 22px 0;
-    background: var(--rd-bg);
-  }
-
-  .banner-strip :global(.document-save-banner) {
-    width: min(100%, 760px);
-    justify-self: center;
-  }
-
   .document-shell {
     min-height: 0;
     height: 100%;
@@ -668,10 +642,6 @@
   @media (max-width: 720px) {
     .document-shell {
       grid-template-columns: 12px minmax(0, 1fr) 12px;
-    }
-
-    .banner-strip {
-      padding: 10px 12px 0;
     }
 
     .error {

--- a/docs/architecture/invariants/README.md
+++ b/docs/architecture/invariants/README.md
@@ -25,6 +25,10 @@ Engineering invariants — how the codebase stays healthy:
 - [Tests are gated and real](./engineering/tests-are-gated-and-real.md)
 - [One failure dialect](./engineering/one-failure-dialect.md)
 
+UI invariants — how shared editor surfaces stay in lockstep:
+
+- [Shared editor chrome](./ui/shared-editor-chrome.md)
+
 ## How To Read These
 
 Each invariant should stay short and concrete:

--- a/docs/architecture/invariants/ui/shared-editor-chrome.md
+++ b/docs/architecture/invariants/ui/shared-editor-chrome.md
@@ -1,0 +1,41 @@
+# Shared Editor Chrome
+
+## Invariant
+
+Shared editor chrome (status indicator, save notifications, presence
+affordances, page shell) lives in `@kb-2/ui` and is consumed by every app that
+renders the editor.
+
+An app MUST NOT fork chrome behavior locally. Any intentional divergence between
+consuming apps is a documented exception in this file with a reason and expiry.
+A PR that changes editor chrome in one app without routing it through
+`@kb-2/ui` or recording an exception here is a violation.
+
+## This Means
+
+- Save-notification layout, stacking, visibility policy, and dismissal affordance
+  are shared UI behavior, not app-local route markup.
+- Apps may supply product-specific copy through props.
+- Apps may own transport state, event sources, and callbacks that feed shared
+  chrome.
+
+## Documented Divergence
+
+- Presence cursors and roster are cloud-only. The local product has no presence
+  by settled decision. No expiry.
+
+## Violations
+
+- Recreating save-notification strips in an app route.
+- Changing the editor status indicator, notification behavior, or page shell in
+  one app without a shared `@kb-2/ui` component change.
+- Hardcoding local-only or cloud-only copy inside shared chrome instead of
+  passing it from the consuming app.
+
+## Review Checklist
+
+- Does editor chrome live in `@kb-2/ui`?
+- Are app differences limited to props, callbacks, or documented exceptions?
+- Do shared chrome components still satisfy
+  [UI packages own no transport](../engineering/ui-packages-own-no-transport.md)?
+- Does new semantic chrome have a Storybook story?

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -24,6 +24,7 @@ export { default as LocalStatusShell } from './layout/LocalStatusShell.svelte';
 export type { DaemonStatus, HealthResponse } from './layout/LocalStatusShell.svelte';
 export { default as DocumentSaveBanner } from './notifications/DocumentSaveBanner.svelte';
 export { default as DocumentHeader } from './local-editor/DocumentHeader.svelte';
+export { default as EditorSaveNotifications } from './local-editor/EditorSaveNotifications.svelte';
 export { default as DocumentNotFoundState } from './local-editor/DocumentNotFoundState.svelte';
 export { default as FileNode } from './local-editor/FileNode.svelte';
 export { default as FilesPanel } from './local-editor/FilesPanel.svelte';
@@ -44,6 +45,13 @@ export type {
   DocumentSaveBannerProps,
   DocumentSaveBannerVariant,
 } from './notifications/DocumentSaveBanner.svelte';
+export type { EditorSaveNotificationsProps } from './local-editor/EditorSaveNotifications.svelte';
+export type {
+  EditorSaveNotificationCopy,
+  EditorSaveNotificationFlags,
+  EditorSaveNotificationsCopy,
+  EditorSaveNotificationVariant,
+} from './local-editor/editor-save-notifications';
 export {
   accentForId,
   accentHex,

--- a/packages/ui/src/lib/local-editor/EditorSaveNotifications.stories.ts
+++ b/packages/ui/src/lib/local-editor/EditorSaveNotifications.stories.ts
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import EditorSaveNotifications, {
+  type EditorSaveNotificationsProps,
+} from './EditorSaveNotifications.svelte';
+
+const noop = () => undefined;
+
+const localCopy = {
+  externalMerge: {
+    title: 'External edit merged',
+    message: 'Merged an edit made outside KB-2.',
+  },
+  externalChange: {
+    title: 'File changed outside KB-2',
+    message: 'This file changed outside KB-2 and was reloaded from disk.',
+  },
+  persistFailure: {
+    title: 'Changes are NOT saving to disk.',
+    message: 'Keep this tab open. KB-2 will keep retrying until saving recovers.',
+  },
+  docDeleted: {
+    title: 'Document deleted',
+    message: 'This file was deleted or moved to trash. The editor is read-only.',
+  },
+} satisfies EditorSaveNotificationsProps['copy'];
+
+const meta = {
+  title: 'App/Local Editor/Editor Save Notifications',
+  component: EditorSaveNotifications,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    externalMergeVisible: true,
+    externalChangeVisible: false,
+    persistFailureActive: false,
+    persistRecoveredVisible: false,
+    docDeleted: false,
+    copy: localCopy,
+    onDismissExternalMerge: noop,
+    onDismissExternalChange: noop,
+  },
+} satisfies Meta<typeof EditorSaveNotifications>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ExternalMerge: Story = {};
+
+export const ExternalChange: Story = {
+  args: {
+    externalMergeVisible: false,
+    externalChangeVisible: true,
+  },
+};
+
+export const PersistFailure: Story = {
+  args: {
+    externalMergeVisible: false,
+    persistFailureActive: true,
+  },
+};
+
+export const DocDeleted: Story = {
+  args: {
+    externalMergeVisible: false,
+    docDeleted: true,
+  },
+};
+
+export const Stack: Story = {
+  args: {
+    externalChangeVisible: true,
+    persistFailureActive: true,
+    docDeleted: true,
+  },
+};
+
+export const PersistRecoveredSuppressed: Story = {
+  args: {
+    externalMergeVisible: false,
+    persistRecoveredVisible: true,
+  },
+};

--- a/packages/ui/src/lib/local-editor/EditorSaveNotifications.svelte
+++ b/packages/ui/src/lib/local-editor/EditorSaveNotifications.svelte
@@ -1,0 +1,99 @@
+<script lang="ts" module>
+  import type {
+    EditorSaveNotificationFlags,
+    EditorSaveNotificationsCopy,
+  } from './editor-save-notifications';
+
+  export interface EditorSaveNotificationsProps extends EditorSaveNotificationFlags {
+    copy: EditorSaveNotificationsCopy;
+    onDismissExternalMerge?: () => void;
+    onDismissExternalChange?: () => void;
+  }
+</script>
+
+<script lang="ts">
+  import DocumentSaveBanner from '../notifications/DocumentSaveBanner.svelte';
+  import { getVisibleEditorSaveNotificationVariants } from './editor-save-notifications';
+
+  let {
+    externalMergeVisible,
+    externalChangeVisible,
+    persistFailureActive,
+    persistRecoveredVisible,
+    docDeleted,
+    copy,
+    onDismissExternalMerge,
+    onDismissExternalChange,
+  }: EditorSaveNotificationsProps = $props();
+
+  const visibleVariants = $derived(
+    getVisibleEditorSaveNotificationVariants({
+      externalMergeVisible,
+      externalChangeVisible,
+      persistFailureActive,
+      persistRecoveredVisible,
+      docDeleted,
+    }),
+  );
+</script>
+
+{#if visibleVariants.length > 0}
+  <section class="notification-stack" aria-label="Document save notifications">
+    {#each visibleVariants as variant}
+      {#if variant === 'external-merge'}
+        <DocumentSaveBanner
+          variant="external-merge"
+          title={copy.externalMerge.title}
+          message={copy.externalMerge.message}
+          dismissLabel={copy.externalMerge.dismissLabel}
+          ondismiss={onDismissExternalMerge}
+        />
+      {:else if variant === 'external-change'}
+        <DocumentSaveBanner
+          variant="external-change"
+          title={copy.externalChange.title}
+          message={copy.externalChange.message}
+          dismissLabel={copy.externalChange.dismissLabel}
+          ondismiss={onDismissExternalChange}
+        />
+      {:else if variant === 'persist-failure'}
+        <DocumentSaveBanner
+          variant="persist-failure"
+          title={copy.persistFailure.title}
+          message={copy.persistFailure.message}
+        />
+      {:else if variant === 'doc-deleted'}
+        <DocumentSaveBanner
+          variant="doc-deleted"
+          title={copy.docDeleted.title}
+          message={copy.docDeleted.message}
+        />
+      {/if}
+    {/each}
+  </section>
+{/if}
+
+<style>
+  .notification-stack {
+    position: fixed;
+    top: 14px;
+    right: 16px;
+    z-index: 40;
+    display: grid;
+    gap: 8px;
+    width: min(420px, calc(100vw - 32px));
+    pointer-events: none;
+  }
+
+  .notification-stack :global(.document-save-banner) {
+    pointer-events: auto;
+  }
+
+  @media (max-width: 720px) {
+    .notification-stack {
+      top: 10px;
+      right: 10px;
+      width: calc(100vw - 20px);
+    }
+  }
+</style>

--- a/packages/ui/src/lib/local-editor/editor-save-notifications.test.ts
+++ b/packages/ui/src/lib/local-editor/editor-save-notifications.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { getVisibleEditorSaveNotificationVariants } from './editor-save-notifications';
+
+describe('editor save notification policy', () => {
+  it('returns visible variants in stable chrome order', () => {
+    expect(getVisibleEditorSaveNotificationVariants({
+      externalMergeVisible: true,
+      externalChangeVisible: true,
+      persistFailureActive: true,
+      persistRecoveredVisible: false,
+      docDeleted: true,
+    })).toEqual(['external-merge', 'external-change', 'persist-failure', 'doc-deleted']);
+  });
+
+  it('suppresses persist-recovered even when the flag is visible', () => {
+    expect(getVisibleEditorSaveNotificationVariants({
+      externalMergeVisible: false,
+      externalChangeVisible: false,
+      persistFailureActive: false,
+      persistRecoveredVisible: true,
+      docDeleted: false,
+    })).toEqual([]);
+  });
+});

--- a/packages/ui/src/lib/local-editor/editor-save-notifications.ts
+++ b/packages/ui/src/lib/local-editor/editor-save-notifications.ts
@@ -1,0 +1,37 @@
+import type { DocumentSaveBannerVariant } from '../notifications/DocumentSaveBanner.svelte';
+
+export type EditorSaveNotificationVariant = Exclude<DocumentSaveBannerVariant, 'persist-recovered'>;
+
+export interface EditorSaveNotificationCopy {
+  title: string;
+  message: string;
+  dismissLabel?: string;
+}
+
+export interface EditorSaveNotificationsCopy {
+  externalMerge: EditorSaveNotificationCopy;
+  externalChange: EditorSaveNotificationCopy;
+  persistFailure: EditorSaveNotificationCopy;
+  docDeleted: EditorSaveNotificationCopy;
+}
+
+export interface EditorSaveNotificationFlags {
+  externalMergeVisible: boolean;
+  externalChangeVisible: boolean;
+  persistFailureActive: boolean;
+  persistRecoveredVisible: boolean;
+  docDeleted: boolean;
+}
+
+export function getVisibleEditorSaveNotificationVariants(
+  flags: EditorSaveNotificationFlags,
+): EditorSaveNotificationVariant[] {
+  const variants: EditorSaveNotificationVariant[] = [];
+
+  if (flags.externalMergeVisible) variants.push('external-merge');
+  if (flags.externalChangeVisible) variants.push('external-change');
+  if (flags.persistFailureActive) variants.push('persist-failure');
+  if (flags.docDeleted) variants.push('doc-deleted');
+
+  return variants;
+}


### PR DESCRIPTION
## Summary
- Added shared `@kb-2/ui` `EditorSaveNotifications` chrome with fixed no-reflow stack layout, app-provided copy, and suppress-`persist-recovered` policy.
- Replaced the local editor route's inline in-flow `banner-strip` with the shared component while preserving local failure/external-change/doc-deleted copy.
- Added the shared editor chrome parity invariant and linked it from the invariants README.

## Verification
- `pnpm --filter @kb-2/ui typecheck`
- `pnpm --filter @kb-2/ui test`
- `pnpm --filter @kb-2/web typecheck`
- `pnpm --filter @kb-2/web build`
- `pnpm --filter @kb-2/ui build`
- `pnpm nx run-many -t typecheck,test,build --skip-nx-cache`
- `fallow health --score` => `88 A`
- Greps: zero `banner-strip` refs in `apps/web/src/routes/+page.svelte`; zero local `Saving restored`/`persist-recovered` render refs in the local route/shared wrapper.
- Real Chrome no-reflow proof on temp app (`KB2_HOME=/tmp/kb2-no-reflow-49b0`, ports `9890/9891`, Chrome CDP `9892`): triggered a real `persist-failure` by making the temp vault unwritable and typing in the editor. Before `shellTop/editorTop = 68.09375`; after `shellTop/editorTop = 68.09375`; delta `0`; stack `position: fixed`, `top: 14px`, `right: 16px`; recovered banner not rendered.
- Independent audit subagent verdict: no findings; acceptance pass.

## Side-by-side chrome parity audit
- Save notifications: FIXED. Daemon now uses shared `@kb-2/ui` fixed-stack notification chrome, suppresses recovered reassurance, and takes app copy as input. Cloud PR #18 behavior/layout matches, but cloud still has its app-local wrapper until the tracked cloud migration follow-up.
- Status indicator: MATCHES. Both derive/pass `daemonStatus` into shared shell/chrome.
- Page shell: MATCHES. Same shared `LocalEditorShell` contract/layout; cloud has presence wrapper as documented exception.
- Search: MATCHES. Shared shell props and shared `FilesPanel`/`FilesSearchResults` render path.
- File tree: MATCHES. Shared `FilesPanel`, `FileNode`, and `FolderNode` render path.
- Presence affordances: DEVIATES WITH REASON. Cloud-only presence is the documented standing exception in `docs/architecture/invariants/ui/shared-editor-chrome.md`.
