### PR TITLE
Introduce a vault registry and a vaults/ layout

### DIFF
--- a/apps/daemon/src/config.test.ts
+++ b/apps/daemon/src/config.test.ts
@@ -58,7 +58,8 @@ describe('daemon config', () => {
       actorDefault: 'user',
       kb2Home,
       daemonHome: join(kb2Home, 'daemon'),
-      vaultRoot: join(kb2Home, 'demo-vault'),
+      vaultsHome: join(kb2Home, 'vaults'),
+      vaultRoot: join(kb2Home, 'vaults', 'demo-vault'),
       statusFile: join(kb2Home, 'daemon', 'status.json'),
       startedAt: now.toISOString(),
       pid: 1234

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -8,6 +8,10 @@ export const DEFAULT_ACTOR_DEFAULT = 'user';
 
 export type ActorDefault = 'user' | 'unknown';
 
+export const DEFAULT_VAULT_SLUG = 'demo-vault';
+export const LEGACY_VAULT_DIRNAME = 'demo-vault';
+export const VAULTS_DIRNAME = 'vaults';
+
 export interface DaemonConfig {
   serviceName: typeof SERVICE_NAME;
   host: string;
@@ -17,6 +21,12 @@ export interface DaemonConfig {
   actorDefault: ActorDefault;
   kb2Home: string;
   daemonHome: string;
+  /** Directory that holds every vault: `<home>/vaults/<slug>/`. */
+  vaultsHome: string;
+  /**
+   * Root of the default vault. Derived from the default slug under
+   * `vaultsHome` for backward compatibility with the single-vault surface.
+   */
   vaultRoot: string;
   statusFile: string;
   startedAt: string;
@@ -109,7 +119,8 @@ export function createDaemonConfig(options: ResolveConfigOptions = {}): DaemonCo
   const homeDir = options.homeDir ?? homedir();
   const kb2Home = resolveKb2Home(env, homeDir);
   const daemonHome = join(kb2Home, 'daemon');
-  const vaultRoot = join(kb2Home, 'demo-vault');
+  const vaultsHome = join(kb2Home, VAULTS_DIRNAME);
+  const vaultRoot = join(vaultsHome, DEFAULT_VAULT_SLUG);
 
   return {
     serviceName: SERVICE_NAME,
@@ -120,6 +131,7 @@ export function createDaemonConfig(options: ResolveConfigOptions = {}): DaemonCo
     actorDefault: resolveActorDefault(env),
     kb2Home,
     daemonHome,
+    vaultsHome,
     vaultRoot,
     statusFile: join(daemonHome, 'status.json'),
     startedAt: (options.now ?? new Date()).toISOString(),

--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -162,6 +162,116 @@ describe('daemon startup', () => {
   });
 });
 
+describe('daemon boot migration', () => {
+  let kb2Home: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  const SEEDED_NOTES: ReadonlyArray<{ readonly path: string; readonly content: string }> = [
+    { path: 'welcome.md', content: '# Welcome\n\nThe first top-level note.\n' },
+    { path: 'ideas.md', content: '# Ideas\n\nA second top-level note with distinctive text.\n' },
+    { path: join('projects', 'roadmap.md'), content: '# Roadmap\n\nA nested note that must survive the move.\n' }
+  ];
+
+  beforeEach(async () => {
+    originalEnv = { ...process.env };
+    kb2Home = await mkdtemp(join(tmpdir(), 'kb2-migration-'));
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    await rm(kb2Home, { force: true, recursive: true });
+  });
+
+  async function seedLegacyLayout(): Promise<void> {
+    const legacyVault = join(kb2Home, 'demo-vault');
+    for (const note of SEEDED_NOTES) {
+      const absolute = join(legacyVault, note.path);
+      await mkdir(join(absolute, '..'), { recursive: true });
+      await writeFile(absolute, note.content, 'utf8');
+    }
+  }
+
+  it('migrates a legacy single-vault layout into the registry layout on boot, preserving every note', async () => {
+    await seedLegacyLayout();
+
+    const port = await reservePort();
+    process.env = {
+      ...originalEnv,
+      KB2_HOME: kb2Home,
+      KB2_HOST: '127.0.0.1',
+      KB2_PORT: String(port)
+    };
+
+    const started = await startDaemon();
+    const vaultRoot = started.config.vaultRoot;
+
+    // The migrated vault lives under <home>/vaults/<slug>/ and the legacy root is gone.
+    expect(vaultRoot).toBe(join(kb2Home, 'vaults', 'demo-vault'));
+    await expect(access(join(kb2Home, 'demo-vault'))).rejects.toBeTruthy();
+
+    // Data-safety: every seeded note, including the nested one, survives byte-for-byte.
+    for (const note of SEEDED_NOTES) {
+      await expect(readFile(join(vaultRoot, note.path), 'utf8')).resolves.toBe(note.content);
+    }
+
+    // A durable vault identity was minted with a non-empty slug and display name.
+    const identity = JSON.parse(await readFile(join(vaultRoot, '.kb2', 'vault.json'), 'utf8'));
+    expect(typeof identity).toBe('object');
+    expect(identity).not.toBeNull();
+    expect(identity.id).toBe('demo-vault');
+    expect(typeof identity.displayName).toBe('string');
+    expect(identity.displayName.length).toBeGreaterThan(0);
+
+    await started.close();
+  });
+
+  it('leaves the migrated tree and minted identity unchanged on a second boot (idempotent slug)', async () => {
+    await seedLegacyLayout();
+
+    const firstPort = await reservePort();
+    process.env = {
+      ...originalEnv,
+      KB2_HOME: kb2Home,
+      KB2_HOST: '127.0.0.1',
+      KB2_PORT: String(firstPort)
+    };
+
+    const firstBoot = await startDaemon();
+    const vaultRoot = firstBoot.config.vaultRoot;
+    const identityFile = join(vaultRoot, '.kb2', 'vault.json');
+    const identityAfterFirstBoot = await readFile(identityFile, 'utf8');
+    const contentsAfterFirstBoot = await Promise.all(
+      SEEDED_NOTES.map((note) => readFile(join(vaultRoot, note.path), 'utf8'))
+    );
+    await firstBoot.close();
+
+    const secondPort = await reservePort();
+    process.env = {
+      ...originalEnv,
+      KB2_HOME: kb2Home,
+      KB2_HOST: '127.0.0.1',
+      KB2_PORT: String(secondPort)
+    };
+
+    const secondBoot = await startDaemon();
+    expect(secondBoot.config.vaultRoot).toBe(vaultRoot);
+
+    // The legacy root is not recreated, and the identity is byte-for-byte identical
+    // (the slug is read back, never recomputed).
+    await expect(access(join(kb2Home, 'demo-vault'))).rejects.toBeTruthy();
+    await expect(readFile(identityFile, 'utf8')).resolves.toBe(identityAfterFirstBoot);
+
+    // Every note is still present with its original content unchanged.
+    for (let index = 0; index < SEEDED_NOTES.length; index += 1) {
+      await expect(readFile(join(vaultRoot, SEEDED_NOTES[index].path), 'utf8')).resolves.toBe(
+        contentsAfterFirstBoot[index]
+      );
+    }
+
+    await secondBoot.close();
+  });
+});
+
 async function reservePort(): Promise<number> {
   const server = createServer();
   await listen(server);

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -1,18 +1,28 @@
 #!/usr/bin/env node
 import { serve } from '@hono/node-server';
-import { DocumentSessionManager, bindYjsWebSocket } from '@kb-2/doc-session';
+import { bindYjsWebSocket } from '@kb-2/doc-session';
 import { createLocalMcpEndpoint } from '@kb-2/local-mcp';
 import { TunnelClient, type TunnelClientLogger } from '@kb-2/tunnel-client';
-import { readdir } from 'node:fs/promises';
+import { mkdir, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { readVaultFile, validateVaultPath, writeVaultFile } from '@kb-2/vault-core';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { WebSocketServer } from 'ws';
 
 import { createApp } from './app.js';
-import { createDaemonConfig, type DaemonConfig } from './config.js';
+import {
+  createDaemonConfig,
+  DEFAULT_VAULT_SLUG,
+  LEGACY_VAULT_DIRNAME,
+  type DaemonConfig
+} from './config.js';
 import { writeDaemonStatus, type DaemonStatus } from './status.js';
-import { createVaultService } from '@kb-2/vault-service';
+import {
+  buildVaultInstances,
+  discoverVaults,
+  migrateLegacyVaultLayout,
+  type VaultInstance
+} from './vault-registry.js';
 
 const DEMO_DOCUMENT_PATH = 'hello-world.md';
 const DEMO_DOCUMENT_YJS_PATH = '/api/demo-document/yjs';
@@ -31,14 +41,35 @@ export interface StartedDaemon {
 
 export async function startDaemon(): Promise<StartedDaemon> {
   const config = createDaemonConfig();
-  const documentSessions = new DocumentSessionManager({ root: config.vaultRoot });
+
+  // Boot migration: copy -> verify -> cleanup the legacy single-vault layout.
+  await migrateLegacyVaultLayout({
+    legacyVaultDir: join(config.kb2Home, LEGACY_VAULT_DIRNAME),
+    vaultsHome: config.vaultsHome,
+    targetSlug: DEFAULT_VAULT_SLUG
+  });
+
+  // Fresh install: ensure the vaults directory and a default vault exist, then
+  // seed the demo document into the default vault.
+  await mkdir(config.vaultsHome, { recursive: true });
+  await mkdir(config.vaultRoot, { recursive: true });
   const hasDemoDocument = await seedDemoDocument(config.vaultRoot);
+
+  // Discover every vault and build one root-scoped instance per vault.
+  const entries = await discoverVaults(config.vaultsHome);
+  const vaultInstances = buildVaultInstances(entries);
+
+  const defaultInstance = vaultInstances.get(DEFAULT_VAULT_SLUG);
+  if (!defaultInstance) {
+    throw new Error(`Default vault "${DEFAULT_VAULT_SLUG}" was not discovered after boot.`);
+  }
+
+  // Backward compat: the existing single-vault HTTP/WS/MCP surface operates on
+  // the default vault's instance.
+  const documentSessions = defaultInstance.manager;
+  const vaultService = defaultInstance.service;
   const demoDocumentSession = hasDemoDocument ? documentSessions.getSession(DEMO_DOCUMENT_PATH) : undefined;
   await demoDocumentSession?.open();
-  const vaultService = createVaultService({
-    vaultRoot: config.vaultRoot,
-    documentSessions
-  });
   const mcpEndpoint = createLocalMcpEndpoint(vaultService);
 
   const app = createApp({
@@ -92,7 +123,7 @@ export async function startDaemon(): Promise<StartedDaemon> {
               await mcpEndpoint.close();
               await closeWebSocketServer(webSocketServer, activeDocumentConnections);
               await closeServer(server);
-              await documentSessions.close();
+              await closeVaultInstances(vaultInstances);
             }
           });
         } catch (error) {
@@ -131,6 +162,10 @@ export async function startDaemon(): Promise<StartedDaemon> {
 
     server.once('error', fail);
   });
+}
+
+async function closeVaultInstances(instances: Map<string, VaultInstance>): Promise<void> {
+  await Promise.all([...instances.values()].map((instance) => instance.manager.close()));
 }
 
 function createRelayTunnelClient(config: DaemonConfig): TunnelClient | undefined {

--- a/apps/daemon/src/vault-registry.test.ts
+++ b/apps/daemon/src/vault-registry.test.ts
@@ -1,0 +1,159 @@
+import { access, mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  discoverVaults,
+  migrateLegacyVaultLayout,
+  readOrMintVaultIdentity,
+  slugFromFolderName
+} from './vault-registry.js';
+
+describe('vault registry', () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'kb2-registry-'));
+  });
+
+  afterEach(async () => {
+    await rm(home, { force: true, recursive: true });
+  });
+
+  describe('slugFromFolderName', () => {
+    it('lowercases and hyphenates', () => {
+      expect(slugFromFolderName('My Vault')).toBe('my-vault');
+      expect(slugFromFolderName('demo-vault')).toBe('demo-vault');
+      expect(slugFromFolderName('Notes & Stuff!!')).toBe('notes-stuff');
+    });
+
+    it('falls back to "vault" when nothing usable remains', () => {
+      expect(slugFromFolderName('***')).toBe('vault');
+    });
+  });
+
+  describe('readOrMintVaultIdentity', () => {
+    it('mints identity from the folder name on first sight', async () => {
+      const root = join(home, 'My Vault');
+      await mkdir(root, { recursive: true });
+
+      const identity = await readOrMintVaultIdentity(root, 'My Vault');
+      expect(identity).toEqual({ id: 'my-vault', displayName: 'My Vault' });
+
+      const persisted = JSON.parse(await readFile(join(root, '.kb2', 'vault.json'), 'utf8'));
+      expect(persisted).toEqual({ id: 'my-vault', displayName: 'My Vault' });
+    });
+
+    it('reads an existing identity without overwriting it', async () => {
+      const root = join(home, 'demo-vault');
+      await mkdir(join(root, '.kb2'), { recursive: true });
+      await writeFile(
+        join(root, '.kb2', 'vault.json'),
+        JSON.stringify({ id: 'custom-slug', displayName: 'Custom Name' }),
+        'utf8'
+      );
+
+      const identity = await readOrMintVaultIdentity(root, 'demo-vault');
+      expect(identity).toEqual({ id: 'custom-slug', displayName: 'Custom Name' });
+    });
+
+    it('fails loudly on malformed identity', async () => {
+      const root = join(home, 'broken');
+      await mkdir(join(root, '.kb2'), { recursive: true });
+      await writeFile(join(root, '.kb2', 'vault.json'), '{ not json', 'utf8');
+
+      await expect(readOrMintVaultIdentity(root, 'broken')).rejects.toThrow(/Malformed vault identity/);
+    });
+  });
+
+  describe('discoverVaults', () => {
+    it('returns [] when the vaults home does not exist', async () => {
+      await expect(discoverVaults(join(home, 'vaults'))).resolves.toEqual([]);
+    });
+
+    it('discovers and mints identities for each vault directory', async () => {
+      const vaultsHome = join(home, 'vaults');
+      await mkdir(join(vaultsHome, 'alpha'), { recursive: true });
+      await mkdir(join(vaultsHome, 'beta'), { recursive: true });
+
+      const entries = await discoverVaults(vaultsHome);
+      expect(entries.map((e) => e.slug).sort()).toEqual(['alpha', 'beta']);
+      expect(entries.every((e) => e.root.startsWith(vaultsHome))).toBe(true);
+    });
+
+    it('throws a hard error on slug collision', async () => {
+      const vaultsHome = join(home, 'vaults');
+      const first = join(vaultsHome, 'one');
+      const second = join(vaultsHome, 'two');
+      await mkdir(join(first, '.kb2'), { recursive: true });
+      await mkdir(join(second, '.kb2'), { recursive: true });
+      const dup = JSON.stringify({ id: 'same', displayName: 'Same' });
+      await writeFile(join(first, '.kb2', 'vault.json'), dup, 'utf8');
+      await writeFile(join(second, '.kb2', 'vault.json'), dup, 'utf8');
+
+      await expect(discoverVaults(vaultsHome)).rejects.toThrow(/Duplicate vault slug "same"/);
+    });
+  });
+
+  describe('migrateLegacyVaultLayout', () => {
+    async function seedLegacyVault(): Promise<string> {
+      const legacy = join(home, 'demo-vault');
+      await mkdir(join(legacy, 'notes'), { recursive: true });
+      await writeFile(join(legacy, 'hello-world.md'), '# Hello\n', 'utf8');
+      await writeFile(join(legacy, 'notes', 'deep.md'), 'deep content\n', 'utf8');
+      return legacy;
+    }
+
+    it('copies, verifies, then removes the legacy vault', async () => {
+      const legacy = await seedLegacyVault();
+      const vaultsHome = join(home, 'vaults');
+
+      const result = await migrateLegacyVaultLayout({
+        legacyVaultDir: legacy,
+        vaultsHome,
+        targetSlug: 'demo-vault'
+      });
+
+      expect(result.migrated).toBe(true);
+      const target = join(vaultsHome, 'demo-vault');
+      await expect(readFile(join(target, 'hello-world.md'), 'utf8')).resolves.toBe('# Hello\n');
+      await expect(readFile(join(target, 'notes', 'deep.md'), 'utf8')).resolves.toBe('deep content\n');
+      // Cleanup: legacy directory gone only after a verified copy.
+      await expect(access(legacy)).rejects.toBeTruthy();
+    });
+
+    it('is idempotent once the vaults home exists', async () => {
+      const legacy = await seedLegacyVault();
+      const vaultsHome = join(home, 'vaults');
+      await migrateLegacyVaultLayout({ legacyVaultDir: legacy, vaultsHome, targetSlug: 'demo-vault' });
+
+      // Recreate a stray legacy dir; migration should now be a no-op because
+      // vaults/ already exists.
+      await mkdir(legacy, { recursive: true });
+      const second = await migrateLegacyVaultLayout({
+        legacyVaultDir: legacy,
+        vaultsHome,
+        targetSlug: 'demo-vault'
+      });
+      expect(second.migrated).toBe(false);
+      await expect(stat(legacy)).resolves.toBeTruthy();
+    });
+
+    it('leaves the original intact when the copy step fails (copy-not-move)', async () => {
+      const legacy = await seedLegacyVault();
+      // Point vaultsHome under a path whose parent is a regular file so the
+      // mkdir/cp step throws partway through, simulating an interrupted run.
+      const fileParent = join(home, 'not-a-dir');
+      await writeFile(fileParent, 'x', 'utf8');
+      const vaultsHome = join(fileParent, 'vaults');
+
+      await expect(
+        migrateLegacyVaultLayout({ legacyVaultDir: legacy, vaultsHome, targetSlug: 'demo-vault' })
+      ).rejects.toBeTruthy();
+
+      // The legacy original must still be fully intact (copy-not-move).
+      await expect(readFile(join(legacy, 'hello-world.md'), 'utf8')).resolves.toBe('# Hello\n');
+      await expect(readFile(join(legacy, 'notes', 'deep.md'), 'utf8')).resolves.toBe('deep content\n');
+    });
+  });
+});

--- a/apps/daemon/src/vault-registry.ts
+++ b/apps/daemon/src/vault-registry.ts
@@ -1,0 +1,249 @@
+import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+import { DocumentSessionManager } from '@kb-2/doc-session';
+import { createVaultService, type VaultService } from '@kb-2/vault-service';
+
+const VAULT_IDENTITY_DIR = '.kb2';
+const VAULT_IDENTITY_FILE = 'vault.json';
+
+/** Durable identity for a single vault, stored at `<vault>/.kb2/vault.json`. */
+export interface VaultIdentity {
+  /** Stable unique slug for the vault within this daemon. */
+  id: string;
+  /** Human-facing name; defaults to the folder name on first sight. */
+  displayName: string;
+}
+
+/** A vault the daemon knows about: identity plus its on-disk root. */
+export interface VaultRegistryEntry {
+  slug: string;
+  displayName: string;
+  root: string;
+}
+
+/** A live, root-scoped instance serving one vault. */
+export interface VaultInstance {
+  entry: VaultRegistryEntry;
+  service: VaultService;
+  manager: DocumentSessionManager;
+}
+
+/**
+ * Derive a slug from a folder name. Lowercases, replaces runs of
+ * non-alphanumeric characters with a single hyphen, and trims hyphens.
+ * Falls back to `vault` when nothing usable remains.
+ */
+export function slugFromFolderName(folderName: string): string {
+  const slug = folderName
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return slug.length > 0 ? slug : 'vault';
+}
+
+function identityPath(vaultRoot: string): string {
+  return join(vaultRoot, VAULT_IDENTITY_DIR, VAULT_IDENTITY_FILE);
+}
+
+function isNodeErrorCode(error: unknown, code: string): boolean {
+  return error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === code;
+}
+
+/**
+ * Read a vault's identity, minting and persisting one if absent. The minted
+ * slug and display name both default from the folder name.
+ */
+export async function readOrMintVaultIdentity(vaultRoot: string, folderName: string): Promise<VaultIdentity> {
+  const file = identityPath(vaultRoot);
+
+  let raw: string | undefined;
+  try {
+    raw = await readFile(file, 'utf8');
+  } catch (error) {
+    if (!isNodeErrorCode(error, 'ENOENT')) {
+      throw error;
+    }
+  }
+
+  if (raw !== undefined) {
+    const parsed = parseVaultIdentity(raw, file);
+    return parsed;
+  }
+
+  const identity: VaultIdentity = {
+    id: slugFromFolderName(folderName),
+    displayName: folderName
+  };
+  await mkdir(join(vaultRoot, VAULT_IDENTITY_DIR), { recursive: true });
+  await writeFile(file, `${JSON.stringify(identity, null, 2)}\n`, 'utf8');
+  return identity;
+}
+
+function parseVaultIdentity(raw: string, file: string): VaultIdentity {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error(`Malformed vault identity at ${file}: not valid JSON.`);
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Malformed vault identity at ${file}: expected a JSON object.`);
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.id !== 'string' || record.id.trim().length === 0) {
+    throw new Error(`Malformed vault identity at ${file}: "id" must be a non-empty string.`);
+  }
+
+  const displayName = typeof record.displayName === 'string' && record.displayName.trim().length > 0
+    ? record.displayName
+    : record.id;
+
+  return { id: record.id, displayName };
+}
+
+/**
+ * Migrate the legacy single-vault layout (`<home>/<legacyDirname>/`) into the
+ * registry layout (`<home>/vaults/<legacyDirname>/`) using copy -> verify ->
+ * cleanup so an interrupted run never loses the original. Idempotent: a no-op
+ * once `<home>/vaults/` exists or the legacy directory is gone.
+ */
+export async function migrateLegacyVaultLayout(options: {
+  legacyVaultDir: string;
+  vaultsHome: string;
+  targetSlug: string;
+}): Promise<{ migrated: boolean }> {
+  const { legacyVaultDir, vaultsHome, targetSlug } = options;
+
+  if (await pathExists(vaultsHome)) {
+    return { migrated: false };
+  }
+
+  if (!(await isDirectory(legacyVaultDir))) {
+    return { migrated: false };
+  }
+
+  const target = join(vaultsHome, targetSlug);
+  await mkdir(vaultsHome, { recursive: true });
+
+  // COPY: copy-not-move so the original survives an interrupted run.
+  await cp(legacyVaultDir, target, { recursive: true });
+
+  // VERIFY: file set + sizes must match before we delete anything.
+  await verifyCopy(legacyVaultDir, target);
+
+  // CLEANUP: only after a verified copy.
+  await rm(legacyVaultDir, { recursive: true, force: true });
+
+  return { migrated: true };
+}
+
+async function verifyCopy(source: string, target: string): Promise<void> {
+  const sourceFiles = await listFilesWithSizes(source);
+  const targetFiles = await listFilesWithSizes(target);
+
+  for (const [relPath, size] of sourceFiles) {
+    const copiedSize = targetFiles.get(relPath);
+    if (copiedSize === undefined) {
+      throw new Error(`Vault migration verification failed: ${relPath} missing from copy.`);
+    }
+    if (copiedSize !== size) {
+      throw new Error(
+        `Vault migration verification failed: ${relPath} size mismatch (source ${size}, copy ${copiedSize}).`
+      );
+    }
+  }
+}
+
+async function listFilesWithSizes(root: string): Promise<Map<string, number>> {
+  const sizes = new Map<string, number>();
+
+  async function walk(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const abs = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(abs);
+      } else if (entry.isFile()) {
+        const info = await stat(abs);
+        sizes.set(relative(root, abs), info.size);
+      }
+    }
+  }
+
+  await walk(root);
+  return sizes;
+}
+
+/**
+ * Discover every vault directory under `vaultsHome`, mint identities as needed,
+ * and return registry entries. Throws if two vaults resolve to the same slug.
+ */
+export async function discoverVaults(vaultsHome: string): Promise<VaultRegistryEntry[]> {
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = await readdir(vaultsHome, { withFileTypes: true });
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) {
+      return [];
+    }
+    throw error;
+  }
+
+  const bySlug = new Map<string, VaultRegistryEntry>();
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isDirectory()) continue;
+    const root = join(vaultsHome, entry.name);
+    const identity = await readOrMintVaultIdentity(root, entry.name);
+
+    const existing = bySlug.get(identity.id);
+    if (existing) {
+      throw new Error(
+        `Duplicate vault slug "${identity.id}" found in ${existing.root} and ${root}. ` +
+          'Vault slugs must be unique within a daemon.'
+      );
+    }
+
+    bySlug.set(identity.id, { slug: identity.id, displayName: identity.displayName, root });
+  }
+
+  return [...bySlug.values()];
+}
+
+/** Build a root-scoped service + document manager per discovered vault. */
+export function buildVaultInstances(entries: VaultRegistryEntry[]): Map<string, VaultInstance> {
+  const instances = new Map<string, VaultInstance>();
+  for (const entry of entries) {
+    const manager = new DocumentSessionManager({ root: entry.root });
+    const service = createVaultService({ vaultRoot: entry.root, documentSessions: manager });
+    instances.set(entry.slug, { entry, service, manager });
+  }
+  return instances;
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await stat(target);
+    return true;
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function isDirectory(target: string): Promise<boolean> {
+  try {
+    return (await stat(target)).isDirectory();
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) {
+      return false;
+    }
+    throw error;
+  }
+}

--- a/docs/architecture/invariants/README.md
+++ b/docs/architecture/invariants/README.md
@@ -14,6 +14,7 @@ Product and domain invariants — what the product is and how it treats data:
 - [Filesystem is durable truth](./product/filesystem-durable-truth.md)
 - [Content, not people (local product)](./product/content-not-people.md)
 - [Edits save or fail loudly](./product/edits-save-or-fail-loudly.md)
+- [Vault slugs are unique within a daemon](./product/vault-slug-uniqueness.md)
 
 Engineering invariants — how the codebase stays healthy:
 

--- a/docs/architecture/invariants/product/vault-slug-uniqueness.md
+++ b/docs/architecture/invariants/product/vault-slug-uniqueness.md
@@ -1,0 +1,45 @@
+# Vault Slugs Are Unique Within A Daemon
+
+## Invariant
+
+Every vault a daemon serves has a stable slug, and that slug is unique across
+all vaults the daemon serves. The slug is the vault's identity for routing,
+addressing, and registry lookup. Two vaults sharing a slug is a hard error, not
+a recoverable condition.
+
+## This Means
+
+- A vault's identity lives on disk at `<vault>/.kb2/vault.json` (`{ id, displayName }`),
+  where `id` is the slug. The filesystem is the source of truth.
+- The registry is built by scanning the vaults directory; each directory's
+  identity is read, or minted from the folder name on first sight.
+- A slug collision during discovery aborts boot with a clear error rather than
+  silently dropping or shadowing a vault.
+- A slug, once minted and persisted, is stable: it is not recomputed from the
+  folder name on later boots.
+
+## Good Examples
+
+- Discovery throwing `Duplicate vault slug "<id>"` and naming both conflicting
+  roots when two vaults carry the same `id`.
+- Minting `{ id, displayName }` from the folder name only when
+  `.kb2/vault.json` is absent, then reusing it verbatim afterward.
+
+## Violations
+
+- Deriving a vault's slug from a mutable property (path, display name) on every
+  boot so it can change underneath callers.
+- Resolving a slug collision by appending a suffix or picking a winner instead
+  of failing loudly.
+- Holding the registry only in memory so identity is lost on restart.
+
+## Exceptions
+
+None currently accepted.
+
+## Review Checklist
+
+- Is each served vault addressable by a single stable slug?
+- Does a slug collision fail boot loudly instead of silently shadowing a vault?
+- Is identity persisted in `.kb2/vault.json` and read back rather than
+  recomputed?


### PR DESCRIPTION
Introduce a vault registry and a vaults/ layout

Discover vaults by scanning <home>/vaults/, each identified by a unique slug stored in its .kb2/vault.json. On boot, migrate a legacy single-vault layout into vaults/ by copying, verifying, then removing the original. The daemon serves a default vault so existing behavior is unchanged.

Test the boot migration end to end against a throwaway home