### PR TITLE
Seed new vaults from a bundled starter kit

### DIFF
--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -32,7 +32,7 @@ import type {
   VaultRegistryErrorCode
 } from './vault-registry.js';
 
-const DEMO_DOCUMENT_PATH = 'demo-vault/hello-world.md';
+const DEMO_DOCUMENT_PATH = 'demo-vault/README.md';
 const ACTOR_HEADER = 'x-kb2-actor';
 const MAX_ACTOR_HEADER_BYTES = 1024;
 

--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -58,16 +58,16 @@ describe('daemon startup', () => {
     expect(response.status).toBe(200);
     expect(body).toMatchObject({
       ok: true,
-      document: 'demo-vault/hello-world.md'
+      document: 'demo-vault/README.md'
     });
     expect(typeof body.content).toBe('string');
-    expect(body.content).toContain('Hello KB-2');
-    await expect(readFile(join(started.config.vaultRoot, 'hello-world.md'), 'utf8')).resolves.toBe(body.content);
+    expect(body.content).toContain('Welcome to your vault');
+    await expect(readFile(join(started.config.vaultRoot, 'README.md'), 'utf8')).resolves.toBe(body.content);
 
     await started.close();
   });
 
-  it('seeds the demo document only for a first boot of an empty vault', async () => {
+  it('seeds the starter kit only for a first boot of an empty vault', async () => {
     const port = await reservePort();
     process.env = {
       ...originalEnv,
@@ -77,17 +77,22 @@ describe('daemon startup', () => {
     };
 
     const firstBoot = await startDaemon();
-    await expect(readFile(join(firstBoot.config.vaultRoot, 'hello-world.md'), 'utf8')).resolves.toContain('Hello KB-2');
+    // The whole bundled kit lands in the first-boot vault: a top-level README and
+    // a nested note, proving the seeder copies the template tree recursively.
+    await expect(readFile(join(firstBoot.config.vaultRoot, 'README.md'), 'utf8')).resolves.toContain('Welcome to your vault');
+    await expect(readFile(join(firstBoot.config.vaultRoot, 'notes', 'getting-started.md'), 'utf8')).resolves.toContain('Getting started');
 
-    const deleted = await fetch(`http://127.0.0.1:${port}/api/files/hello-world.md`, { method: 'DELETE' });
+    const deleted = await fetch(`http://127.0.0.1:${port}/api/files/README.md`, { method: 'DELETE' });
     expect(deleted.status).toBe(200);
-    await expect(access(join(firstBoot.config.vaultRoot, 'hello-world.md'))).rejects.toBeTruthy();
+    await expect(access(join(firstBoot.config.vaultRoot, 'README.md'))).rejects.toBeTruthy();
     await firstBoot.close();
 
+    // Restart does not re-seed an existing vault: the deleted file stays gone.
     const restartedAfterDelete = await startDaemon();
-    await expect(access(join(restartedAfterDelete.config.vaultRoot, 'hello-world.md'))).rejects.toBeTruthy();
+    await expect(access(join(restartedAfterDelete.config.vaultRoot, 'README.md'))).rejects.toBeTruthy();
     await restartedAfterDelete.close();
 
+    // A pre-existing (non-empty) vault is migrated but never seeded with the kit.
     const populatedHome = await mkdtemp(join(tmpdir(), 'kb2-populated-startup-'));
     process.env = {
       ...originalEnv,
@@ -100,7 +105,7 @@ describe('daemon startup', () => {
     await writeFile(join(populatedVault, 'notes', 'preexisting.md'), 'already here\n', 'utf8');
 
     const populatedBoot = await startDaemon();
-    await expect(access(join(populatedBoot.config.vaultRoot, 'hello-world.md'))).rejects.toBeTruthy();
+    await expect(access(join(populatedBoot.config.vaultRoot, 'README.md'))).rejects.toBeTruthy();
     await expect(readFile(join(populatedBoot.config.vaultRoot, 'notes', 'preexisting.md'), 'utf8')).resolves.toBe('already here\n');
     await populatedBoot.close();
     await rm(populatedHome, { force: true, recursive: true });
@@ -126,7 +131,7 @@ describe('daemon startup', () => {
       reason: JSON.stringify({ ok: false, error: 'not_found', message: 'file not found' })
     });
     await expect(access(join(started.config.vaultRoot, 'typo'))).rejects.toBeTruthy();
-    await expect(readFile(join(started.config.vaultRoot, 'hello-world.md'), 'utf8')).resolves.toContain('Hello KB-2');
+    await expect(readFile(join(started.config.vaultRoot, 'README.md'), 'utf8')).resolves.toContain('Welcome to your vault');
 
     await started.close();
   });

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import { serve } from '@hono/node-server';
-import { bindYjsWebSocket, type DocumentSessionManager } from '@kb-2/doc-session';
+import { bindYjsWebSocket, type DocumentSessionManager, type OneFileDocumentSession } from '@kb-2/doc-session';
 import { createLocalMcpEndpoint } from '@kb-2/local-mcp';
 import { TunnelClient, type TunnelClientLogger } from '@kb-2/tunnel-client';
-import { mkdir, readdir } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { readVaultFile, validateVaultPath, writeVaultFile } from '@kb-2/vault-core';
+import { readVaultFile, validateVaultPath } from '@kb-2/vault-core';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { WebSocketServer } from 'ws';
 
@@ -23,14 +23,11 @@ import {
   VaultRegistry
 } from './vault-registry.js';
 
-const DEMO_DOCUMENT_PATH = 'hello-world.md';
+// The legacy single-vault demo surface (`/api/demo-document` + its Yjs socket)
+// is backed by the starter kit's top-level README, which a first-boot vault is
+// always seeded with. The session is bound only when that file is present.
+const DEMO_DOCUMENT_PATH = 'README.md';
 const DEMO_DOCUMENT_YJS_PATH = '/api/demo-document/yjs';
-const DEFAULT_DEMO_DOCUMENT_CONTENT = [
-  '# Hello KB-2',
-  '',
-  'This Markdown file is served by the local KB-2 daemon.',
-  ''
-].join('\n');
 
 export interface StartedDaemon {
   config: DaemonConfig;
@@ -48,28 +45,32 @@ export async function startDaemon(): Promise<StartedDaemon> {
     targetSlug: DEFAULT_VAULT_SLUG
   });
 
-  // Fresh install: ensure the vaults directory and a default vault exist, then
-  // seed the demo document into the default vault.
-  await mkdir(config.vaultsHome, { recursive: true });
-  await mkdir(config.vaultRoot, { recursive: true });
-  const hasDemoDocument = await seedDemoDocument(config.vaultRoot);
-
   // Discover every vault into a live registry: listable, addressable by slug,
   // and mutable at runtime (create/rename/soft-delete) with no restart.
+  await mkdir(config.vaultsHome, { recursive: true });
   const trashHome = join(config.kb2Home, VAULT_TRASH_DIRNAME);
   const registry = await VaultRegistry.load(config.vaultsHome, trashHome);
 
+  // First boot: with no legacy vault to migrate and nothing discovered, stand up
+  // a single starter vault seeded from the bundled kit. `create` performs the
+  // seeding, so there is no separate seed path.
+  if (registry.list().length === 0) {
+    const created = await registry.create({ displayName: DEFAULT_VAULT_SLUG });
+    if (!created.ok) {
+      throw new Error(`Failed to create the starter vault: ${created.message}`);
+    }
+  }
+
+  // Backward compat: the existing single-vault HTTP/WS/MCP surface operates on
+  // the default vault's instance. First boot guarantees it exists; discovery
+  // finds it on every subsequent boot.
   const defaultInstance = registry.get(DEFAULT_VAULT_SLUG);
   if (!defaultInstance) {
     throw new Error(`Default vault "${DEFAULT_VAULT_SLUG}" was not discovered after boot.`);
   }
-
-  // Backward compat: the existing single-vault HTTP/WS/MCP surface operates on
-  // the default vault's instance.
   const documentSessions = defaultInstance.manager;
   const vaultService = defaultInstance.service;
-  const demoDocumentSession = hasDemoDocument ? documentSessions.getSession(DEMO_DOCUMENT_PATH) : undefined;
-  await demoDocumentSession?.open();
+  const demoDocumentSession = await openDemoDocumentSession(documentSessions, config.vaultRoot);
 
   // One MCP endpoint, every vault: vaultId resolution and vault enumeration both
   // go through the SAME live registry the HTTP layer uses — no second vault map.
@@ -209,67 +210,26 @@ const daemonRelayLogger: TunnelClientLogger = {
   },
 };
 
-async function seedDemoDocument(vaultRoot: string): Promise<boolean> {
+/**
+ * Open the legacy demo-document session when the default vault has the backing
+ * file. The demo surface is served only while that file exists, so a vault that
+ * lacks it simply has no demo session.
+ */
+async function openDemoDocumentSession(
+  manager: DocumentSessionManager,
+  vaultRoot: string
+): Promise<OneFileDocumentSession | undefined> {
   const existing = await readVaultFile({ root: vaultRoot }, DEMO_DOCUMENT_PATH);
-  if (existing.ok) return true;
-  if (existing.error !== 'not_found') {
-    throw new Error(existing.message);
-  }
-
-  if (await hasMarkdownFiles(vaultRoot) || await hasKb2State(vaultRoot)) {
-    return false;
-  }
-
-  const seeded = await writeVaultFile(
-    { root: vaultRoot, actor: { kind: 'system' } },
-    { path: DEMO_DOCUMENT_PATH, content: DEFAULT_DEMO_DOCUMENT_CONTENT }
-  );
-  if (!seeded.ok) {
-    throw new Error(seeded.message);
-  }
-  return true;
-}
-
-async function hasKb2State(vaultRoot: string): Promise<boolean> {
-  try {
-    await readdir(join(vaultRoot, '.kb2'), { withFileTypes: true });
-    return true;
-  } catch (error) {
-    if (isNodeErrorCode(error, 'ENOENT')) {
-      return false;
+  if (!existing.ok) {
+    if (existing.error !== 'not_found') {
+      throw new Error(existing.message);
     }
-    throw error;
-  }
-}
-
-async function hasMarkdownFiles(directory: string): Promise<boolean> {
-  let entries;
-  try {
-    entries = await readdir(directory, { withFileTypes: true });
-  } catch (error) {
-    if (isNodeErrorCode(error, 'ENOENT')) {
-      return false;
-    }
-    throw error;
+    return undefined;
   }
 
-  for (const entry of entries) {
-    if (entry.name === '.kb2') {
-      continue;
-    }
-    if (entry.isFile() && entry.name.endsWith('.md')) {
-      return true;
-    }
-    if (entry.isDirectory() && await hasMarkdownFiles(join(directory, entry.name))) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function isNodeErrorCode(error: unknown, code: string): boolean {
-  return error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === code;
+  const session = manager.getSession(DEMO_DOCUMENT_PATH);
+  await session.open();
+  return session;
 }
 
 interface WebSocketTarget {

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -131,7 +131,7 @@ describe('daemon routing', () => {
         KB2_HOME: kb2Home
       }
     });
-    const demoDocumentFile = join(config.vaultRoot, 'hello-world.md');
+    const demoDocumentFile = join(config.vaultRoot, 'README.md');
     const documentSession = new OneFileDocumentSession(demoDocumentFile, { defaultContent: 'route seed\n' });
     await documentSession.open();
 
@@ -146,7 +146,7 @@ describe('daemon routing', () => {
     expect(readResponse.status).toBe(200);
     expect(readBody).toEqual({
       ok: true,
-      document: 'demo-vault/hello-world.md',
+      document: 'demo-vault/README.md',
       content: 'route seed\n'
     });
 
@@ -162,7 +162,7 @@ describe('daemon routing', () => {
     expect(resetResponse.status).toBe(200);
     expect(resetBody).toEqual({
       ok: true,
-      document: 'demo-vault/hello-world.md',
+      document: 'demo-vault/README.md',
       content: 'route reset\n'
     });
     await expect(readFile(demoDocumentFile, 'utf8')).resolves.toBe('route reset\n');

--- a/apps/daemon/src/starter-kit-template/README.md
+++ b/apps/daemon/src/starter-kit-template/README.md
@@ -1,0 +1,14 @@
+# Welcome to your vault
+
+This is your personal knowledge vault. Everything here is a plain Markdown
+file on your own machine, so you stay in control of your notes.
+
+A few ideas to get you going:
+
+- Capture a thought the moment you have it, then refine it later.
+- Link related notes together so your ideas form a web, not a pile.
+- Keep one note per idea and let folders group the themes that emerge.
+
+Take a look at the `notes` folder for an example of how a note can grow over
+time. Rename anything, move things around, and delete what you do not need.
+This vault is yours to shape.

--- a/apps/daemon/src/starter-kit-template/notes/getting-started.md
+++ b/apps/daemon/src/starter-kit-template/notes/getting-started.md
@@ -1,0 +1,13 @@
+# Getting started
+
+This note lives inside the `notes` folder to show how a vault can be organized
+into sections. Folders are just folders, so group your notes however feels
+natural to you.
+
+## Try this
+
+1. Edit this note and watch the change save automatically.
+2. Create a new note next to this one for whatever is on your mind.
+3. Make a fresh folder when a topic outgrows a single note.
+
+When you are ready, clear out this starter content and make the space your own.

--- a/apps/daemon/src/starter-kit.ts
+++ b/apps/daemon/src/starter-kit.ts
@@ -1,0 +1,101 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { writeVaultFile } from '@kb-2/vault-core';
+
+/** Vault-internal directory that holds identity/state, never user content. */
+const VAULT_IDENTITY_DIR = '.kb2';
+
+/**
+ * Absolute path to the bundled starter-kit template tree. Resolved relative to
+ * this module so it works both under `tsx`/dev (src tree) and after a build,
+ * where the build step copies the template directory alongside the compiled
+ * module (dist tree).
+ */
+export const STARTER_KIT_DIR = fileURLToPath(new URL('./starter-kit-template/', import.meta.url));
+
+/**
+ * Recursively copy the bundled starter-kit template tree into a vault root.
+ *
+ * Safe to call on any vault: it seeds only when the vault has no user content
+ * yet (the vault-identity `.kb2` directory does not count), so an existing or
+ * already-seeded vault is never overwritten or duplicated. Files are written
+ * through the shared vault-core write path so seeding follows the same fs and
+ * audit conventions as every other vault write.
+ *
+ * Expanding the kit needs no code change here: whatever files and folders live
+ * under {@link STARTER_KIT_DIR} are copied as-is, recursively.
+ *
+ * @returns `true` when the kit was seeded, `false` when the vault already had
+ *   content and was left untouched.
+ */
+export async function seedVaultFromStarterKit(vaultRoot: string): Promise<boolean> {
+  if (await hasUserContent(vaultRoot)) {
+    return false;
+  }
+
+  const files = await collectTemplateFiles(STARTER_KIT_DIR);
+  for (const file of files) {
+    const seeded = await writeVaultFile(
+      { root: vaultRoot, actor: { kind: 'system' } },
+      { path: file.vaultPath, content: file.content }
+    );
+    if (!seeded.ok) {
+      throw new Error(`Failed to seed starter-kit file "${file.vaultPath}": ${seeded.message}`);
+    }
+  }
+
+  return true;
+}
+
+/** A vault holds user content when it has any entry other than the `.kb2` dir. */
+async function hasUserContent(vaultRoot: string): Promise<boolean> {
+  let entries;
+  try {
+    entries = await readdir(vaultRoot, { withFileTypes: true });
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) {
+      return false;
+    }
+    throw error;
+  }
+
+  return entries.some((entry) => entry.name !== VAULT_IDENTITY_DIR);
+}
+
+interface TemplateFile {
+  /** Vault-relative POSIX path the file should be written to. */
+  vaultPath: string;
+  content: string;
+}
+
+/**
+ * Walk the template tree and return every file with its vault-relative path.
+ * Directories are implied by their files: empty directories carry no content
+ * and so are not represented, which keeps the seeder driven purely by the files
+ * present in the kit.
+ */
+async function collectTemplateFiles(templateDir: string): Promise<TemplateFile[]> {
+  const files: TemplateFile[] = [];
+
+  async function walk(absoluteDir: string, relativeDir: string): Promise<void> {
+    const entries = await readdir(absoluteDir, { withFileTypes: true });
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      const absolute = join(absoluteDir, entry.name);
+      const relative = relativeDir.length > 0 ? `${relativeDir}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(absolute, relative);
+      } else if (entry.isFile()) {
+        files.push({ vaultPath: relative, content: await readFile(absolute, 'utf8') });
+      }
+    }
+  }
+
+  await walk(templateDir, '');
+  return files;
+}
+
+function isNodeErrorCode(error: unknown, code: string): boolean {
+  return error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === code;
+}

--- a/apps/daemon/src/vault-registry.ts
+++ b/apps/daemon/src/vault-registry.ts
@@ -4,6 +4,8 @@ import { join, relative } from 'node:path';
 import { DocumentSessionManager } from '@kb-2/doc-session';
 import { createVaultService, type VaultService } from '@kb-2/vault-service';
 
+import { seedVaultFromStarterKit } from './starter-kit.js';
+
 const VAULT_IDENTITY_DIR = '.kb2';
 const VAULT_IDENTITY_FILE = 'vault.json';
 
@@ -308,6 +310,11 @@ export class VaultRegistry {
     await mkdir(root, { recursive: true });
     const identity: VaultIdentity = { id: slug, displayName };
     await writeVaultIdentity(root, identity);
+
+    // Every newly created vault starts from the bundled starter kit. The seeder
+    // is a no-op on a vault that already has user content, so this is safe even
+    // though identity was just written above (`.kb2` does not count as content).
+    await seedVaultFromStarterKit(root);
 
     const entry: VaultRegistryEntry = { slug, displayName, root };
     this.instances.set(slug, buildVaultInstance(entry));


### PR DESCRIPTION
Replace the single hello-world demo document with a source-resident starter
kit (a README and a notes/ folder) copied into every newly created vault and
into the vault stood up on a first boot. The seeder walks the template tree
recursively, so growing the kit is just dropping files in, and it no-ops on a
vault that already holds content.