### PR TITLE
Cloud 007: Add Tunnel Control Heartbeat

### DIFF
--- a/packages/tunnel-client/src/heartbeat.test.ts
+++ b/packages/tunnel-client/src/heartbeat.test.ts
@@ -1,0 +1,98 @@
+import { EventEmitter } from 'node:events';
+import { encodeTunnelMessage } from '@kb-2/tunnel-protocol';
+
+class MockWebSocket extends EventEmitter {
+  static readonly OPEN = 1;
+  static readonly instances: MockWebSocket[] = [];
+
+  readyState = 0;
+  readonly sent: unknown[] = [];
+  terminated = false;
+
+  constructor(readonly url: URL) {
+    super();
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: unknown): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.readyState = 3;
+    this.emit('close', code ?? 1000, Buffer.from(reason ?? ''));
+  }
+
+  terminate(): void {
+    this.terminated = true;
+    this.readyState = 3;
+    this.emit('close', 1006, Buffer.from(''));
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.emit('open');
+  }
+
+  message(data: string): void {
+    this.emit('message', Buffer.from(data));
+  }
+}
+
+function sentText(socket: MockWebSocket, index: number): string {
+  const data = socket.sent[index];
+  return Buffer.isBuffer(data) ? data.toString() : String(data);
+}
+
+vi.mock('ws', () => ({ WebSocket: MockWebSocket }));
+
+describe('TunnelClient control heartbeat', () => {
+  beforeEach(() => {
+    MockWebSocket.instances.length = 0;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('terminates a missed-pong control socket to trip the existing reconnect path', async () => {
+    const { CONTROL_HEARTBEAT_INTERVAL_MS, CONTROL_HEARTBEAT_TIMEOUT_MS, TunnelClient } = await import('./index.js');
+    const logger = { log: vi.fn() };
+    const client = new TunnelClient({
+      relayUrl: new URL('http://relay.example/t/dev1'),
+      daemonUrl: new URL('http://127.0.0.1:9891'),
+      token: 'token-1',
+      logger,
+      random: () => 0,
+    });
+
+    client.start();
+    const firstControl = MockWebSocket.instances[0];
+    firstControl.open();
+
+    expect(sentText(firstControl, 0)).toBe(encodeTunnelMessage({
+      type: 'control.hello',
+      version: 2,
+      token: 'token-1',
+    }));
+
+    await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_INTERVAL_MS);
+    expect(sentText(firstControl, 1)).toBe(encodeTunnelMessage({ type: 'control.ping' }));
+
+    firstControl.message(encodeTunnelMessage({ type: 'control.pong' }));
+    await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_TIMEOUT_MS);
+    expect(firstControl.terminated).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_INTERVAL_MS);
+    expect(sentText(firstControl, 2)).toBe(encodeTunnelMessage({ type: 'control.ping' }));
+
+    await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_TIMEOUT_MS);
+    expect(firstControl.terminated).toBe(true);
+    expect(logger.log).toHaveBeenCalledWith('warn', 'relay control heartbeat missed; terminating socket to reconnect');
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+});

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -202,7 +202,7 @@ export class TunnelClient {
       }
 
       this.clearControlHeartbeatDeadline();
-      control.send(encodeJsonBytes({ type: 'control.ping' }));
+      control.send(encodeTunnelMessage({ type: 'control.ping' }));
       this.controlHeartbeatDeadline = setTimeout(() => {
         if (this.control !== control || this.stopped) return;
 

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -43,6 +43,8 @@ export type BackoffOptions = {
 const DEFAULT_BACKOFF_BASE_MS = 250;
 const DEFAULT_BACKOFF_MAX_MS = 10_000;
 const DEFAULT_BACKOFF_JITTER_RATIO = 0.25;
+export const CONTROL_HEARTBEAT_INTERVAL_MS = 15_000;
+export const CONTROL_HEARTBEAT_TIMEOUT_MS = 5_000;
 
 const hopByHopHeaders = new Set([
   'connection',
@@ -65,6 +67,8 @@ export class TunnelClient {
   private readonly random: () => number;
   private control: WebSocket | undefined;
   private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+  private controlHeartbeatInterval: ReturnType<typeof setInterval> | undefined;
+  private controlHeartbeatDeadline: ReturnType<typeof setTimeout> | undefined;
   private readonly httpAssembler = new ChunkedHttpRequestAssembler();
   private stopped = true;
   private reconnectAttempt = 0;
@@ -89,6 +93,7 @@ export class TunnelClient {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = undefined;
     }
+    this.clearControlHeartbeat();
     this.control?.close(1001, 'Tunnel client stopping');
     this.control = undefined;
   }
@@ -106,6 +111,7 @@ export class TunnelClient {
         version: TUNNEL_PROTOCOL_VERSION,
         token: this.config.token,
       }));
+      this.startControlHeartbeat(control);
       this.logger.log('info', 'relay control connected', {
         relayHost: controlUrl.host,
         protocolVersion: TUNNEL_PROTOCOL_VERSION,
@@ -121,6 +127,7 @@ export class TunnelClient {
     control.on('close', (code) => {
       if (this.control === control) {
         this.control = undefined;
+        this.clearControlHeartbeat();
       }
 
       if (this.stopped) return;
@@ -156,6 +163,9 @@ export class TunnelClient {
         this.reconnectAttempt = 0;
         this.logger.log('info', 'relay control ready', { protocolVersion: message.version });
         return;
+      case 'control.pong':
+        this.clearControlHeartbeatDeadline();
+        return;
       case 'control.error':
         this.logger.log('error', 'relay control rejected message', {
           code: message.code,
@@ -181,6 +191,39 @@ export class TunnelClient {
       case 'ws.open':
         this.openDialback(message);
         return;
+    }
+  }
+
+  private startControlHeartbeat(control: WebSocket): void {
+    this.clearControlHeartbeat();
+    this.controlHeartbeatInterval = setInterval(() => {
+      if (this.control !== control || this.stopped || control.readyState !== WebSocket.OPEN) {
+        return;
+      }
+
+      this.clearControlHeartbeatDeadline();
+      control.send(encodeJsonBytes({ type: 'control.ping' }));
+      this.controlHeartbeatDeadline = setTimeout(() => {
+        if (this.control !== control || this.stopped) return;
+
+        this.logger.log('warn', 'relay control heartbeat missed; terminating socket to reconnect');
+        control.terminate();
+      }, CONTROL_HEARTBEAT_TIMEOUT_MS);
+    }, CONTROL_HEARTBEAT_INTERVAL_MS);
+  }
+
+  private clearControlHeartbeat(): void {
+    if (this.controlHeartbeatInterval) {
+      clearInterval(this.controlHeartbeatInterval);
+      this.controlHeartbeatInterval = undefined;
+    }
+    this.clearControlHeartbeatDeadline();
+  }
+
+  private clearControlHeartbeatDeadline(): void {
+    if (this.controlHeartbeatDeadline) {
+      clearTimeout(this.controlHeartbeatDeadline);
+      this.controlHeartbeatDeadline = undefined;
     }
   }
 

--- a/packages/tunnel-protocol/src/index.test.ts
+++ b/packages/tunnel-protocol/src/index.test.ts
@@ -20,6 +20,14 @@ it("round-trips an HTTP response envelope", () => {
   expect(decodeTunnelMessage(encodeTunnelMessage(message))).toEqual(message);
 });
 
+it("round-trips control heartbeat envelopes", () => {
+  const ping = { type: "control.ping" } as const;
+  const pong = { type: "control.pong" } as const;
+
+  expect(decodeTunnelMessage(encodeTunnelMessage(ping))).toEqual(ping);
+  expect(decodeTunnelMessage(encodeTunnelMessage(pong))).toEqual(pong);
+});
+
 it("round-trips chunked HTTP request envelopes", () => {
   const start = {
     type: "http.request.start",

--- a/packages/tunnel-protocol/src/index.ts
+++ b/packages/tunnel-protocol/src/index.ts
@@ -115,6 +115,14 @@ export type TunnelControlServerReady = {
   version: TunnelProtocolVersion;
 };
 
+export type TunnelControlPing = {
+  type: "control.ping";
+};
+
+export type TunnelControlPong = {
+  type: "control.pong";
+};
+
 export type TunnelControlServerError = {
   type: "control.error";
   code: "unauthorized" | "unsupported-version" | "bad-message" | "relay-error";
@@ -197,6 +205,7 @@ export type TunnelWebSocketDialbackHello = {
 
 export type TunnelControlClientMessage =
   | TunnelControlClientHello
+  | TunnelControlPing
   | TunnelHttpResponseEnvelope
   | TunnelHttpResponseStartEnvelope
   | TunnelHttpResponseChunkEnvelope
@@ -204,6 +213,7 @@ export type TunnelControlClientMessage =
 
 export type TunnelControlServerMessage =
   | TunnelControlServerReady
+  | TunnelControlPong
   | TunnelControlServerError
   | TunnelHttpRequestEnvelope
   | TunnelHttpRequestStartEnvelope


### PR DESCRIPTION
## Summary
- Adds control.ping/control.pong envelopes to @kb-2/tunnel-protocol.
- Adds TunnelClient heartbeat over the existing control socket.
- Missed pong terminates the current socket so the existing close-handler backoff reconnect path runs; CONTROL_REPLACED still remains terminal.

## Tests
- pnpm --filter @kb-2/tunnel-protocol test
- pnpm --filter @kb-2/tunnel-client test
- pnpm --filter @kb-2/tunnel-protocol typecheck
- pnpm --filter @kb-2/tunnel-client typecheck
- pnpm --filter @kb-2/tunnel-protocol build
- pnpm --filter @kb-2/tunnel-client build
- pnpm nx run-many -t typecheck,test,build --skip-nx-cache

## Notes
- Heartbeat pings are sent as text JSON so Cloudflare Durable Object WebSocket auto-response can match them in the cloud relay.