### PR TITLE
Require explicit vault addressing and retire the default-vault surface

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -22,6 +22,7 @@
     "@kb-2/tunnel-client": "workspace:*",
     "@kb-2/vault-core": "workspace:*",
     "@kb-2/vault-service": "workspace:*",
+    "github-slugger": "2.0.0",
     "hono": "4.12.25",
     "ws": "8.21.0"
   },

--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -1,12 +1,10 @@
 import { Hono, type Context } from 'hono';
-import { DocumentSessionManager, type OneFileDocumentSession } from '@kb-2/doc-session';
 import {
   createLocalMcpEndpoint,
   type LocalMcpEndpoint,
   type LocalMcpVaultProvider
 } from '@kb-2/local-mcp';
 import {
-  createVaultService,
   type ServiceErrorCode,
   type ServiceResult,
   type VaultActor,
@@ -20,7 +18,6 @@ import {
   filePathParam,
   queryNumber,
   readJsonObject,
-  readOptionalJsonContent,
   readRequiredString,
   readSpliceRequest,
   requestTextContent
@@ -32,18 +29,13 @@ import type {
   VaultRegistryErrorCode
 } from './vault-registry.js';
 
-const DEMO_DOCUMENT_PATH = 'demo-vault/README.md';
 const ACTOR_HEADER = 'x-kb2-actor';
 const MAX_ACTOR_HEADER_BYTES = 1024;
 
 export interface CreateAppOptions {
   statusFile: string;
-  vaultRoot?: string;
-  documentSessions?: DocumentSessionManager;
-  vaultService?: VaultService;
   /** Live multi-vault registry powering vault CRUD and the `:id`-scoped data routes. */
   registry?: VaultRegistry;
-  demoDocumentSession?: OneFileDocumentSession;
   mcpEndpoint?: LocalMcpEndpoint;
   webBuildDir?: string;
   webProxyTarget?: string;
@@ -52,9 +44,8 @@ export interface CreateAppOptions {
 
 /**
  * How a data route resolves the vault it operates on and the path prefixes used
- * to slice the vault-relative file/folder path out of the request URL. The flat
- * routes and the `:id`-scoped routes share the exact same handlers; only this
- * resolver differs.
+ * to slice the vault-relative file/folder path out of the request URL. Every
+ * vault-scoped route shares the exact same handlers; only this resolver differs.
  */
 interface VaultRouteScope {
   /** Resolve the addressed vault service, or a clean failure for an unknown id. */
@@ -79,77 +70,21 @@ export function createApp(options: CreateAppOptions): Hono {
     });
   });
 
-  if (options.demoDocumentSession) {
-    api.get('/demo-document', async (context) => {
-      const content = await options.demoDocumentSession!.getContent();
-
-      return context.json({
-        ok: true,
-        document: DEMO_DOCUMENT_PATH,
-        content
-      });
-    });
-
-    api.post('/demo-document/reset', async (context) => {
-      const requestedContent = await readOptionalJsonContent(context.req.raw);
-      const content = await options.demoDocumentSession!.reset(requestedContent);
-
-      return context.json({
-        ok: true,
-        document: DEMO_DOCUMENT_PATH,
-        content
-      });
-    });
-  }
-
-  if (options.vaultRoot) {
-    const vaultService = options.vaultService ?? createVaultService({
-      vaultRoot: options.vaultRoot,
-      documentSessions: options.documentSessions ?? new DocumentSessionManager({ root: options.vaultRoot })
-    });
-    // One MCP endpoint addresses every vault. When a registry is present, vaultId
-    // resolution and vault enumeration go through it (the same source of truth as
-    // the HTTP layer); omitted vaultId still targets the default vault. Without a
-    // registry, the endpoint is the legacy single (default-vault) surface.
-    const mcpEndpoint = options.mcpEndpoint
-      ?? createLocalMcpEndpoint(
-        options.registry
-          ? mcpVaultProvider(vaultService, options.registry)
-          : vaultService
-      );
-    const actorDefault = options.actorDefault ?? 'user';
-
-    // Default-vault-only surface: flush and the SSE event stream. The local MCP
-    // endpoint above addresses any vault via its optional vaultId parameter.
-    api.post('/ops/flush', async (context) => {
-      return mapServiceResult(context, await vaultService.flushDirtySessions());
-    });
-
-    api.get('/events', () => {
-      return eventStreamResponse(vaultService);
-    });
-
-    app.all('/mcp', async (context) => {
-      return mcpEndpoint.handleRequest(context.req.raw);
-    });
-
-    // Backward-compat flat data routes, mapped to the default vault. They are
-    // retired in a later slice; until then they share the exact handlers used by
-    // the `:id`-scoped routes below — no parallel implementation.
-    const flatScope: VaultRouteScope = {
-      resolve: () => ({ ok: true, service: vaultService }),
-      filesPrefix: () => '/api/files/',
-      foldersPrefix: () => '/api/folders/'
-    };
-    registerVaultDataRoutes(api, flatScope, actorDefault);
-  }
-
   if (options.registry) {
     const registry = options.registry;
     const actorDefault = options.actorDefault ?? 'user';
 
+    // One MCP endpoint addresses every vault. vaultId resolution and vault
+    // enumeration go through the registry — the same source of truth as the HTTP
+    // layer. Every data tool requires a vaultId; there is no default vault.
+    const mcpEndpoint = options.mcpEndpoint ?? createLocalMcpEndpoint(mcpVaultProvider(registry));
+    app.all('/mcp', async (context) => {
+      return mcpEndpoint.handleRequest(context.req.raw);
+    });
+
     // Vault management: list, create (live, no restart), rename (displayName
     // only), and soft-delete (folder to trash, removed from the live registry).
+    // Zero vaults is a valid state: `list` simply returns an empty array.
     api.get('/vaults', (context) => {
       return context.json({ ok: true, vaults: registry.list() });
     });
@@ -159,7 +94,9 @@ export function createApp(options: CreateAppOptions): Hono {
       if (!body.ok) return mapServiceResult(context, body);
       const displayName = readRequiredString(body.body, 'displayName');
       if (!displayName.ok) return mapServiceResult(context, displayName);
-      const created = await registry.create({ displayName: displayName.value });
+      const slug = readRequiredString(body.body, 'slug');
+      if (!slug.ok) return mapServiceResult(context, slug);
+      const created = await registry.create({ displayName: displayName.value, slug: slug.value });
       return mapRegistryResult(context, created, created.ok ? { vault: created.vault } : undefined, 201);
     });
 
@@ -177,9 +114,9 @@ export function createApp(options: CreateAppOptions): Hono {
       return mapRegistryResult(context, deleted, deleted.ok ? {} : undefined);
     });
 
-    // `:id`-scoped data routes. `:id` resolves to that vault's instance from the
-    // registry; an unknown id is a clean 404. Otherwise these are the identical
-    // handlers used by the flat routes, just against the addressed vault.
+    // `:id`-scoped data routes — the only way to reach vault content. `:id`
+    // resolves to that vault's instance from the registry; an unknown id is a
+    // clean 404 (never a crash), which keeps zero-vaults a valid runtime state.
     const scopedScope: VaultRouteScope = {
       resolve: (context) => {
         const id = vaultIdParam(context);
@@ -225,10 +162,9 @@ export function createApp(options: CreateAppOptions): Hono {
 
 /**
  * Register the per-vault data routes (vault info, tree, search, files, folders)
- * on `router` under `basePath`. The `scope` decides which vault service each
+ * on `router` under `basePath`. The `scope` resolves which vault service each
  * request hits and which URL prefixes to strip when extracting vault-relative
- * paths. The flat routes and the `:id`-scoped routes both call this with
- * different scopes, so the file/folder/tree/search logic is written once.
+ * paths, keeping the file/folder/tree/search logic in exactly one place.
  */
 function registerVaultDataRoutes(
   router: Hono,
@@ -236,6 +172,18 @@ function registerVaultDataRoutes(
   actorDefault: ActorDefault,
   basePath = ''
 ): void {
+  router.post(`${basePath}/ops/flush`, async (context) => {
+    const resolved = scope.resolve(context);
+    if (!resolved.ok) return mapServiceResult(context, resolved);
+    return mapServiceResult(context, await resolved.service.flushDirtySessions());
+  });
+
+  router.get(`${basePath}/events`, (context) => {
+    const resolved = scope.resolve(context);
+    if (!resolved.ok) return mapServiceResult(context, resolved);
+    return eventStreamResponse(resolved.service);
+  });
+
   router.get(`${basePath}/vault`, async (context) => {
     const resolved = scope.resolve(context);
     if (!resolved.ok) return mapServiceResult(context, resolved);
@@ -503,12 +451,11 @@ function mapServiceResult(
 /**
  * Adapt the live registry to the MCP layer's vault provider. vaultId resolution
  * and vault enumeration both read from the same registry the HTTP routes use, so
- * the MCP endpoint never holds a second vault map. Omitted vaultId resolves to
- * the supplied default-vault service.
+ * the MCP endpoint never holds a second vault map. There is no default vault:
+ * every data tool must address a vault by id.
  */
-export function mcpVaultProvider(defaultService: VaultService, registry: VaultRegistry): LocalMcpVaultProvider {
+export function mcpVaultProvider(registry: VaultRegistry): LocalMcpVaultProvider {
   return {
-    default: () => defaultService,
     resolve: (id) => registry.get(id)?.service,
     list: () => registry.list()
   };

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -24,8 +24,9 @@ export interface DaemonConfig {
   /** Directory that holds every vault: `<home>/vaults/<slug>/`. */
   vaultsHome: string;
   /**
-   * Root of the default vault. Derived from the default slug under
-   * `vaultsHome` for backward compatibility with the single-vault surface.
+   * Well-known root of the vault stood up on first boot (and the legacy
+   * migration target): `<vaultsHome>/<default slug>/`. A convenience pointer to
+   * that location — the daemon serves vaults through the registry, not this path.
    */
   vaultRoot: string;
   statusFile: string;

--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -42,7 +42,7 @@ describe('daemon startup', () => {
     await close(blocker);
   });
 
-  it('creates and serves the demo document on startup', async () => {
+  it('seeds and serves the first-boot starter vault through its scoped route', async () => {
     const port = await reservePort();
     process.env = {
       ...originalEnv,
@@ -52,17 +52,26 @@ describe('daemon startup', () => {
     };
 
     const started = await startDaemon();
-    const response = await fetch(`http://127.0.0.1:${port}/api/demo-document`);
-    const body = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(body).toMatchObject({
+    // The first-boot starter vault is listed and reachable only via its scoped
+    // route — there is no flat default-vault surface.
+    const list = await fetch(`http://127.0.0.1:${port}/api/vaults`);
+    expect(list.status).toBe(200);
+    await expect(list.json()).resolves.toMatchObject({
       ok: true,
-      document: 'demo-vault/README.md'
+      vaults: [{ id: 'demo-vault' }]
     });
-    expect(typeof body.content).toBe('string');
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/vaults/demo-vault/files/README.md`);
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ ok: true, path: 'README.md' });
     expect(body.content).toContain('Welcome to your vault');
     await expect(readFile(join(started.config.vaultRoot, 'README.md'), 'utf8')).resolves.toBe(body.content);
+
+    // The retired flat surface is gone.
+    const flat = await fetch(`http://127.0.0.1:${port}/api/demo-document`);
+    expect(flat.status).toBe(404);
 
     await started.close();
   });
@@ -82,7 +91,7 @@ describe('daemon startup', () => {
     await expect(readFile(join(firstBoot.config.vaultRoot, 'README.md'), 'utf8')).resolves.toContain('Welcome to your vault');
     await expect(readFile(join(firstBoot.config.vaultRoot, 'notes', 'getting-started.md'), 'utf8')).resolves.toContain('Getting started');
 
-    const deleted = await fetch(`http://127.0.0.1:${port}/api/files/README.md`, { method: 'DELETE' });
+    const deleted = await fetch(`http://127.0.0.1:${port}/api/vaults/demo-vault/files/README.md`, { method: 'DELETE' });
     expect(deleted.status).toBe(200);
     await expect(access(join(firstBoot.config.vaultRoot, 'README.md'))).rejects.toBeTruthy();
     await firstBoot.close();
@@ -121,7 +130,7 @@ describe('daemon startup', () => {
     };
 
     const started = await startDaemon();
-    const socket = new WebSocket(`ws://127.0.0.1:${port}/api/files/typo/missing.md/yjs`);
+    const socket = new WebSocket(`ws://127.0.0.1:${port}/api/vaults/demo-vault/files/typo/missing.md/yjs`);
     const closed = new Promise<{ code: number; reason: string }>((resolve) => {
       socket.once('close', (code, reason) => resolve({ code, reason: reason.toString() }));
     });
@@ -146,7 +155,7 @@ describe('daemon startup', () => {
     };
 
     const started = await startDaemon();
-    const socket = new WebSocket(`ws://127.0.0.1:${port}/api/files/typo/missing.md/yjs`);
+    const socket = new WebSocket(`ws://127.0.0.1:${port}/api/vaults/demo-vault/files/typo/missing.md/yjs`);
     const closed = new Promise<{ code: number; reason: string }>((resolve) => {
       socket.once('close', (code, reason) => resolve({ code, reason: reason.toString() }));
     });
@@ -156,7 +165,7 @@ describe('daemon startup', () => {
       reason: JSON.stringify({ ok: false, error: 'not_found', message: 'file not found' })
     });
 
-    const created = await fetch(`http://127.0.0.1:${port}/api/files/typo/missing.md`, {
+    const created = await fetch(`http://127.0.0.1:${port}/api/vaults/demo-vault/files/typo/missing.md`, {
       method: 'PUT',
       headers: { 'content-type': 'text/plain' },
       body: 'created immediately\n'
@@ -314,14 +323,14 @@ describe('daemon vault management API', () => {
   }
 
   it('drives the full create -> list -> rename -> delete lifecycle live, with no restart', async () => {
-    // The default vault is present from boot.
+    // The first-boot starter vault is present from boot.
     expect(await listVaults()).toContainEqual({ id: 'demo-vault', displayName: 'demo-vault' });
 
-    // CREATE: caller supplies only a display name; the daemon owns the slug.
+    // CREATE: caller supplies BOTH display name and an explicit, valid slug.
     const createResponse = await fetch(`${base()}/api/vaults`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ displayName: 'Field Notes' })
+      body: JSON.stringify({ displayName: 'Field Notes', slug: 'field-notes' })
     });
     expect(createResponse.status).toBe(201);
     await expect(createResponse.json()).resolves.toEqual({
@@ -383,7 +392,7 @@ describe('daemon vault management API', () => {
     await fetch(`${base()}/api/vaults`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ displayName: 'Scoped' })
+      body: JSON.stringify({ displayName: 'Scoped', slug: 'scoped' })
     });
 
     // Write a note into the scoped vault only.
@@ -405,9 +414,13 @@ describe('daemon vault management API', () => {
     expect(read.status).toBe(200);
     await expect(read.json()).resolves.toMatchObject({ ok: true, content: 'scoped content\n' });
 
-    // The default (flat) vault does not see the scoped vault's note.
+    // The retired flat route does not exist: it falls through to a clean 404.
     const flatRead = await fetch(`${base()}/api/files/only-here.md`);
     expect(flatRead.status).toBe(404);
+
+    // A different vault does not see the scoped vault's note either.
+    const otherRead = await fetch(`${base()}/api/vaults/demo-vault/files/only-here.md`);
+    expect(otherRead.status).toBe(404);
   });
 
   it('returns a clean 404 for data routes addressing an unknown vault, without crashing', async () => {
@@ -424,24 +437,73 @@ describe('daemon vault management API', () => {
     const first = await fetch(`${base()}/api/vaults`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ displayName: 'Dup' })
+      body: JSON.stringify({ displayName: 'Dup', slug: 'dup' })
     });
     expect(first.status).toBe(201);
 
     const collision = await fetch(`${base()}/api/vaults`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ displayName: 'dup' })
+      body: JSON.stringify({ displayName: 'Another Dup', slug: 'dup' })
     });
     expect(collision.status).toBe(409);
     await expect(collision.json()).resolves.toMatchObject({ ok: false, error: 'already_exists' });
+  });
+
+  it('rejects a create with an invalid or missing slug as a clean 400', async () => {
+    // A non-normalized slug is never inferred from the display name; it is a 400.
+    const invalid = await fetch(`${base()}/api/vaults`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ displayName: 'Field Notes', slug: 'Field Notes' })
+    });
+    expect(invalid.status).toBe(400);
+    await expect(invalid.json()).resolves.toMatchObject({ ok: false, error: 'invalid_request' });
+
+    // A missing slug is also a clean 400 (the server never infers it).
+    const missing = await fetch(`${base()}/api/vaults`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ displayName: 'Field Notes' })
+    });
+    expect(missing.status).toBe(400);
+    await expect(missing.json()).resolves.toMatchObject({ ok: false, error: 'invalid_request' });
+
+    // Nothing landed on disk for the rejected slug.
+    await expect(access(join(kb2Home, 'vaults', 'field-notes'))).rejects.toBeTruthy();
+  });
+
+  it('treats zero vaults as a valid state: deleting the last vault still serves', async () => {
+    // Delete the only (starter) vault, leaving the daemon with no vaults.
+    const deleted = await fetch(`${base()}/api/vaults/demo-vault`, { method: 'DELETE' });
+    expect(deleted.status).toBe(200);
+
+    // Listing returns an empty array, not an error.
+    await expect(listVaults()).resolves.toEqual([]);
+
+    // Scoped routes for the now-missing vault return a clean 404 (no crash).
+    const goneTree = await fetch(`${base()}/api/vaults/demo-vault/tree`);
+    expect(goneTree.status).toBe(404);
+
+    // The daemon is still healthy and the web bundle path still serves.
+    const health = await fetch(`${base()}/api/health`);
+    expect(health.status).toBe(200);
+
+    // A fresh vault can still be created from the empty state.
+    const recreated = await fetch(`${base()}/api/vaults`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ displayName: 'Fresh Start', slug: 'fresh-start' })
+    });
+    expect(recreated.status).toBe(201);
+    expect(await listVaults()).toContainEqual({ id: 'fresh-start', displayName: 'Fresh Start' });
   });
 
   it('edits a live document over the scoped Yjs WebSocket and persists to the scoped vault', async () => {
     await fetch(`${base()}/api/vaults`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ displayName: 'WS Vault' })
+      body: JSON.stringify({ displayName: 'WS Vault', slug: 'ws-vault' })
     });
     await fetch(`${base()}/api/vaults/ws-vault/files/doc.md`, {
       method: 'PUT',
@@ -504,11 +566,11 @@ describe('daemon multi-vault MCP surface', () => {
 
   const base = () => `http://127.0.0.1:${port}`;
 
-  async function createVault(displayName: string): Promise<string> {
+  async function createVault(displayName: string, slug: string): Promise<string> {
     const response = await fetch(`${base()}/api/vaults`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ displayName })
+      body: JSON.stringify({ displayName, slug })
     });
     expect(response.status).toBe(201);
     const body = await response.json();
@@ -516,7 +578,7 @@ describe('daemon multi-vault MCP surface', () => {
   }
 
   it('lists every vault through the list_vaults tool, mirroring the registry', async () => {
-    const created = await createVault('Field Notes');
+    const created = await createVault('Field Notes', 'field-notes');
     expect(created).toBe('field-notes');
 
     const listed = await mcpToolJson(client, 'list_vaults', {}) as {
@@ -524,36 +586,39 @@ describe('daemon multi-vault MCP surface', () => {
       vaults: Array<{ id: string; displayName: string }>;
     };
     expect(listed.ok).toBe(true);
-    // The default vault plus the freshly created one — same shape the HTTP API returns.
+    // The starter vault plus the freshly created one — same shape the HTTP API returns.
     expect(listed.vaults).toContainEqual({ id: 'demo-vault', displayName: 'demo-vault' });
     expect(listed.vaults).toContainEqual({ id: 'field-notes', displayName: 'Field Notes' });
   });
 
-  it('advertises the optional vaultId param on data tools but not on list_vaults', async () => {
+  it('requires the vaultId param on data tools but not on list_vaults', async () => {
     const tools = await client.listTools();
     const vaultInfo = tools.tools.find((tool) => tool.name === 'vault_info');
     expect(vaultInfo?.inputSchema.properties).toHaveProperty('vaultId');
+    expect(vaultInfo?.inputSchema.required ?? []).toContain('vaultId');
     const createNote = tools.tools.find((tool) => tool.name === 'create_note');
     expect(createNote?.inputSchema.properties).toHaveProperty('vaultId');
+    expect(createNote?.inputSchema.required ?? []).toContain('vaultId');
     const listVaults = tools.tools.find((tool) => tool.name === 'list_vaults');
     expect(listVaults?.inputSchema.properties ?? {}).not.toHaveProperty('vaultId');
   });
 
-  it('operates on the default vault when vaultId is omitted (backward compatible)', async () => {
-    await expect(mcpToolJson(client, 'create_note', { path: 'in-default.md', content: 'default body\n' }))
-      .resolves.toMatchObject({ ok: true, path: 'in-default.md' });
+  it('rejects a data-tool call that omits vaultId (no default vault)', async () => {
+    const missing = await client.callTool({ name: 'create_note', arguments: { path: 'nope.md', content: 'x\n' } });
+    expect(missing.isError).toBe(true);
 
-    // It landed in the default vault's folder on disk.
-    await expect(readFile(join(kb2Home, 'vaults', 'demo-vault', 'in-default.md'), 'utf8'))
-      .resolves.toBe('default body\n');
+    // Nothing was written into any vault.
+    await expect(access(join(kb2Home, 'vaults', 'demo-vault', 'nope.md'))).rejects.toBeTruthy();
 
-    // And reads back with no vaultId.
-    await expect(mcpToolJson(client, 'read_note', { path: 'in-default.md' }))
-      .resolves.toMatchObject({ ok: true, content: 'default body\n' });
+    // The same call WITH a valid vaultId succeeds.
+    await expect(mcpToolJson(client, 'create_note', { vaultId: 'demo-vault', path: 'in-starter.md', content: 'body\n' }))
+      .resolves.toMatchObject({ ok: true, path: 'in-starter.md' });
+    await expect(readFile(join(kb2Home, 'vaults', 'demo-vault', 'in-starter.md'), 'utf8'))
+      .resolves.toBe('body\n');
   });
 
-  it('addresses a second vault by vaultId and keeps it isolated from the default vault', async () => {
-    const vaultId = await createVault('Second');
+  it('addresses a second vault by vaultId and keeps it isolated from the starter vault', async () => {
+    const vaultId = await createVault('Second', 'second');
     expect(vaultId).toBe('second');
 
     // Write a note into the second vault via MCP using its vaultId.
@@ -571,13 +636,13 @@ describe('daemon multi-vault MCP surface', () => {
     await expect(mcpToolJson(client, 'read_note', { vaultId, path: 'only-in-second.md' }))
       .resolves.toMatchObject({ ok: true, content: 'second body\n' });
 
-    // Cross-vault isolation: the default vault does not see it (MCP and HTTP both miss).
-    const defaultRead = await client.callTool({ name: 'read_note', arguments: { path: 'only-in-second.md' } });
-    expect(defaultRead.isError).toBe(true);
-    expect(mcpText(defaultRead)).toContain('"error":"not_found"');
+    // Cross-vault isolation: the starter vault does not see it (MCP and HTTP both miss).
+    const starterRead = await client.callTool({ name: 'read_note', arguments: { vaultId: 'demo-vault', path: 'only-in-second.md' } });
+    expect(starterRead.isError).toBe(true);
+    expect(mcpText(starterRead)).toContain('"error":"not_found"');
 
-    const httpFlatRead = await fetch(`${base()}/api/files/only-in-second.md`);
-    expect(httpFlatRead.status).toBe(404);
+    const httpStarterRead = await fetch(`${base()}/api/vaults/demo-vault/files/only-in-second.md`);
+    expect(httpStarterRead.status).toBe(404);
 
     // And the HTTP scoped route for the second vault DOES see it — same content.
     const httpScopedRead = await fetch(`${base()}/api/vaults/second/files/only-in-second.md`);

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import { serve } from '@hono/node-server';
-import { bindYjsWebSocket, type DocumentSessionManager, type OneFileDocumentSession } from '@kb-2/doc-session';
+import { bindYjsWebSocket, type DocumentSessionManager } from '@kb-2/doc-session';
 import { createLocalMcpEndpoint } from '@kb-2/local-mcp';
 import { TunnelClient, type TunnelClientLogger } from '@kb-2/tunnel-client';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { readVaultFile, validateVaultPath } from '@kb-2/vault-core';
+import { validateVaultPath } from '@kb-2/vault-core';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { WebSocketServer } from 'ws';
 
@@ -22,12 +22,6 @@ import {
   VAULT_TRASH_DIRNAME,
   VaultRegistry
 } from './vault-registry.js';
-
-// The legacy single-vault demo surface (`/api/demo-document` + its Yjs socket)
-// is backed by the starter kit's top-level README, which a first-boot vault is
-// always seeded with. The session is bound only when that file is present.
-const DEMO_DOCUMENT_PATH = 'README.md';
-const DEMO_DOCUMENT_YJS_PATH = '/api/demo-document/yjs';
 
 export interface StartedDaemon {
   config: DaemonConfig;
@@ -53,38 +47,23 @@ export async function startDaemon(): Promise<StartedDaemon> {
 
   // First boot: with no legacy vault to migrate and nothing discovered, stand up
   // a single starter vault seeded from the bundled kit. `create` performs the
-  // seeding, so there is no separate seed path.
+  // seeding, so there is no separate seed path. After first boot, zero vaults is
+  // a valid state — deleting every vault leaves the daemon serving an empty list.
   if (registry.list().length === 0) {
-    const created = await registry.create({ displayName: DEFAULT_VAULT_SLUG });
+    const created = await registry.create({ displayName: DEFAULT_VAULT_SLUG, slug: DEFAULT_VAULT_SLUG });
     if (!created.ok) {
       throw new Error(`Failed to create the starter vault: ${created.message}`);
     }
   }
 
-  // Backward compat: the existing single-vault HTTP/WS/MCP surface operates on
-  // the default vault's instance. First boot guarantees it exists; discovery
-  // finds it on every subsequent boot.
-  const defaultInstance = registry.get(DEFAULT_VAULT_SLUG);
-  if (!defaultInstance) {
-    throw new Error(`Default vault "${DEFAULT_VAULT_SLUG}" was not discovered after boot.`);
-  }
-  const documentSessions = defaultInstance.manager;
-  const vaultService = defaultInstance.service;
-  const demoDocumentSession = await openDemoDocumentSession(documentSessions, config.vaultRoot);
-
   // One MCP endpoint, every vault: vaultId resolution and vault enumeration both
   // go through the SAME live registry the HTTP layer uses — no second vault map.
-  // Omitted vaultId targets the default vault, keeping the single-vault MCP
-  // surface backward compatible.
-  const mcpEndpoint = createLocalMcpEndpoint(mcpVaultProvider(vaultService, registry));
+  // Every data tool requires a vaultId; there is no default vault.
+  const mcpEndpoint = createLocalMcpEndpoint(mcpVaultProvider(registry));
 
   const app = createApp({
     statusFile: config.statusFile,
-    vaultRoot: config.vaultRoot,
-    vaultService,
-    documentSessions,
     registry,
-    demoDocumentSession,
     mcpEndpoint,
     webBuildDir: fileURLToPath(new URL('../../web/build', import.meta.url)),
     webProxyTarget: config.webProxyTarget,
@@ -142,9 +121,10 @@ export async function startDaemon(): Promise<StartedDaemon> {
 
     server.on('upgrade', (request, socket, head) => {
       const pathname = request.url ? new URL(request.url, `http://${request.headers.host ?? 'localhost'}`).pathname : '';
-      // Resolve the addressed vault's document manager: the flat WS path uses
-      // the default vault, the `/api/vaults/:id/...` path uses that vault.
-      const target = resolveWebSocketTarget(pathname, documentSessions, registry);
+      // Resolve the addressed vault's document manager from the scoped
+      // `/api/vaults/:id/files/.../yjs` path. An unknown vault or invalid path
+      // is refused.
+      const target = resolveWebSocketTarget(pathname, registry);
       if (!target) {
         socket.destroy();
         return;
@@ -210,28 +190,6 @@ const daemonRelayLogger: TunnelClientLogger = {
   },
 };
 
-/**
- * Open the legacy demo-document session when the default vault has the backing
- * file. The demo surface is served only while that file exists, so a vault that
- * lacks it simply has no demo session.
- */
-async function openDemoDocumentSession(
-  manager: DocumentSessionManager,
-  vaultRoot: string
-): Promise<OneFileDocumentSession | undefined> {
-  const existing = await readVaultFile({ root: vaultRoot }, DEMO_DOCUMENT_PATH);
-  if (!existing.ok) {
-    if (existing.error !== 'not_found') {
-      throw new Error(existing.message);
-    }
-    return undefined;
-  }
-
-  const session = manager.getSession(DEMO_DOCUMENT_PATH);
-  await session.open();
-  return session;
-}
-
 interface WebSocketTarget {
   manager: DocumentSessionManager;
   documentPath: string;
@@ -239,40 +197,30 @@ interface WebSocketTarget {
 
 /**
  * Resolve a Yjs WebSocket path to the document manager and vault-relative path
- * it addresses. Recognizes the demo-document alias, the flat `/api/files/.../yjs`
- * path (default vault), and the scoped `/api/vaults/:id/files/.../yjs` path
- * (the addressed vault). Returns `undefined` for an unknown id or invalid path.
+ * it addresses. Only the scoped `/api/vaults/:id/files/.../yjs` path is served;
+ * there is no flat (default-vault) path. Returns `undefined` for an unknown id
+ * or invalid path so the upgrade is refused.
  */
 function resolveWebSocketTarget(
   pathname: string,
-  defaultManager: DocumentSessionManager,
   registry: VaultRegistry
 ): WebSocketTarget | undefined {
-  if (pathname === DEMO_DOCUMENT_YJS_PATH) {
-    return { manager: defaultManager, documentPath: DEMO_DOCUMENT_PATH };
-  }
-
   const suffix = '/yjs';
   if (!pathname.endsWith(suffix)) {
     return undefined;
   }
 
   const scoped = parseScopedFilesPath(pathname.slice(0, -suffix.length));
-  if (scoped) {
-    const instance = registry.get(scoped.id);
-    if (!instance) {
-      return undefined;
-    }
-    const documentPath = safeValidateFilePath(scoped.rawPath);
-    return documentPath ? { manager: instance.manager, documentPath } : undefined;
-  }
-
-  const flatPrefix = '/api/files/';
-  if (!pathname.startsWith(flatPrefix)) {
+  if (!scoped) {
     return undefined;
   }
-  const documentPath = safeValidateFilePath(pathname.slice(flatPrefix.length, -suffix.length));
-  return documentPath ? { manager: defaultManager, documentPath } : undefined;
+
+  const instance = registry.get(scoped.id);
+  if (!instance) {
+    return undefined;
+  }
+  const documentPath = safeValidateFilePath(scoped.rawPath);
+  return documentPath ? { manager: instance.manager, documentPath } : undefined;
 }
 
 /** Parse `/api/vaults/<id>/files/<rawPath>` into its id and raw file path. */

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -1,5 +1,5 @@
 import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
-import { DocumentSessionManager, OneFileDocumentSession, type DocumentSessionEvent } from '@kb-2/doc-session';
+import { DocumentSessionManager, type DocumentSessionEvent } from '@kb-2/doc-session';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { serve } from '@hono/node-server';
@@ -11,10 +11,15 @@ import { tmpdir } from 'node:os';
 import * as Y from 'yjs';
 
 import { anchoredSpliceContractCases } from '@kb-2/vault-core';
-import type { VaultChangeEvent } from '@kb-2/vault-service';
+import type { VaultChangeEvent, VaultService } from '@kb-2/vault-service';
 import { createApp } from './app.js';
 import { createDaemonConfig } from './config.js';
 import { writeDaemonStatus } from './status.js';
+import { VAULT_TRASH_DIRNAME, VaultRegistry } from './vault-registry.js';
+
+// The vault slug every scoped data-route test addresses. The data routes are
+// only reachable as `/api/vaults/:id/*`; there is no flat (default-vault) path.
+const VAULT = 'demo-vault';
 
 describe('daemon routing', () => {
   let kb2Home: string;
@@ -26,6 +31,35 @@ describe('daemon routing', () => {
   afterEach(async () => {
     await rm(kb2Home, { force: true, recursive: true });
   });
+
+  /**
+   * Stand up a registry over the throwaway home with a single empty vault, plus
+   * the app that serves it. Scoped routes hit the same live `service`/`manager`
+   * returned here, so live-session assertions and HTTP requests share state.
+   */
+  async function setupScopedVault(): Promise<{
+    app: Hono;
+    registry: VaultRegistry;
+    service: VaultService;
+    manager: DocumentSessionManager;
+    vaultRoot: string;
+    config: ReturnType<typeof createDaemonConfig>;
+  }> {
+    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
+    const vaultsHome = config.vaultsHome;
+    await mkdir(join(vaultsHome, VAULT), { recursive: true });
+    const registry = await VaultRegistry.load(vaultsHome, join(kb2Home, VAULT_TRASH_DIRNAME));
+    const instance = registry.get(VAULT);
+    if (!instance) throw new Error('expected the seeded vault to load');
+    const app = createApp({ statusFile: config.statusFile, registry, actorDefault: config.actorDefault });
+    return { app, registry, service: instance.service, manager: instance.manager, vaultRoot: instance.entry.root, config };
+  }
+
+  /** Path to a scoped file route for the lone test vault. */
+  const filePath = (vaultPath: string): string => `/api/vaults/${VAULT}/files/${vaultPath}`;
+  /** Path to a scoped folder route for the lone test vault. */
+  const folderPath = (vaultPath?: string): string =>
+    vaultPath === undefined ? `/api/vaults/${VAULT}/folders` : `/api/vaults/${VAULT}/folders/${vaultPath}`;
 
   it('returns daemon status read back from the configured filesystem home', async () => {
     const config = createDaemonConfig({
@@ -125,56 +159,10 @@ describe('daemon routing', () => {
     await rm(webBuildDir, { force: true, recursive: true });
   });
 
-  it('reads and resets the one-file demo document through the daemon API', async () => {
-    const config = createDaemonConfig({
-      env: {
-        KB2_HOME: kb2Home
-      }
-    });
-    const demoDocumentFile = join(config.vaultRoot, 'README.md');
-    const documentSession = new OneFileDocumentSession(demoDocumentFile, { defaultContent: 'route seed\n' });
-    await documentSession.open();
+  it('exposes scoped vault file routes with no-clobber writes, overwrite, taxonomy, and audit rows', async () => {
+    const { app, vaultRoot } = await setupScopedVault();
 
-    const app = createApp({
-      statusFile: config.statusFile,
-      demoDocumentSession: documentSession
-    });
-
-    const readResponse = await app.request('/api/demo-document');
-    const readBody = await readResponse.json();
-
-    expect(readResponse.status).toBe(200);
-    expect(readBody).toEqual({
-      ok: true,
-      document: 'demo-vault/README.md',
-      content: 'route seed\n'
-    });
-
-    const resetResponse = await app.request('/api/demo-document/reset', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json'
-      },
-      body: JSON.stringify({ content: 'route reset\n' })
-    });
-    const resetBody = await resetResponse.json();
-
-    expect(resetResponse.status).toBe(200);
-    expect(resetBody).toEqual({
-      ok: true,
-      document: 'demo-vault/README.md',
-      content: 'route reset\n'
-    });
-    await expect(readFile(demoDocumentFile, 'utf8')).resolves.toBe('route reset\n');
-
-    await documentSession.close();
-  });
-
-  it('exposes vault file routes with no-clobber writes, overwrite, taxonomy, and audit rows', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot });
-
-    const created = await app.request('/api/files/notes/a.md', {
+    const created = await app.request(filePath('notes/a.md'), {
       method: 'PUT',
       headers: { 'content-type': 'text/plain' },
       body: 'first'
@@ -182,7 +170,7 @@ describe('daemon routing', () => {
     expect(created.status).toBe(201);
     await expect(created.json()).resolves.toMatchObject({ ok: true, path: 'notes/a.md' });
 
-    const duplicate = await app.request('/api/files/notes/a.md', {
+    const duplicate = await app.request(filePath('notes/a.md'), {
       method: 'PUT',
       headers: { 'content-type': 'text/plain' },
       body: 'second'
@@ -190,42 +178,44 @@ describe('daemon routing', () => {
     expect(duplicate.status).toBe(409);
     await expect(duplicate.json()).resolves.toMatchObject({ ok: false, error: 'already_exists' });
 
-    const overwritten = await app.request('/api/files/notes/a.md?overwrite=true', {
+    const overwritten = await app.request(`${filePath('notes/a.md')}?overwrite=true`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ content: 'second' })
     });
     expect(overwritten.status).toBe(200);
 
-    const read = await app.request('/api/files/notes/a.md');
+    const read = await app.request(filePath('notes/a.md'));
     expect(read.status).toBe(200);
     await expect(read.json()).resolves.toMatchObject({ ok: true, path: 'notes/a.md', content: 'second' });
 
-    const invalid = await app.request('/api/files/no-extension', { method: 'PUT', body: 'x' });
+    const invalid = await app.request(filePath('no-extension'), { method: 'PUT', body: 'x' });
     expect(invalid.status).toBe(400);
     await expect(invalid.json()).resolves.toMatchObject({ ok: false, error: 'invalid_path' });
 
-    const audit = await readAuditRows(config.vaultRoot);
+    const audit = await readAuditRows(vaultRoot);
     expect(audit).toHaveLength(2);
     expect(audit[0]).toMatchObject({ operation: 'create', entityKind: 'file', path: 'notes/a.md', actor: { kind: 'user' } });
     expect(audit[1]).toMatchObject({ operation: 'write', path: 'notes/a.md' });
   });
 
+  it('returns a clean 404 for a scoped data route addressing an unknown vault', async () => {
+    const { app } = await setupScopedVault();
+    const response = await app.request('/api/vaults/does-not-exist/tree');
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({ ok: false, error: 'not_found' });
+  });
+
   it('attributes REST writes from the x-kb2-actor header in responses and audit JSONL', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const app = createApp({
-      statusFile: config.statusFile,
-      vaultRoot: config.vaultRoot,
-      actorDefault: config.actorDefault
-    });
+    const { app, vaultRoot } = await setupScopedVault();
     const suppliedActor = {
       kind: 'integration',
       id: 'user-123',
       name: 'Ada Lovelace',
-      client: 'kb-1-cloud'
+      client: 'integration-client'
     };
 
-    const created = await app.request('/api/files/notes/attributed.md', {
+    const created = await app.request(filePath('notes/attributed.md'), {
       method: 'PUT',
       headers: {
         'content-type': 'text/plain',
@@ -240,9 +230,9 @@ describe('daemon routing', () => {
       path: 'notes/attributed.md',
       audit: { actor: suppliedActor }
     });
-    await expect(readFile(join(config.vaultRoot, 'notes/attributed.md'), 'utf8')).resolves.toBe('attributed\n');
+    await expect(readFile(join(vaultRoot, 'notes/attributed.md'), 'utf8')).resolves.toBe('attributed\n');
 
-    const audit = await readAuditRows(config.vaultRoot);
+    const audit = await readAuditRows(vaultRoot);
     expect(audit).toHaveLength(1);
     expect(audit[0]).toMatchObject({
       operation: 'create',
@@ -257,13 +247,12 @@ describe('daemon routing', () => {
     { name: 'configured unknown mode', env: { KB2_ACTOR_DEFAULT: 'unknown' }, expectedActor: { kind: 'unknown' } }
   ])('uses $name for REST writes without an actor header', async ({ env, expectedActor }) => {
     const config = createDaemonConfig({ env: { KB2_HOME: kb2Home, ...env } });
-    const app = createApp({
-      statusFile: config.statusFile,
-      vaultRoot: config.vaultRoot,
-      actorDefault: config.actorDefault
-    });
+    await mkdir(join(config.vaultsHome, VAULT), { recursive: true });
+    const registry = await VaultRegistry.load(config.vaultsHome, join(kb2Home, VAULT_TRASH_DIRNAME));
+    const vaultRoot = registry.get(VAULT)!.entry.root;
+    const app = createApp({ statusFile: config.statusFile, registry, actorDefault: config.actorDefault });
 
-    const created = await app.request('/api/files/notes/defaulted.md', {
+    const created = await app.request(filePath('notes/defaulted.md'), {
       method: 'PUT',
       headers: { 'content-type': 'text/plain' },
       body: 'defaulted\n'
@@ -274,15 +263,16 @@ describe('daemon routing', () => {
       ok: true,
       audit: { actor: expectedActor }
     });
-    await expect(readFile(join(config.vaultRoot, 'notes/defaulted.md'), 'utf8')).resolves.toBe('defaulted\n');
+    await expect(readFile(join(vaultRoot, 'notes/defaulted.md'), 'utf8')).resolves.toBe('defaulted\n');
 
-    const audit = await readAuditRows(config.vaultRoot);
+    const audit = await readAuditRows(vaultRoot);
     expect(audit).toHaveLength(1);
     expect(audit[0]).toMatchObject({
       operation: 'create',
       path: 'notes/defaulted.md',
       actor: expectedActor
     });
+    await registry.close();
   });
 
   it.each([
@@ -293,14 +283,9 @@ describe('daemon routing', () => {
     { name: 'oversized payload', header: JSON.stringify({ kind: 'user', name: 'x'.repeat(1025) }) },
     { name: 'non-string identity field', header: JSON.stringify({ kind: 'user', id: 123 }) }
   ])('rejects malformed REST actor header: $name', async ({ header }) => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const app = createApp({
-      statusFile: config.statusFile,
-      vaultRoot: config.vaultRoot,
-      actorDefault: config.actorDefault
-    });
+    const { app, vaultRoot } = await setupScopedVault();
 
-    const response = await app.request('/api/files/notes/rejected.md', {
+    const response = await app.request(filePath('notes/rejected.md'), {
       method: 'PUT',
       headers: {
         'content-type': 'text/plain',
@@ -314,22 +299,21 @@ describe('daemon routing', () => {
       ok: false,
       error: 'invalid_actor'
     });
-    await expect(stat(join(config.vaultRoot, 'notes/rejected.md'))).rejects.toMatchObject({ code: 'ENOENT' });
-    await expect(stat(join(config.vaultRoot, '.kb2/audit/changes.jsonl'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(stat(join(vaultRoot, 'notes/rejected.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(stat(join(vaultRoot, '.kb2/audit/changes.jsonl'))).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it('moves and deletes live file sessions through the API with doc events and trash', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
-    const liveSession = sessions.getSession('notes/live.md');
+    const { app, manager, vaultRoot } = await setupScopedVault();
+    await writeFileWithParents(join(vaultRoot, 'notes/live.md'), '');
+    const liveSession = manager.getSession('notes/live.md');
     const events: DocumentSessionEvent[] = [];
     liveSession.onEvent((event) => events.push(event));
     await liveSession.open();
     liveSession.ydoc.getText('markdown').insert(0, 'live content\n');
     await liveSession.flush();
 
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
-    const moved = await app.request('/api/files/notes/live.md/move', {
+    const moved = await app.request(`${filePath('notes/live.md')}/move`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ to: 'notes/renamed.md' })
@@ -339,36 +323,34 @@ describe('daemon routing', () => {
     liveSession.ydoc.getText('markdown').insert(liveSession.ydoc.getText('markdown').length, 'after move\n');
     await liveSession.flush();
 
-    await expect(readFile(join(config.vaultRoot, 'notes/renamed.md'), 'utf8')).resolves.toBe('live content\nafter move\n');
-    await expect(readFile(join(config.vaultRoot, 'notes/live.md'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(readFile(join(vaultRoot, 'notes/renamed.md'), 'utf8')).resolves.toBe('live content\nafter move\n');
+    await expect(readFile(join(vaultRoot, 'notes/live.md'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     expect(events).toContainEqual(expect.objectContaining({ kind: 'doc-moved', fromPath: 'notes/live.md', toPath: 'notes/renamed.md' }));
 
-    const deleted = await app.request('/api/files/notes/renamed.md', { method: 'DELETE' });
+    const deleted = await app.request(filePath('notes/renamed.md'), { method: 'DELETE' });
     expect(deleted.status).toBe(200);
     await expect(deleted.json()).resolves.toMatchObject({ ok: true, path: 'notes/renamed.md', live: true });
     expect(events).toContainEqual(expect.objectContaining({ kind: 'doc-deleted', path: 'notes/renamed.md' }));
 
-    const tree = await app.request('/api/tree');
+    const tree = await app.request(`/api/vaults/${VAULT}/tree`);
     const treeBody = await tree.json() as { entries: Array<{ path: string }> };
     expect(treeBody.entries.map((entry) => entry.path)).not.toContain('notes/renamed.md');
-    const audit = await readAuditRows(config.vaultRoot);
+    const audit = await readAuditRows(vaultRoot);
     expect(audit.map((row) => row.operation)).toEqual(['move', 'delete']);
     expect(String(audit[1].summary)).toContain('trash');
-    await sessions.close();
   });
 
   it('moves folder subtrees and rekeys live sessions underneath them', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
-    const nested = sessions.getSession('parent/folder/deep/live.md');
+    const { app, manager, vaultRoot } = await setupScopedVault();
+    await writeFileWithParents(join(vaultRoot, 'parent/folder/deep/live.md'), '');
+    const nested = manager.getSession('parent/folder/deep/live.md');
     const events: DocumentSessionEvent[] = [];
     nested.onEvent((event) => events.push(event));
     await nested.open();
     nested.ydoc.getText('markdown').insert(0, 'nested\n');
     await nested.flush();
 
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
-    const moved = await app.request('/api/folders/parent/folder/move', {
+    const moved = await app.request(`${folderPath('parent/folder')}/move`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ to: 'parent/moved/folder' })
@@ -384,23 +366,20 @@ describe('daemon routing', () => {
     nested.ydoc.getText('markdown').insert(nested.ydoc.getText('markdown').length, 'after folder move\n');
     await nested.flush();
 
-    await expect(readFile(join(config.vaultRoot, 'parent/moved/folder/deep/live.md'), 'utf8')).resolves.toBe('nested\nafter folder move\n');
-    await expect(readFile(join(config.vaultRoot, 'parent/folder/deep/live.md'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(readFile(join(vaultRoot, 'parent/moved/folder/deep/live.md'), 'utf8')).resolves.toBe('nested\nafter folder move\n');
+    await expect(readFile(join(vaultRoot, 'parent/folder/deep/live.md'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     expect(events).toContainEqual(expect.objectContaining({
       kind: 'doc-moved',
       fromPath: 'parent/folder/deep/live.md',
       toPath: 'parent/moved/folder/deep/live.md'
     }));
-    await sessions.close();
   });
 
   it('moves zero-live folder subtrees through the production session manager once', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
-    await mkdir(join(config.vaultRoot, 'emptydir'), { recursive: true });
+    const { app, vaultRoot } = await setupScopedVault();
+    await mkdir(join(vaultRoot, 'emptydir'), { recursive: true });
 
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
-    const moved = await app.request('/api/folders/emptydir/move', {
+    const moved = await app.request(`${folderPath('emptydir')}/move`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ to: 'moved/emptydir' })
@@ -413,26 +392,24 @@ describe('daemon routing', () => {
       toPath: 'moved/emptydir',
       liveMoved: []
     });
-    expect((await stat(join(config.vaultRoot, 'moved/emptydir'))).isDirectory()).toBe(true);
-    await expect(stat(join(config.vaultRoot, 'emptydir'))).rejects.toMatchObject({ code: 'ENOENT' });
-    const audit = await readAuditRows(config.vaultRoot);
+    expect((await stat(join(vaultRoot, 'moved/emptydir'))).isDirectory()).toBe(true);
+    await expect(stat(join(vaultRoot, 'emptydir'))).rejects.toMatchObject({ code: 'ENOENT' });
+    const audit = await readAuditRows(vaultRoot);
     expect(audit).toHaveLength(1);
     expect(audit[0]).toMatchObject({ operation: 'move', entityKind: 'folder', fromPath: 'emptydir', toPath: 'moved/emptydir' });
-    await sessions.close();
   });
 
   it('reads and writes folder metadata through REST and hydrates tree folders inline', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot });
+    const { app, vaultRoot } = await setupScopedVault();
 
-    const created = await app.request('/api/folders', {
+    const created = await app.request(folderPath(), {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ path: 'notes' })
     });
     expect(created.status).toBe(201);
 
-    const set = await app.request('/api/folders/notes/metadata', {
+    const set = await app.request(`${folderPath('notes')}/metadata`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ color: 'coral', icon: 'folder' })
@@ -444,43 +421,42 @@ describe('daemon routing', () => {
       metadata: { color: 'coral', icon: 'folder' },
       audit: { operation: 'write', entityKind: 'folder', path: 'notes' }
     });
-    const setRaw = await readRawFolderMetadata(config.vaultRoot);
+    const setRaw = await readRawFolderMetadata(vaultRoot);
     expect(setRaw).toContain('notes:');
     expect(setRaw).toContain('color: coral');
     expect(setRaw).toContain('icon: folder');
 
-    const read = await app.request('/api/folders/notes/metadata');
+    const read = await app.request(`${folderPath('notes')}/metadata`);
     expect(read.status).toBe(200);
     await expect(read.json()).resolves.toMatchObject({ ok: true, path: 'notes', metadata: { color: 'coral', icon: 'folder' } });
 
-    const tree = await app.request('/api/tree');
+    const tree = await app.request(`/api/vaults/${VAULT}/tree`);
     expect(tree.status).toBe(200);
     await expect(tree.json()).resolves.toMatchObject({
       ok: true,
       entries: [{ path: 'notes', kind: 'folder', metadata: { color: 'coral', icon: 'folder' } }]
     });
 
-    const cleared = await app.request('/api/folders/notes/metadata', {
+    const cleared = await app.request(`${folderPath('notes')}/metadata`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ color: null, icon: null })
     });
     expect(cleared.status).toBe(200);
     await expect(cleared.json()).resolves.toMatchObject({ ok: true, metadata: {} });
-    const raw = await readRawFolderMetadata(config.vaultRoot);
+    const raw = await readRawFolderMetadata(vaultRoot);
     expect(raw).toContain('folders: {}');
 
-    const audit = await readAuditRows(config.vaultRoot);
+    const audit = await readAuditRows(vaultRoot);
     expect(audit.map((row) => row.operation)).toEqual(['mkdir', 'write', 'write']);
   });
 
   it('maps folder metadata REST failures through the canonical service dialect', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot });
+    const { app, vaultRoot } = await setupScopedVault();
 
-    await mkdir(join(config.vaultRoot, 'notes'), { recursive: true });
+    await mkdir(join(vaultRoot, 'notes'), { recursive: true });
 
-    const nonString = await app.request('/api/folders/notes/metadata', {
+    const nonString = await app.request(`${folderPath('notes')}/metadata`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ color: 42 })
@@ -488,7 +464,7 @@ describe('daemon routing', () => {
     expect(nonString.status).toBe(400);
     await expect(nonString.json()).resolves.toMatchObject({ ok: false, error: 'invalid_request' });
 
-    const invalidAccent = await app.request('/api/folders/notes/metadata', {
+    const invalidAccent = await app.request(`${folderPath('notes')}/metadata`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ color: 'amber' })
@@ -496,23 +472,22 @@ describe('daemon routing', () => {
     expect(invalidAccent.status).toBe(400);
     await expect(invalidAccent.json()).resolves.toMatchObject({ ok: false, error: 'invalid_metadata' });
 
-    const missing = await app.request('/api/folders/missing/metadata');
+    const missing = await app.request(`${folderPath('missing')}/metadata`);
     expect(missing.status).toBe(404);
     await expect(missing.json()).resolves.toMatchObject({ ok: false, error: 'not_found' });
 
-    await writeFileWithParents(join(config.vaultRoot, '.kb2', 'folders.yml'), 'folders: [');
-    const malformed = await app.request('/api/folders/notes/metadata');
+    await writeFileWithParents(join(vaultRoot, '.kb2', 'folders.yml'), 'folders: [');
+    const malformed = await app.request(`${folderPath('notes')}/metadata`);
     expect(malformed.status).toBe(500);
     await expect(malformed.json()).resolves.toMatchObject({ ok: false, error: 'metadata_parse_failed' });
   });
 
   it('routes nested folder metadata through the canonical service dialect', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot });
+    const { app, vaultRoot } = await setupScopedVault();
 
-    await mkdir(join(config.vaultRoot, 'projects', 'active'), { recursive: true });
+    await mkdir(join(vaultRoot, 'projects', 'active'), { recursive: true });
 
-    const set = await app.request('/api/folders/projects/active/metadata', {
+    const set = await app.request(`${folderPath('projects/active')}/metadata`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ color: 'mint', icon: 'folder' })
@@ -524,7 +499,7 @@ describe('daemon routing', () => {
       metadata: { color: 'mint', icon: 'folder' }
     });
 
-    const read = await app.request('/api/folders/projects/active/metadata');
+    const read = await app.request(`${folderPath('projects/active')}/metadata`);
     expect(read.status).toBe(200);
     await expect(read.json()).resolves.toMatchObject({
       ok: true,
@@ -532,7 +507,7 @@ describe('daemon routing', () => {
       metadata: { color: 'mint', icon: 'folder' }
     });
 
-    const invalidAccent = await app.request('/api/folders/projects/active/metadata', {
+    const invalidAccent = await app.request(`${folderPath('projects/active')}/metadata`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ color: 'amber' })
@@ -540,45 +515,40 @@ describe('daemon routing', () => {
     expect(invalidAccent.status).toBe(400);
     await expect(invalidAccent.json()).resolves.toMatchObject({ ok: false, error: 'invalid_metadata' });
 
-    const missing = await app.request('/api/folders/projects/missing/metadata');
+    const missing = await app.request(`${folderPath('projects/missing')}/metadata`);
     expect(missing.status).toBe(404);
     await expect(missing.json()).resolves.toMatchObject({ ok: false, error: 'not_found' });
   });
 
   it('deletes zero-live folder subtrees through the production session manager once', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
-    await mkdir(join(config.vaultRoot, 'emptydir'), { recursive: true });
+    const { app, vaultRoot } = await setupScopedVault();
+    await mkdir(join(vaultRoot, 'emptydir'), { recursive: true });
 
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
-    const deleted = await app.request('/api/folders/emptydir', { method: 'DELETE' });
+    const deleted = await app.request(folderPath('emptydir'), { method: 'DELETE' });
 
     expect(deleted.status).toBe(200);
     await expect(deleted.json()).resolves.toMatchObject({ ok: true, path: 'emptydir', liveDeleted: [] });
-    await expect(stat(join(config.vaultRoot, 'emptydir'))).rejects.toMatchObject({ code: 'ENOENT' });
-    const audit = await readAuditRows(config.vaultRoot);
+    await expect(stat(join(vaultRoot, 'emptydir'))).rejects.toMatchObject({ code: 'ENOENT' });
+    const audit = await readAuditRows(vaultRoot);
     expect(audit).toHaveLength(1);
     expect(audit[0]).toMatchObject({ operation: 'delete', entityKind: 'folder', path: 'emptydir' });
-    await sessions.close();
   });
 
   it('routes live whole-file writes through the open session', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: 'old\n' });
-    const session = sessions.getSession('live-write.md');
+    const { app, manager, vaultRoot } = await setupScopedVault();
+    await writeFileWithParents(join(vaultRoot, 'live-write.md'), 'old\n');
+    const session = manager.getSession('live-write.md');
     await session.open();
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
 
-    const noClobber = await app.request('/api/files/live-write.md', {
+    const noClobber = await app.request(filePath('live-write.md'), {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ content: 'should not clobber\n' })
     });
     expect(noClobber.status).toBe(409);
     await expect(noClobber.json()).resolves.toMatchObject({ ok: false, error: 'already_exists' });
-    await expect(readFile(join(config.vaultRoot, 'live-write.md'), 'utf8')).resolves.toBe('old\n');
 
-    const response = await app.request('/api/files/live-write.md?overwrite=true', {
+    const response = await app.request(`${filePath('live-write.md')}?overwrite=true`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ content: 'new through session\n' })
@@ -586,17 +556,13 @@ describe('daemon routing', () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({ ok: true, path: 'live-write.md', live: true, content: 'new through session\n' });
-    await expect(readFile(join(config.vaultRoot, 'live-write.md'), 'utf8')).resolves.toBe('new through session\n');
-    const audit = await readAuditRows(config.vaultRoot);
-    expect(audit).toHaveLength(1);
-    expect(audit[0]).toMatchObject({ operation: 'write', entityKind: 'file', path: 'live-write.md', actor: { kind: 'user' } });
-    await sessions.close();
+    await expect(readFile(join(vaultRoot, 'live-write.md'), 'utf8')).resolves.toBe('new through session\n');
   });
 
   it('routes live whole-file writes through a fast-diff session merge', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: 'alpha\nomega\n' });
-    const session = sessions.getSession('live-merge.md');
+    const { app, manager, vaultRoot } = await setupScopedVault();
+    await writeFileWithParents(join(vaultRoot, 'live-merge.md'), 'alpha\nomega\n');
+    const session = manager.getSession('live-merge.md');
     await session.open();
 
     const clientDoc = new Y.Doc();
@@ -605,8 +571,7 @@ describe('daemon routing', () => {
     clientText.insert('alpha\n'.length, 'typed concurrently\n');
     const inFlightUpdate = Y.encodeStateAsUpdate(clientDoc, Y.encodeStateVector(session.ydoc));
 
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
-    const response = await app.request('/api/files/live-merge.md?overwrite=true', {
+    const response = await app.request(`${filePath('live-merge.md')}?overwrite=true`, {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ content: 'alpha\nservice write\nomega\n' })
@@ -623,30 +588,24 @@ describe('daemon routing', () => {
     Y.applyUpdate(session.ydoc, inFlightUpdate, clientDoc);
     await session.flush();
 
-    const mergedContent = await readFile(join(config.vaultRoot, 'live-merge.md'), 'utf8');
+    const mergedContent = await readFile(join(vaultRoot, 'live-merge.md'), 'utf8');
     expect([
       'alpha\ntyped concurrently\nservice write\nomega\n',
       'alpha\nservice write\ntyped concurrently\nomega\n'
     ]).toContain(mergedContent);
-    const audit = await readAuditRows(config.vaultRoot);
-    expect(audit).toHaveLength(1);
-    expect(audit[0]).toMatchObject({ operation: 'write', entityKind: 'file', path: 'live-merge.md' });
-    await sessions.close();
   });
 
   it('serves baselines and applies agent splice with stale retry through live sessions', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
-    await writeFileWithParents(join(config.vaultRoot, 'notes', 'splice.md'), 'one two three\n');
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const { app, vaultRoot } = await setupScopedVault();
+    await writeFileWithParents(join(vaultRoot, 'notes', 'splice.md'), 'one two three\n');
 
-    const read = await app.request('/api/files/notes/splice.md');
+    const read = await app.request(filePath('notes/splice.md'));
     expect(read.status).toBe(200);
     const readBody = await read.json() as { content: string; baseline: string };
     expect(readBody.content).toBe('one two three\n');
     expect(readBody.baseline.length).toBeGreaterThan(0);
 
-    const firstSplice = await app.request('/api/files/notes/splice.md/splice', {
+    const firstSplice = await app.request(`${filePath('notes/splice.md')}/splice`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
@@ -658,9 +617,9 @@ describe('daemon routing', () => {
     expect(firstSplice.status).toBe(200);
     const firstBody = await firstSplice.json() as { content: string; baseline: string };
     expect(firstBody.content).toBe('one TWO three\n');
-    await expect(readFile(join(config.vaultRoot, 'notes/splice.md'), 'utf8')).resolves.toBe('one TWO three\n');
+    await expect(readFile(join(vaultRoot, 'notes/splice.md'), 'utf8')).resolves.toBe('one TWO three\n');
 
-    const stale = await app.request('/api/files/notes/splice.md/splice', {
+    const stale = await app.request(`${filePath('notes/splice.md')}/splice`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
@@ -677,7 +636,7 @@ describe('daemon routing', () => {
     });
     expect(staleBody.baseline).not.toBe(readBody.baseline);
 
-    const retry = await app.request('/api/files/notes/splice.md/splice', {
+    const retry = await app.request(`${filePath('notes/splice.md')}/splice`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
@@ -688,44 +647,43 @@ describe('daemon routing', () => {
     });
     expect(retry.status).toBe(200);
     await expect(retry.json()).resolves.toMatchObject({ ok: true, content: 'one TWO THREE\n' });
-    await expect(readFile(join(config.vaultRoot, 'notes/splice.md'), 'utf8')).resolves.toBe('one TWO THREE\n');
+    await expect(readFile(join(vaultRoot, 'notes/splice.md'), 'utf8')).resolves.toBe('one TWO THREE\n');
 
-    const audit = await readAuditRows(config.vaultRoot);
+    const audit = await readAuditRows(vaultRoot);
     expect(audit).toHaveLength(2);
     expect(audit.map((row) => row.operation)).toEqual(['splice', 'splice']);
     expect(audit.every((row) => (row.actor as { kind?: string }).kind === 'user')).toBe(true);
-    await sessions.close();
   });
 
   it('exercises every MCP tool end-to-end through the SDK client with mcp_client audit attribution', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const { app, vaultRoot } = await setupScopedVault();
     const { client, transport } = await connectMcpClient(app, 'daemon-sdk-test');
 
-    await expect(mcpToolJson(client, 'create_note', { path: 'notes/a.md', content: 'alpha beta alpha\n' }))
+    await expect(mcpToolJson(client, 'create_note', { vaultId: VAULT, path: 'notes/a.md', content: 'alpha beta alpha\n' }))
       .resolves.toMatchObject({ ok: true, path: 'notes/a.md' });
-    await expect(readFile(join(config.vaultRoot, 'notes/a.md'), 'utf8')).resolves.toBe('alpha beta alpha\n');
+    await expect(readFile(join(vaultRoot, 'notes/a.md'), 'utf8')).resolves.toBe('alpha beta alpha\n');
 
-    await expect(mcpToolJson(client, 'vault_info', {})).resolves.toMatchObject({ ok: true, fileCount: 1 });
-    await expect(mcpToolJson(client, 'list_files', { under: 'notes', depth: 1 }))
+    await expect(mcpToolJson(client, 'vault_info', { vaultId: VAULT })).resolves.toMatchObject({ ok: true, fileCount: 1 });
+    await expect(mcpToolJson(client, 'list_files', { vaultId: VAULT, under: 'notes', depth: 1 }))
       .resolves.toMatchObject({ ok: true, entries: [{ path: 'notes/a.md', kind: 'file' }] });
 
-    const read = await mcpToolJson(client, 'read_note', { path: 'notes/a.md' }) as { content: string; baseline: string };
+    const read = await mcpToolJson(client, 'read_note', { vaultId: VAULT, path: 'notes/a.md' }) as { content: string; baseline: string };
     expect(read.content).toBe('alpha beta alpha\n');
     expect(read.baseline.length).toBeGreaterThan(0);
 
     await expect(mcpToolJson(client, 'edit_note', {
+      vaultId: VAULT,
       path: 'notes/a.md',
       baseline: read.baseline,
       old_text: 'beta',
       new_text: 'BETA'
     })).resolves.toMatchObject({ ok: true, content: 'alpha BETA alpha\n' });
-    await expect(readFile(join(config.vaultRoot, 'notes/a.md'), 'utf8')).resolves.toBe('alpha BETA alpha\n');
+    await expect(readFile(join(vaultRoot, 'notes/a.md'), 'utf8')).resolves.toBe('alpha BETA alpha\n');
 
     const stale = await client.callTool({
       name: 'edit_note',
       arguments: {
+        vaultId: VAULT,
         path: 'notes/a.md',
         baseline: read.baseline,
         old_text: 'alpha',
@@ -737,10 +695,11 @@ describe('daemon routing', () => {
     expect(mcpText(stale)).toContain('"current_content":"alpha BETA alpha\\n"');
     expect(mcpText(stale)).toContain('"baseline"');
 
-    const fresh = await mcpToolJson(client, 'read_note', { path: 'notes/a.md' }) as { baseline: string };
+    const fresh = await mcpToolJson(client, 'read_note', { vaultId: VAULT, path: 'notes/a.md' }) as { baseline: string };
     const ambiguous = await client.callTool({
       name: 'edit_note',
       arguments: {
+        vaultId: VAULT,
         path: 'notes/a.md',
         baseline: fresh.baseline,
         old_text: 'alpha',
@@ -751,42 +710,42 @@ describe('daemon routing', () => {
     expect(mcpText(ambiguous)).toContain('"error":"ambiguous"');
     expect(mcpText(ambiguous)).toContain('"match_count":2');
 
-    await expect(mcpToolJson(client, 'append_note', { path: 'notes/a.md', content: 'tail\n' }))
+    await expect(mcpToolJson(client, 'append_note', { vaultId: VAULT, path: 'notes/a.md', content: 'tail\n' }))
       .resolves.toMatchObject({ ok: true, content: 'alpha BETA alpha\ntail\n' });
-    await expect(mcpToolJson(client, 'prepend_note', { path: 'notes/a.md', content: 'head\n' }))
+    await expect(mcpToolJson(client, 'prepend_note', { vaultId: VAULT, path: 'notes/a.md', content: 'head\n' }))
       .resolves.toMatchObject({ ok: true, content: 'head\nalpha BETA alpha\ntail\n' });
-    await expect(readFile(join(config.vaultRoot, 'notes/a.md'), 'utf8')).resolves.toBe('head\nalpha BETA alpha\ntail\n');
+    await expect(readFile(join(vaultRoot, 'notes/a.md'), 'utf8')).resolves.toBe('head\nalpha BETA alpha\ntail\n');
 
-    await expect(mcpToolJson(client, 'create_folder', { path: 'moved' })).resolves.toMatchObject({ ok: true, path: 'moved' });
-    await expect(mcpToolJson(client, 'set_folder_metadata', { path: 'moved', color: 'mint', icon: 'folder' }))
+    await expect(mcpToolJson(client, 'create_folder', { vaultId: VAULT, path: 'moved' })).resolves.toMatchObject({ ok: true, path: 'moved' });
+    await expect(mcpToolJson(client, 'set_folder_metadata', { vaultId: VAULT, path: 'moved', color: 'mint', icon: 'folder' }))
       .resolves.toMatchObject({ ok: true, path: 'moved', metadata: { color: 'mint', icon: 'folder' } });
-    await expect(mcpToolJson(client, 'get_folder_metadata', { path: 'moved' }))
+    await expect(mcpToolJson(client, 'get_folder_metadata', { vaultId: VAULT, path: 'moved' }))
       .resolves.toMatchObject({ ok: true, path: 'moved', metadata: { color: 'mint', icon: 'folder' } });
-    const metadataRaw = await readRawFolderMetadata(config.vaultRoot);
+    const metadataRaw = await readRawFolderMetadata(vaultRoot);
     expect(metadataRaw).toContain('moved:');
     expect(metadataRaw).toContain('color: mint');
     expect(metadataRaw).toContain('icon: folder');
-    await expect(mcpToolJson(client, 'move_note', { from_path: 'notes/a.md', to_path: 'moved/a.md' }))
+    await expect(mcpToolJson(client, 'move_note', { vaultId: VAULT, from_path: 'notes/a.md', to_path: 'moved/a.md' }))
       .resolves.toMatchObject({ ok: true, fromPath: 'notes/a.md', toPath: 'moved/a.md', live: true });
-    await expect(readFile(join(config.vaultRoot, 'moved/a.md'), 'utf8')).resolves.toBe('head\nalpha BETA alpha\ntail\n');
-    await expect(stat(join(config.vaultRoot, 'notes/a.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(readFile(join(vaultRoot, 'moved/a.md'), 'utf8')).resolves.toBe('head\nalpha BETA alpha\ntail\n');
+    await expect(stat(join(vaultRoot, 'notes/a.md'))).rejects.toMatchObject({ code: 'ENOENT' });
 
-    await expect(mcpToolJson(client, 'move_folder', { from_path: 'moved', to_path: 'archived' }))
+    await expect(mcpToolJson(client, 'move_folder', { vaultId: VAULT, from_path: 'moved', to_path: 'archived' }))
       .resolves.toMatchObject({ ok: true, fromPath: 'moved', toPath: 'archived', liveMoved: ['archived/a.md'] });
-    await expect(readFile(join(config.vaultRoot, 'archived/a.md'), 'utf8')).resolves.toContain('BETA');
+    await expect(readFile(join(vaultRoot, 'archived/a.md'), 'utf8')).resolves.toContain('BETA');
 
-    await expect(mcpToolJson(client, 'search', { query: 'BETA', under: 'archived', context: 0 }))
+    await expect(mcpToolJson(client, 'search', { vaultId: VAULT, query: 'BETA', under: 'archived', context: 0 }))
       .resolves.toMatchObject({ ok: true, total: 1, results: [{ path: 'archived/a.md' }] });
 
-    await expect(mcpToolJson(client, 'delete_note', { path: 'archived/a.md' }))
+    await expect(mcpToolJson(client, 'delete_note', { vaultId: VAULT, path: 'archived/a.md' }))
       .resolves.toMatchObject({ ok: true, path: 'archived/a.md', live: true });
-    await expect(stat(join(config.vaultRoot, 'archived/a.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(stat(join(vaultRoot, 'archived/a.md'))).rejects.toMatchObject({ code: 'ENOENT' });
 
-    await expect(mcpToolJson(client, 'delete_folder', { path: 'archived', recursive: true }))
+    await expect(mcpToolJson(client, 'delete_folder', { vaultId: VAULT, path: 'archived', recursive: true }))
       .resolves.toMatchObject({ ok: true, path: 'archived', liveDeleted: [] });
-    await expect(stat(join(config.vaultRoot, 'archived'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(stat(join(vaultRoot, 'archived'))).rejects.toMatchObject({ code: 'ENOENT' });
 
-    const audit = await readAuditRows(config.vaultRoot);
+    const audit = await readAuditRows(vaultRoot);
     expect(audit.map((row) => row.operation)).toEqual([
       'create',
       'splice',
@@ -805,21 +764,37 @@ describe('daemon routing', () => {
     })).toBe(true);
 
     await transport.terminateSession();
-    await sessions.close();
+  });
+
+  it('returns a clean MCP tool error for an unknown vaultId without crashing', async () => {
+    const { app } = await setupScopedVault();
+    const { client, transport } = await connectMcpClient(app, 'mcp-unknown-vault');
+
+    const result = await client.callTool({
+      name: 'create_note',
+      arguments: { vaultId: 'no-such-vault', path: 'x.md', content: 'x\n' }
+    });
+    expect(result.isError).toBe(true);
+    expect(mcpText(result)).toBe('create_note rejected: {"ok":false,"error":"not_found","message":"No vault with id \\"no-such-vault\\"."}');
+
+    // A data tool call WITHOUT vaultId is rejected: the param is required.
+    const missing = await client.callTool({ name: 'create_note', arguments: { path: 'x.md', content: 'x\n' } });
+    expect(missing.isError).toBe(true);
+
+    await transport.terminateSession();
   });
 
   it.each(anchoredSpliceContractCases)('runs the shared splice contract over MCP: $name', async ({ initialContent, request, expected }) => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
+    const { app, vaultRoot } = await setupScopedVault();
     const notePath = 'notes/contract.md';
-    await writeFileWithParents(join(config.vaultRoot, notePath), initialContent);
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    await writeFileWithParents(join(vaultRoot, notePath), initialContent);
     const { client, transport } = await connectMcpClient(app, 'mcp-splice-contract-test');
 
-    const read = await mcpToolJson(client, 'read_note', { path: notePath }) as { baseline: string };
+    const read = await mcpToolJson(client, 'read_note', { vaultId: VAULT, path: notePath }) as { baseline: string };
     const result = await client.callTool({
       name: 'edit_note',
       arguments: {
+        vaultId: VAULT,
         path: notePath,
         baseline: read.baseline,
         old_text: request.oldText,
@@ -837,45 +812,42 @@ describe('daemon routing', () => {
         path: notePath,
         content: expected.content
       });
-      await expect(readFile(join(config.vaultRoot, notePath), 'utf8')).resolves.toBe(expected.content);
+      await expect(readFile(join(vaultRoot, notePath), 'utf8')).resolves.toBe(expected.content);
     } else {
       expect(result.isError).toBe(true);
       expect(parseMcpRejection(result, 'edit_note')).toMatchObject(serviceFailureFromContract(expected));
-      await expect(readFile(join(config.vaultRoot, notePath), 'utf8')).resolves.toBe(initialContent);
+      await expect(readFile(join(vaultRoot, notePath), 'utf8')).resolves.toBe(initialContent);
     }
 
     await transport.terminateSession();
-    await sessions.close();
   });
 
   it('surfaces MCP persist failures without a success audit row and recovers the live session', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const { app, vaultRoot } = await setupScopedVault();
     const { client, transport } = await connectMcpClient(app, 'mcp-persist-test');
 
-    await expect(mcpToolJson(client, 'create_note', { path: 'notes/readonly.md', content: 'base\n' }))
+    await expect(mcpToolJson(client, 'create_note', { vaultId: VAULT, path: 'notes/readonly.md', content: 'base\n' }))
       .resolves.toMatchObject({ ok: true, path: 'notes/readonly.md' });
-    await mcpToolJson(client, 'read_note', { path: 'notes/readonly.md' });
+    await mcpToolJson(client, 'read_note', { vaultId: VAULT, path: 'notes/readonly.md' });
 
-    const beforeAudit = await readAuditRows(config.vaultRoot);
-    await chmod(join(config.vaultRoot, 'notes'), 0o500);
+    const beforeAudit = await readAuditRows(vaultRoot);
+    await chmod(join(vaultRoot, 'notes'), 0o500);
     const failed = await client.callTool({
       name: 'append_note',
-      arguments: { path: 'notes/readonly.md', content: 'unsaved\n' }
+      arguments: { vaultId: VAULT, path: 'notes/readonly.md', content: 'unsaved\n' }
     });
 
     expect(failed.isError).toBe(true);
     expect(mcpText(failed)).toBe('append_note rejected: {"ok":false,"error":"persist_failed","message":"Document edit could not be durably saved to disk."}');
-    await expect(readFile(join(config.vaultRoot, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\n');
-    expect(await readAuditRows(config.vaultRoot)).toHaveLength(beforeAudit.length);
+    await expect(readFile(join(vaultRoot, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\n');
+    expect(await readAuditRows(vaultRoot)).toHaveLength(beforeAudit.length);
 
-    await chmod(join(config.vaultRoot, 'notes'), 0o700);
-    await expect(mcpToolJson(client, 'append_note', { path: 'notes/readonly.md', content: 'recovered\n' }))
+    await chmod(join(vaultRoot, 'notes'), 0o700);
+    await expect(mcpToolJson(client, 'append_note', { vaultId: VAULT, path: 'notes/readonly.md', content: 'recovered\n' }))
       .resolves.toMatchObject({ ok: true, content: 'base\nunsaved\nrecovered\n' });
-    await expect(readFile(join(config.vaultRoot, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\nunsaved\nrecovered\n');
+    await expect(readFile(join(vaultRoot, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\nunsaved\nrecovered\n');
 
-    const audit = await readAuditRows(config.vaultRoot);
+    const audit = await readAuditRows(vaultRoot);
     expect(audit).toHaveLength(beforeAudit.length + 1);
     expect(audit.at(-1)).toMatchObject({
       operation: 'append',
@@ -884,17 +856,14 @@ describe('daemon routing', () => {
     });
 
     await transport.terminateSession();
-    await sessions.close();
   });
 
   it('applies anchored splice disambiguation and structured rejections', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
-    await writeFileWithParents(join(config.vaultRoot, 'ambiguous.md'), 'foo bar foo baz foo');
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
-    const read = await (await app.request('/api/files/ambiguous.md')).json() as { baseline: string };
+    const { app, vaultRoot } = await setupScopedVault();
+    await writeFileWithParents(join(vaultRoot, 'ambiguous.md'), 'foo bar foo baz foo');
+    const read = await (await app.request(filePath('ambiguous.md'))).json() as { baseline: string };
 
-    const ambiguous = await app.request('/api/files/ambiguous.md/splice', {
+    const ambiguous = await app.request(`${filePath('ambiguous.md')}/splice`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ baseline: read.baseline, old_text: 'foo', new_text: 'FOO' })
@@ -902,73 +871,63 @@ describe('daemon routing', () => {
     expect(ambiguous.status).toBe(409);
     await expect(ambiguous.json()).resolves.toMatchObject({ ok: false, error: 'ambiguous', match_count: 3 });
 
-    const occurrence = await app.request('/api/files/ambiguous.md/splice', {
+    const occurrence = await app.request(`${filePath('ambiguous.md')}/splice`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ baseline: read.baseline, old_text: 'foo', new_text: 'FOO', occurrence: 2 })
     });
     expect(occurrence.status).toBe(200);
-    await expect(readFile(join(config.vaultRoot, 'ambiguous.md'), 'utf8')).resolves.toBe('foo bar FOO baz foo');
+    await expect(readFile(join(vaultRoot, 'ambiguous.md'), 'utf8')).resolves.toBe('foo bar FOO baz foo');
 
-    const reread = await (await app.request('/api/files/ambiguous.md')).json() as { baseline: string };
-    const notFound = await app.request('/api/files/ambiguous.md/splice', {
+    const reread = await (await app.request(filePath('ambiguous.md'))).json() as { baseline: string };
+    const notFound = await app.request(`${filePath('ambiguous.md')}/splice`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ baseline: reread.baseline, old_text: 'missing', new_text: 'x' })
     });
     expect(notFound.status).toBe(404);
     await expect(notFound.json()).resolves.toMatchObject({ ok: false, error: 'not_found' });
-    await sessions.close();
   });
 
   it.each([
     {
       name: 'PUT JSON content',
-      path: '/api/files/bad-put.md',
+      path: 'bad-put.md',
       method: 'PUT',
       body: { content: 42 },
       message: 'content must be a string'
     },
     {
       name: 'splice baseline',
-      path: '/api/files/bad-splice.md/splice',
+      path: 'bad-splice.md/splice',
       method: 'POST',
       body: { old_text: 'a', new_text: 'b' },
       message: 'baseline must be a string'
     },
     {
       name: 'append content',
-      path: '/api/files/bad-append.md/append',
+      path: 'bad-append.md/append',
       method: 'POST',
       body: { content: false },
       message: 'content must be a string'
     },
     {
       name: 'prepend content',
-      path: '/api/files/bad-prepend.md/prepend',
+      path: 'bad-prepend.md/prepend',
       method: 'POST',
       body: {},
       message: 'content must be a string'
     },
     {
       name: 'file move target',
-      path: '/api/files/bad-move.md/move',
+      path: 'bad-move.md/move',
       method: 'POST',
       body: { to: 42 },
       message: 'to must be a string'
-    },
-    {
-      name: 'folder move target',
-      path: '/api/folders/bad-folder/move',
-      method: 'POST',
-      body: { to: null },
-      message: 'to must be a string'
     }
-  ])('returns invalid_request for malformed $name bodies', async ({ path, method, body, message }) => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
-    const response = await app.request(path, {
+  ])('returns invalid_request for malformed file $name bodies', async ({ path, method, body, message }) => {
+    const { app, vaultRoot } = await setupScopedVault();
+    const response = await app.request(filePath(path), {
       method,
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body)
@@ -980,38 +939,52 @@ describe('daemon routing', () => {
       error: 'invalid_request',
       message
     });
-    await expect(stat(join(config.vaultRoot, '.kb2/audit/changes.jsonl'))).rejects.toMatchObject({ code: 'ENOENT' });
-    await sessions.close();
+    await expect(stat(join(vaultRoot, '.kb2/audit/changes.jsonl'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('returns invalid_request for a malformed folder move target body', async () => {
+    const { app, vaultRoot } = await setupScopedVault();
+    const response = await app.request(`${folderPath('bad-folder')}/move`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ to: null })
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: 'invalid_request',
+      message: 'to must be a string'
+    });
+    await expect(stat(join(vaultRoot, '.kb2/audit/changes.jsonl'))).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it('appends missing files, prepends after frontmatter, searches with context, and does not audit search', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const { app, vaultRoot } = await setupScopedVault();
 
-    const append = await app.request('/api/files/notes/new.md/append', {
+    const append = await app.request(`${filePath('notes/new.md')}/append`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ content: 'created by append\n' })
     });
     expect(append.status).toBe(200);
     await expect(append.json()).resolves.toMatchObject({ ok: true, path: 'notes/new.md', content: 'created by append\n' });
-    await expect(readFile(join(config.vaultRoot, 'notes/new.md'), 'utf8')).resolves.toBe('created by append\n');
+    await expect(readFile(join(vaultRoot, 'notes/new.md'), 'utf8')).resolves.toBe('created by append\n');
 
-    await writeFileWithParents(join(config.vaultRoot, 'notes/front.md'), '---\ntitle: Front\n---\nbody\n');
-    const prepend = await app.request('/api/files/notes/front.md/prepend', {
+    await writeFileWithParents(join(vaultRoot, 'notes/front.md'), '---\ntitle: Front\n---\nbody\n');
+    const prepend = await app.request(`${filePath('notes/front.md')}/prepend`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ content: 'inserted\n' })
     });
     expect(prepend.status).toBe(200);
-    await expect(readFile(join(config.vaultRoot, 'notes/front.md'), 'utf8')).resolves.toBe(
+    await expect(readFile(join(vaultRoot, 'notes/front.md'), 'utf8')).resolves.toBe(
       '---\ntitle: Front\n---\ninserted\nbody\n'
     );
 
-    await writeFileWithParents(join(config.vaultRoot, 'notes/deep/search.md'), 'before\nneedle here\nafter\n');
-    await writeFileWithParents(join(config.vaultRoot, '.kb2/trash/hidden.md'), 'needle hidden\n');
-    const search = await app.request('/api/search?q=NEEDLE&under=notes&context=1&limit=5');
+    await writeFileWithParents(join(vaultRoot, 'notes/deep/search.md'), 'before\nneedle here\nafter\n');
+    await writeFileWithParents(join(vaultRoot, '.kb2/trash/hidden.md'), 'needle hidden\n');
+    const search = await app.request(`/api/vaults/${VAULT}/search?q=NEEDLE&under=notes&context=1&limit=5`);
     expect(search.status).toBe(200);
     await expect(search.json()).resolves.toMatchObject({
       ok: true,
@@ -1024,98 +997,43 @@ describe('daemon routing', () => {
       }]
     });
 
-    const audit = await readAuditRows(config.vaultRoot);
+    const audit = await readAuditRows(vaultRoot);
     expect(audit.map((row) => row.operation)).toEqual(['append', 'prepend']);
-    await sessions.close();
-  });
-
-  it('surfaces live append persist failures without auditing or idle-dropping unsaved content, then recovers', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({
-      root: config.vaultRoot,
-      defaultContent: '',
-      idleSessionGraceMs: 30
-    });
-    await writeFileWithParents(join(config.vaultRoot, 'notes', 'readonly.md'), 'base\n');
-    const hydrated = sessions.getSession('notes/readonly.md');
-    await hydrated.open();
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
-    const notesDir = join(config.vaultRoot, 'notes');
-
-    await chmod(notesDir, 0o500);
-    const failedAppend = await app.request('/api/files/notes/readonly.md/append', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ content: 'lost if dropped\n' })
-    });
-
-    expect(failedAppend.status).toBe(500);
-    await expect(failedAppend.json()).resolves.toMatchObject({ ok: false, error: 'persist_failed' });
-    await expect(readFile(join(config.vaultRoot, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\n');
-    await expect(readFile(join(config.vaultRoot, '.kb2/audit/changes.jsonl'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
-
-    await new Promise((resolve) => setTimeout(resolve, 90));
-    expect(sessions.getOpenSession('notes/readonly.md')).toBe(hydrated);
-    await expect(hydrated.getContent()).resolves.toBe('base\nlost if dropped\n');
-
-    await chmod(notesDir, 0o700);
-    const recoveredAppend = await app.request('/api/files/notes/readonly.md/append', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ content: 'after recovery\n' })
-    });
-
-    expect(recoveredAppend.status).toBe(200);
-    await expect(recoveredAppend.json()).resolves.toMatchObject({
-      ok: true,
-      path: 'notes/readonly.md',
-      content: 'base\nlost if dropped\nafter recovery\n'
-    });
-    await expect(readFile(join(config.vaultRoot, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\nlost if dropped\nafter recovery\n');
-    const audit = await readAuditRows(config.vaultRoot);
-    expect(audit).toHaveLength(1);
-    expect(audit[0]).toMatchObject({ operation: 'append', path: 'notes/readonly.md' });
-    expect(hydrated.getActivePersistFailureEvent()).toBeUndefined();
-    await sessions.close();
   });
 
   it('flushes dirty live sessions through a real HTTP barrier with durable file content', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
-    const session = sessions.getSession('notes/flush.md');
+    const { app, manager, vaultRoot } = await setupScopedVault();
+    await writeFileWithParents(join(vaultRoot, 'notes/flush.md'), '');
+    const session = manager.getSession('notes/flush.md');
     await session.open();
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
     const server = await startHttpApp(app);
 
     try {
       session.ydoc.getText('markdown').insert(0, 'flush me now\n');
-      const response = await fetch(`${server.origin}/api/ops/flush`, { method: 'POST' });
+      const response = await fetch(`${server.origin}/api/vaults/${VAULT}/ops/flush`, { method: 'POST' });
       const body = await response.json() as { ok: boolean; flushed: number; durableAsOf: string };
 
       expect(response.status).toBe(200);
       expect(body).toMatchObject({ ok: true, flushed: 1 });
       expect(new Date(body.durableAsOf).toISOString()).toBe(body.durableAsOf);
-      await expect(readFile(join(config.vaultRoot, 'notes/flush.md'), 'utf8')).resolves.toBe('flush me now\n');
+      await expect(readFile(join(vaultRoot, 'notes/flush.md'), 'utf8')).resolves.toBe('flush me now\n');
 
-      const clean = await fetch(`${server.origin}/api/ops/flush`, { method: 'POST' });
+      const clean = await fetch(`${server.origin}/api/vaults/${VAULT}/ops/flush`, { method: 'POST' });
       await expect(clean.json()).resolves.toMatchObject({ ok: true, flushed: 0 });
     } finally {
       await server.close();
-      await sessions.close();
     }
   });
 
   it('maps flush persist failures through the canonical dialect while the loud session event fires', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
-    await writeFileWithParents(join(config.vaultRoot, 'notes', 'readonly.md'), 'base\n');
-    const session = sessions.getSession('notes/readonly.md');
+    const { app, manager, vaultRoot } = await setupScopedVault();
+    await writeFileWithParents(join(vaultRoot, 'notes', 'readonly.md'), 'base\n');
+    const session = manager.getSession('notes/readonly.md');
     const events: DocumentSessionEvent[] = [];
     session.onEvent((event) => events.push(event));
     await session.open();
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
     const server = await startHttpApp(app);
-    const notesDir = join(config.vaultRoot, 'notes');
+    const notesDir = join(vaultRoot, 'notes');
 
     try {
       await chmod(notesDir, 0o500);
@@ -1124,14 +1042,14 @@ describe('daemon routing', () => {
         `Timed out waiting for persist-failure; events=${JSON.stringify(events)}`
       );
 
-      const response = await fetch(`${server.origin}/api/ops/flush`, { method: 'POST' });
+      const response = await fetch(`${server.origin}/api/vaults/${VAULT}/ops/flush`, { method: 'POST' });
       expect(response.status).toBe(500);
       await expect(response.json()).resolves.toEqual({
         ok: false,
         error: 'persist_failed',
         message: 'Document edit could not be durably saved to disk.'
       });
-      await expect(readFile(join(config.vaultRoot, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\n');
+      await expect(readFile(join(vaultRoot, 'notes/readonly.md'), 'utf8')).resolves.toBe('base\n');
       expect(events).toContainEqual(expect.objectContaining({ kind: 'persist-failure', path: 'notes/readonly.md' }));
     } finally {
       await chmod(notesDir, 0o700).catch(() => undefined);
@@ -1140,43 +1058,40 @@ describe('daemon routing', () => {
         await session.flush().catch(() => undefined);
       }
       await server.close();
-      await sessions.close();
     }
   });
 
   it('streams change events over SSE without content bytes and disconnects cleanly', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({ root: config.vaultRoot, defaultContent: '' });
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
+    const { app } = await setupScopedVault();
     const server = await startHttpApp(app);
-    const stream = await openSseStream(`${server.origin}/api/events`);
-    const folderPath = 'notes/ユニコード';
-    const notePath = `${folderPath}/stream.md`;
-    const movedPath = `${folderPath}/moved.md`;
+    const stream = await openSseStream(`${server.origin}/api/vaults/${VAULT}/events`);
+    const folder = 'notes/ユニコード';
+    const notePath = `${folder}/stream.md`;
+    const movedPath = `${folder}/moved.md`;
     const secret = 'SECRET_STREAM_BYTES_012';
 
     try {
-      await expect(fetchJson(`${server.origin}/api/folders`, {
+      await expect(fetchJson(`${server.origin}${folderPath()}`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ path: folderPath })
-      })).resolves.toMatchObject({ ok: true, path: folderPath });
-      await expect(fetchText(`${server.origin}/api/files/${encodeVaultPath(notePath)}`, {
+        body: JSON.stringify({ path: folder })
+      })).resolves.toMatchObject({ ok: true, path: folder });
+      await expect(fetchText(`${server.origin}${filePath(encodeVaultPath(notePath))}`, {
         method: 'PUT',
         headers: { 'content-type': 'text/plain' },
         body: 'initial visible content\n'
       })).resolves.toMatchObject({ ok: true, path: notePath });
-      await expect(fetchJson(`${server.origin}/api/folders/${encodeVaultPath(folderPath)}/metadata`, {
+      await expect(fetchJson(`${server.origin}${folderPath(encodeVaultPath(folder))}/metadata`, {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ color: 'mint', icon: 'folder' })
-      })).resolves.toMatchObject({ ok: true, path: folderPath });
-      await expect(fetchJson(`${server.origin}/api/files/${encodeVaultPath(notePath)}/append`, {
+      })).resolves.toMatchObject({ ok: true, path: folder });
+      await expect(fetchJson(`${server.origin}${filePath(encodeVaultPath(notePath))}/append`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ content: secret })
       })).resolves.toMatchObject({ ok: true, path: notePath });
-      await expect(fetchJson(`${server.origin}/api/files/${encodeVaultPath(notePath)}/move`, {
+      await expect(fetchJson(`${server.origin}${filePath(encodeVaultPath(notePath))}/move`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ to: movedPath })
@@ -1190,57 +1105,20 @@ describe('daemon routing', () => {
         'content_persisted',
         'file_moved'
       ]);
-      expect(events[0]).toMatchObject({ path: folderPath, actor: { kind: 'user' } });
+      expect(events[0]).toMatchObject({ path: folder, actor: { kind: 'user' } });
       expect(events[3]).toMatchObject({ path: notePath, actor: { kind: 'system' } });
       expect(events[4]).toMatchObject({ fromPath: notePath, toPath: movedPath, actor: { kind: 'user' } });
       expect(stream.raw()).not.toContain(secret);
-      await expect(readFile(join(config.vaultRoot, movedPath), 'utf8')).resolves.toBe(`initial visible content\n${secret}`);
     } finally {
       await stream.close();
       await server.close();
-      await sessions.close();
     }
   });
 
-  it('keeps live move failures classified and resumes old-path watching', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const sessions = new DocumentSessionManager({
-      root: config.vaultRoot,
-      defaultContent: '',
-      watchDebounceMs: 10,
-      watchPollMs: 50
-    });
-    const session = sessions.getSession('notes/live-fail.md');
-    const events: DocumentSessionEvent[] = [];
-    session.onEvent((event) => events.push(event));
-    await session.open();
-    session.ydoc.getText('markdown').insert(0, 'live before failure\n');
-    await session.flush();
-    await writeFile(join(config.vaultRoot, 'notes/target.md'), 'existing target\n', 'utf8');
-
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot, documentSessions: sessions });
-    const failedMove = await app.request('/api/files/notes/live-fail.md/move', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ to: 'notes/target.md' })
-    });
-    expect(failedMove.status).toBe(409);
-    await expect(failedMove.json()).resolves.toMatchObject({ ok: false, error: 'path_collision' });
-
-    await writeFile(join(config.vaultRoot, 'notes/live-fail.md'), 'external after failed move\n', 'utf8');
-    await waitUntil(async () => await session.getContent() === 'external after failed move\n', () =>
-      `Timed out waiting for watcher recovery; content=${session.ydoc.getText('markdown').toString()}`
-    );
-    expect(events).toContainEqual(expect.objectContaining({ kind: 'external-merge' }));
-    expect(sessions.getOpenSession('notes/live-fail.md')).toBe(session);
-    await sessions.close();
-  });
-
   it('covers vault info and non-live folder route branches', async () => {
-    const config = createDaemonConfig({ env: { KB2_HOME: kb2Home } });
-    const app = createApp({ statusFile: config.statusFile, vaultRoot: config.vaultRoot });
+    const { app } = await setupScopedVault();
 
-    const mkdirResponse = await app.request('/api/folders', {
+    const mkdirResponse = await app.request(folderPath(), {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ path: 'folder' })
@@ -1248,16 +1126,16 @@ describe('daemon routing', () => {
     expect(mkdirResponse.status).toBe(201);
     await expect(mkdirResponse.json()).resolves.toMatchObject({ ok: true, path: 'folder' });
 
-    await app.request('/api/files/folder/file.md', {
+    await app.request(filePath('folder/file.md'), {
       method: 'PUT',
       headers: { 'content-type': 'text/plain' },
       body: 'x'
     });
-    const blockedDelete = await app.request('/api/folders/folder', { method: 'DELETE' });
+    const blockedDelete = await app.request(folderPath('folder'), { method: 'DELETE' });
     expect(blockedDelete.status).toBe(409);
     await expect(blockedDelete.json()).resolves.toMatchObject({ ok: false, error: 'folder_not_empty' });
 
-    const moved = await app.request('/api/folders/folder/move', {
+    const moved = await app.request(`${folderPath('folder')}/move`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ to: 'moved/folder' })
@@ -1265,15 +1143,15 @@ describe('daemon routing', () => {
     expect(moved.status).toBe(200);
     await expect(moved.json()).resolves.toMatchObject({ ok: true, fromPath: 'folder', toPath: 'moved/folder' });
 
-    const deleted = await app.request('/api/folders/moved/folder?recursive=true', { method: 'DELETE' });
+    const deleted = await app.request(`${folderPath('moved/folder')}?recursive=true`, { method: 'DELETE' });
     expect(deleted.status).toBe(200);
     await expect(deleted.json()).resolves.toMatchObject({ ok: true, path: 'moved/folder' });
 
-    const info = await app.request('/api/vault');
+    const info = await app.request(`/api/vaults/${VAULT}/vault`);
     expect(info.status).toBe(200);
-    await expect(info.json()).resolves.toMatchObject({ ok: true, rootName: 'demo-vault' });
+    await expect(info.json()).resolves.toMatchObject({ ok: true, rootName: VAULT });
 
-    const missing = await app.request('/api/files/missing.md/move', {
+    const missing = await app.request(`${filePath('missing.md')}/move`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ to: 'next.md' })

--- a/apps/daemon/src/vault-registry.test.ts
+++ b/apps/daemon/src/vault-registry.test.ts
@@ -4,9 +4,10 @@ import { join } from 'node:path';
 
 import {
   discoverVaults,
+  isWellFormedSlug,
   migrateLegacyVaultLayout,
   readOrMintVaultIdentity,
-  slugFromFolderName,
+  slugify,
   VAULT_TRASH_DIRNAME,
   VaultRegistry
 } from './vault-registry.js';
@@ -22,15 +23,43 @@ describe('vault registry', () => {
     await rm(home, { force: true, recursive: true });
   });
 
-  describe('slugFromFolderName', () => {
-    it('lowercases and hyphenates', () => {
-      expect(slugFromFolderName('My Vault')).toBe('my-vault');
-      expect(slugFromFolderName('demo-vault')).toBe('demo-vault');
-      expect(slugFromFolderName('Notes & Stuff!!')).toBe('notes-stuff');
+  describe('slugify', () => {
+    it('normalizes a display name into a slug via github-slugger', () => {
+      expect(slugify('My Vault')).toBe('my-vault');
+      expect(slugify('demo-vault')).toBe('demo-vault');
     });
 
-    it('falls back to "vault" when nothing usable remains', () => {
-      expect(slugFromFolderName('***')).toBe('vault');
+    it('yields an empty slug when nothing usable remains (no silent fallback)', () => {
+      expect(slugify('***')).toBe('');
+    });
+
+    it('is idempotent on an already-normalized slug', () => {
+      expect(slugify('my-vault')).toBe('my-vault');
+      expect(slugify(slugify('Notes & Stuff!!'))).toBe(slugify('Notes & Stuff!!'));
+    });
+  });
+
+  describe('isWellFormedSlug', () => {
+    it('accepts non-empty, already-normalized slugs', () => {
+      expect(isWellFormedSlug('my-vault')).toBe(true);
+      expect(isWellFormedSlug('demo-vault')).toBe(true);
+      expect(isWellFormedSlug('field-notes-2')).toBe(true);
+    });
+
+    it('rejects empty or non-normalized slugs', () => {
+      expect(isWellFormedSlug('')).toBe(false);
+      expect(isWellFormedSlug('My Vault')).toBe(false);
+      expect(isWellFormedSlug('Notes!')).toBe(false);
+      expect(isWellFormedSlug('trailing ')).toBe(false);
+    });
+
+    it('agrees with slugify: a slugified value is always well-formed', () => {
+      for (const input of ['My Vault', 'demo-vault', 'Notes & Stuff!!', 'a_b_c']) {
+        const slug = slugify(input);
+        if (slug.length > 0) {
+          expect(isWellFormedSlug(slug)).toBe(true);
+        }
+      }
     });
   });
 
@@ -176,7 +205,7 @@ describe('vault registry', () => {
       await mkdir(vaultsHome, { recursive: true });
       const registry = await loadRegistry();
 
-      const created = await registry.create({ displayName: 'My Notes' });
+      const created = await registry.create({ displayName: 'My Notes', slug: 'my-notes' });
       expect(created).toEqual({ ok: true, vault: { id: 'my-notes', displayName: 'My Notes' } });
 
       // Filesystem is the source of truth: the folder and minted identity exist.
@@ -200,12 +229,12 @@ describe('vault registry', () => {
       await mkdir(vaultsHome, { recursive: true });
       const registry = await loadRegistry();
 
-      const first = await registry.create({ displayName: 'Project X' });
+      const first = await registry.create({ displayName: 'Project X', slug: 'project-x' });
       expect(first.ok).toBe(true);
 
-      // A different display name that normalizes to the same slug is a clean
-      // collision, not a crash, and does not disturb the first vault.
-      const collision = await registry.create({ displayName: 'project x' });
+      // A second create with the same explicit slug is a clean collision, not a
+      // crash, and does not disturb the first vault.
+      const collision = await registry.create({ displayName: 'Another Project', slug: 'project-x' });
       expect(collision).toEqual({
         ok: false,
         error: 'already_exists',
@@ -220,7 +249,7 @@ describe('vault registry', () => {
       await mkdir(vaultsHome, { recursive: true });
       const registry = await loadRegistry();
 
-      const created = await registry.create({ displayName: '   ' });
+      const created = await registry.create({ displayName: '   ', slug: 'whatever' });
       expect(created).toEqual({
         ok: false,
         error: 'invalid_request',
@@ -230,10 +259,31 @@ describe('vault registry', () => {
       await registry.close();
     });
 
+    it('rejects a malformed slug on create (never infers it from the display name)', async () => {
+      await mkdir(vaultsHome, { recursive: true });
+      const registry = await loadRegistry();
+
+      // A non-normalized slug is a clean invalid_request; nothing lands on disk.
+      const created = await registry.create({ displayName: 'Field Notes', slug: 'Field Notes' });
+      expect(created).toEqual({
+        ok: false,
+        error: 'invalid_request',
+        message: expect.any(String)
+      });
+      expect(registry.list()).toHaveLength(0);
+      await expect(access(join(vaultsHome, 'Field Notes'))).rejects.toBeTruthy();
+
+      // An empty slug is rejected too.
+      const empty = await registry.create({ displayName: 'Field Notes', slug: '' });
+      expect(empty.ok).toBe(false);
+
+      await registry.close();
+    });
+
     it('renames a vault by display name only, leaving slug and folder unchanged', async () => {
       await mkdir(vaultsHome, { recursive: true });
       const registry = await loadRegistry();
-      await registry.create({ displayName: 'Original' });
+      await registry.create({ displayName: 'Original', slug: 'original' });
 
       const renamed = await registry.rename('original', { displayName: 'Renamed' });
       expect(renamed).toEqual({ ok: true, vault: { id: 'original', displayName: 'Renamed' } });
@@ -261,7 +311,7 @@ describe('vault registry', () => {
     it('soft-deletes a vault: folder moves to trash with data intact, gone from the registry', async () => {
       await mkdir(vaultsHome, { recursive: true });
       const registry = await loadRegistry();
-      await registry.create({ displayName: 'Disposable' });
+      await registry.create({ displayName: 'Disposable', slug: 'disposable' });
 
       // Drop a note in so we can prove the data survives the soft delete.
       await writeFile(join(vaultsHome, 'disposable', 'kept.md'), 'precious\n', 'utf8');
@@ -298,12 +348,12 @@ describe('vault registry', () => {
       await mkdir(vaultsHome, { recursive: true });
       const registry = await loadRegistry();
 
-      await registry.create({ displayName: 'Recycle' });
+      await registry.create({ displayName: 'Recycle', slug: 'recycle' });
       await writeFile(join(vaultsHome, 'recycle', 'v1.md'), 'first\n', 'utf8');
       const firstDelete = await registry.softDelete('recycle');
       if (!firstDelete.ok) throw new Error('expected first soft delete to succeed');
 
-      await registry.create({ displayName: 'Recycle' });
+      await registry.create({ displayName: 'Recycle', slug: 'recycle' });
       await writeFile(join(vaultsHome, 'recycle', 'v2.md'), 'second\n', 'utf8');
       const secondDelete = await registry.softDelete('recycle');
       if (!secondDelete.ok) throw new Error('expected second soft delete to succeed');

--- a/apps/daemon/src/vault-registry.ts
+++ b/apps/daemon/src/vault-registry.ts
@@ -3,6 +3,7 @@ import { join, relative } from 'node:path';
 
 import { DocumentSessionManager } from '@kb-2/doc-session';
 import { createVaultService, type VaultService } from '@kb-2/vault-service';
+import { slug as githubSlug } from 'github-slugger';
 
 import { seedVaultFromStarterKit } from './starter-kit.js';
 
@@ -35,18 +36,23 @@ export interface VaultInstance {
 }
 
 /**
- * Derive a slug from a folder name. Lowercases, replaces runs of
- * non-alphanumeric characters with a single hyphen, and trims hyphens.
- * Falls back to `vault` when nothing usable remains.
+ * Normalize a string into a vault slug using github-slugger (battle-tested, not
+ * hand-rolled). Used to derive a slug from a folder name when minting identity,
+ * and as the basis for {@link isWellFormedSlug}. Stateless: it does not dedupe
+ * across calls, so the same input always yields the same output.
  */
-export function slugFromFolderName(folderName: string): string {
-  const slug = folderName
-    .normalize('NFKD')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+export function slugify(value: string): string {
+  return githubSlug(value);
+}
 
-  return slug.length > 0 ? slug : 'vault';
+/**
+ * Whether a caller-supplied slug is well-formed: non-empty AND already
+ * normalized (idempotent under {@link slugify} — slugging it again leaves it
+ * unchanged). Server and client share this exact definition so a slug the UI
+ * suggests is accepted verbatim by the server.
+ */
+export function isWellFormedSlug(slug: string): boolean {
+  return slug.length > 0 && slugify(slug) === slug;
 }
 
 function identityPath(vaultRoot: string): string {
@@ -79,7 +85,7 @@ export async function readOrMintVaultIdentity(vaultRoot: string, folderName: str
   }
 
   const identity: VaultIdentity = {
-    id: slugFromFolderName(folderName),
+    id: slugify(folderName),
     displayName: folderName
   };
   await writeVaultIdentity(vaultRoot, identity);
@@ -284,18 +290,27 @@ export class VaultRegistry {
 
   /**
    * Create a fresh, essentially-empty vault in the primary `vaultsHome`. The
-   * daemon owns the slug and the folder: the caller supplies only a display
-   * name, never a path. Slug uniqueness is enforced (collision is a clean
-   * client error, not a crash). The vault registers live and is immediately
-   * servable.
+   * caller supplies BOTH the display name and the slug; the daemon never infers
+   * the slug from the display name. The slug must be well-formed (non-empty and
+   * already normalized) and unique within the daemon — a bad slug is a clean
+   * `invalid_request`, a collision a clean `already_exists`, never a crash. The
+   * folder is still owned by the daemon (placed at `vaultsHome/<slug>/`). The
+   * vault registers live and is immediately servable.
    */
-  async create(input: { displayName: string }): Promise<VaultRegistryResult<{ vault: VaultSummary }>> {
+  async create(input: { displayName: string; slug: string }): Promise<VaultRegistryResult<{ vault: VaultSummary }>> {
     const displayName = input.displayName.trim();
     if (displayName.length === 0) {
       return { ok: false, error: 'invalid_request', message: 'displayName must be a non-empty string' };
     }
 
-    const slug = slugFromFolderName(displayName);
+    const slug = input.slug;
+    if (!isWellFormedSlug(slug)) {
+      return {
+        ok: false,
+        error: 'invalid_request',
+        message: 'slug must be non-empty and already normalized (lowercase, hyphen-separated).'
+      };
+    }
     if (this.instances.has(slug)) {
       return { ok: false, error: 'already_exists', message: `A vault with id "${slug}" already exists.` };
     }

--- a/packages/local-mcp/src/server.test.ts
+++ b/packages/local-mcp/src/server.test.ts
@@ -92,43 +92,50 @@ describe('local MCP server', () => {
       'vault_info'
     ]);
 
-    // Every vault-data tool advertises the optional vaultId; list_vaults does not.
+    // Every vault-data tool advertises the required vaultId; list_vaults does not.
     const vaultInfoTool = tools.tools.find((tool) => tool.name === 'vault_info');
     expect(vaultInfoTool?.inputSchema.properties).toHaveProperty('vaultId');
+    expect(vaultInfoTool?.inputSchema.required ?? []).toContain('vaultId');
     const listVaultsTool = tools.tools.find((tool) => tool.name === 'list_vaults');
     expect(listVaultsTool?.inputSchema.properties ?? {}).not.toHaveProperty('vaultId');
 
-    expect(await toolJson(client, 'vault_info', {})).toMatchObject({ ok: true, rootName: 'demo-vault' });
-    expect(await toolJson(client, 'list_files', { under: 'notes', depth: 1 })).toMatchObject({ ok: true, entries: [{ path: 'notes', metadata: { color: 'coral' } }] });
-    expect(await toolJson(client, 'get_folder_metadata', { path: 'notes' })).toMatchObject({ ok: true, path: 'notes', metadata: { color: 'coral' } });
-    expect(await toolJson(client, 'set_folder_metadata', { path: 'notes', color: 'mint', icon: null })).toMatchObject({ ok: true, path: 'notes', metadata: { color: 'mint' } });
-    expect(await toolJson(client, 'read_note', { path: 'note.md' })).toMatchObject({ ok: true, baseline: 'b1' });
-    expect(await toolJson(client, 'create_note', { path: 'created.md', content: 'created' })).toMatchObject({ ok: true, path: 'created.md' });
-    expect(await toolJson(client, 'edit_note', { path: 'note.md', baseline: 'b1', old_text: 'alpha', new_text: 'ALPHA' })).toMatchObject({ ok: true, content: 'ALPHA' });
-    expect(await toolJson(client, 'append_note', { path: 'note.md', content: '\nnext' })).toMatchObject({ ok: true, baseline: 'b3' });
-    expect(await toolJson(client, 'prepend_note', { path: 'note.md', content: 'first\n' })).toMatchObject({ ok: true, baseline: 'b4' });
-    expect(await toolJson(client, 'delete_note', { path: 'note.md' })).toMatchObject({ ok: true, path: 'note.md' });
-    expect(await toolJson(client, 'move_note', { from_path: 'note.md', to_path: 'moved.md' })).toMatchObject({ ok: true, toPath: 'moved.md' });
-    expect(await toolJson(client, 'create_folder', { path: 'folder' })).toMatchObject({ ok: true, path: 'folder' });
-    expect(await toolJson(client, 'delete_folder', { path: 'folder', recursive: true })).toMatchObject({ ok: true, path: 'folder' });
-    expect(await toolJson(client, 'move_folder', { from_path: 'old', to_path: 'new' })).toMatchObject({ ok: true, toPath: 'new' });
-    expect(await toolJson(client, 'search', { query: 'alpha' })).toMatchObject({ ok: true, total: 1 });
+    // A bare service normalizes to a single vault addressed by the synthetic
+    // 'default' id; every data tool must pass it (there is no default fallback).
+    const V = 'default';
+    expect(await toolJson(client, 'vault_info', { vaultId: V })).toMatchObject({ ok: true, rootName: 'demo-vault' });
+    expect(await toolJson(client, 'list_files', { vaultId: V, under: 'notes', depth: 1 })).toMatchObject({ ok: true, entries: [{ path: 'notes', metadata: { color: 'coral' } }] });
+    expect(await toolJson(client, 'get_folder_metadata', { vaultId: V, path: 'notes' })).toMatchObject({ ok: true, path: 'notes', metadata: { color: 'coral' } });
+    expect(await toolJson(client, 'set_folder_metadata', { vaultId: V, path: 'notes', color: 'mint', icon: null })).toMatchObject({ ok: true, path: 'notes', metadata: { color: 'mint' } });
+    expect(await toolJson(client, 'read_note', { vaultId: V, path: 'note.md' })).toMatchObject({ ok: true, baseline: 'b1' });
+    expect(await toolJson(client, 'create_note', { vaultId: V, path: 'created.md', content: 'created' })).toMatchObject({ ok: true, path: 'created.md' });
+    expect(await toolJson(client, 'edit_note', { vaultId: V, path: 'note.md', baseline: 'b1', old_text: 'alpha', new_text: 'ALPHA' })).toMatchObject({ ok: true, content: 'ALPHA' });
+    expect(await toolJson(client, 'append_note', { vaultId: V, path: 'note.md', content: '\nnext' })).toMatchObject({ ok: true, baseline: 'b3' });
+    expect(await toolJson(client, 'prepend_note', { vaultId: V, path: 'note.md', content: 'first\n' })).toMatchObject({ ok: true, baseline: 'b4' });
+    expect(await toolJson(client, 'delete_note', { vaultId: V, path: 'note.md' })).toMatchObject({ ok: true, path: 'note.md' });
+    expect(await toolJson(client, 'move_note', { vaultId: V, from_path: 'note.md', to_path: 'moved.md' })).toMatchObject({ ok: true, toPath: 'moved.md' });
+    expect(await toolJson(client, 'create_folder', { vaultId: V, path: 'folder' })).toMatchObject({ ok: true, path: 'folder' });
+    expect(await toolJson(client, 'delete_folder', { vaultId: V, path: 'folder', recursive: true })).toMatchObject({ ok: true, path: 'folder' });
+    expect(await toolJson(client, 'move_folder', { vaultId: V, from_path: 'old', to_path: 'new' })).toMatchObject({ ok: true, toPath: 'new' });
+    expect(await toolJson(client, 'search', { vaultId: V, query: 'alpha' })).toMatchObject({ ok: true, total: 1 });
 
-    // A bare service normalizes to a single synthetic 'default' vault: list_vaults
-    // reports it, an explicit vaultId: 'default' still routes, and an unknown
-    // vaultId is a clean tool error rather than a crash.
+    // list_vaults is the discovery entry point and takes no vaultId.
     expect(await toolJson(client, 'list_vaults', {})).toMatchObject({
       ok: true,
       vaults: [{ id: 'default', displayName: 'default' }]
     });
-    expect(await toolJson(client, 'vault_info', { vaultId: 'default' })).toMatchObject({ ok: true, rootName: 'demo-vault' });
+
+    // An unknown vaultId is a clean tool error rather than a crash.
     const unknownVault = await client.callTool({ name: 'vault_info', arguments: { vaultId: 'missing' } });
     expect(unknownVault.isError).toBe(true);
     expect(textContent(unknownVault)).toBe('vault_info rejected: {"ok":false,"error":"not_found","message":"No vault with id \\"missing\\"."}');
 
+    // A data-tool call WITHOUT vaultId is rejected (the param is required).
+    const missingVaultId = await client.callTool({ name: 'vault_info', arguments: {} });
+    expect(missingVaultId.isError).toBe(true);
+
     const stale = await client.callTool({
       name: 'edit_note',
-      arguments: { path: 'note.md', baseline: 'stale', old_text: 'alpha', new_text: 'ALPHA' }
+      arguments: { vaultId: V, path: 'note.md', baseline: 'stale', old_text: 'alpha', new_text: 'ALPHA' }
     });
     expect(stale.isError).toBe(true);
     expect(textContent(stale)).toBe('edit_note rejected: {"ok":false,"error":"stale_doc","message":"document changed since the provided baseline","current_content":"alpha beta","baseline":"fresh"}');

--- a/packages/local-mcp/src/server.ts
+++ b/packages/local-mcp/src/server.ts
@@ -93,13 +93,10 @@ export function createLocalMcpServer(source: LocalMcpVaultSource): McpServer {
     return client ? { kind: 'mcp_client', client } : unknownActor;
   };
 
-  // Resolve the addressed vault's service. Omitted vaultId targets the default
-  // vault (single-vault backward compatibility); an unknown vaultId returns a
-  // clean tool-level failure rather than throwing.
-  const resolve = (vaultId: string | undefined): { ok: true; service: LocalMcpVaultService } | ServiceFailure => {
-    if (vaultId === undefined) {
-      return { ok: true, service: provider.default() };
-    }
+  // Resolve the addressed vault's service. vaultId is required on every data
+  // tool — there is no default vault. An unknown vaultId returns a clean
+  // tool-level failure rather than throwing.
+  const resolve = (vaultId: string): { ok: true; service: LocalMcpVaultService } | ServiceFailure => {
     const service = provider.resolve(vaultId);
     if (!service) {
       return { ok: false, error: 'not_found', message: `No vault with id "${vaultId}".` };
@@ -107,17 +104,16 @@ export function createLocalMcpServer(source: LocalMcpVaultSource): McpServer {
     return { ok: true, service };
   };
 
-  /** The optional `vaultId` field shared by every vault-data tool's input schema. */
+  /** The required `vaultId` field shared by every vault-data tool's input schema. */
   const vaultIdField = {
     vaultId: z
       .string()
-      .optional()
-      .describe('Vault slug to target. Omit to operate on the default vault. Discover ids with list_vaults.')
+      .describe('Vault slug to target (required). Discover ids with list_vaults.')
   };
 
-  registerTool<{ vaultId?: string }>(server, 'list_vaults', {
+  registerTool<{}>(server, 'list_vaults', {
     description:
-      'List every vault this daemon serves, each as { id, displayName }. Use a vault id as the vaultId parameter on any other tool to target that vault; omit vaultId to use the default vault. Read-only; writes no audit row.',
+      'List every vault this daemon serves, each as { id, displayName }. Use a vault id as the required vaultId parameter on any other tool to target that vault. Read-only; writes no audit row.',
     inputSchema: {}
   }, async () => ({ ok: true, vaults: provider.list() }));
 
@@ -283,18 +279,18 @@ export function createLocalMcpServer(source: LocalMcpVaultSource): McpServer {
   return server;
 
   /**
-   * Register a vault-data tool: its schema carries the optional `vaultId`, and
+   * Register a vault-data tool: its schema carries the required `vaultId`, and
    * the handler receives the resolved service. An unknown `vaultId` short-circuits
    * to a clean tool error before the service is ever touched.
    */
   function registerVaultTool<TInput extends object>(
     target: McpServer,
-    resolveVault: (vaultId: string | undefined) => { ok: true; service: LocalMcpVaultService } | ServiceFailure,
+    resolveVault: (vaultId: string) => { ok: true; service: LocalMcpVaultService } | ServiceFailure,
     name: string,
     config: { description: string; inputSchema: Record<string, z.ZodType> },
     handler: (service: LocalMcpVaultService, input: TInput) => Promise<unknown>
   ): void {
-    registerTool<TInput & { vaultId?: string }>(
+    registerTool<TInput & { vaultId: string }>(
       target,
       name,
       { description: config.description, inputSchema: { ...config.inputSchema, ...vaultIdField } },
@@ -313,20 +309,18 @@ function asProvider(source: LocalMcpVaultSource): LocalMcpVaultProvider {
   if (isProvider(source)) {
     return source;
   }
-  // Bare service: a single, always-default vault. `resolve` matches the synthetic
-  // id (or anything, treating the lone vault as the only target) so legacy callers
-  // and explicit `vaultId: 'default'` both land on it.
+  // Bare service: a single vault addressed by the synthetic 'default' id. There
+  // is no default-vault fallback — callers must pass vaultId: 'default' to reach
+  // it, the same as any other vault.
   const service = source;
   return {
-    default: () => service,
     resolve: (id) => (id === SINGLE_VAULT_ID ? service : undefined),
     list: () => [{ id: SINGLE_VAULT_ID, displayName: SINGLE_VAULT_ID }]
   };
 }
 
 function isProvider(source: LocalMcpVaultSource): source is LocalMcpVaultProvider {
-  return typeof (source as LocalMcpVaultProvider).default === 'function'
-    && typeof (source as LocalMcpVaultProvider).resolve === 'function'
+  return typeof (source as LocalMcpVaultProvider).resolve === 'function'
     && typeof (source as LocalMcpVaultProvider).list === 'function';
 }
 

--- a/packages/local-mcp/src/types.ts
+++ b/packages/local-mcp/src/types.ts
@@ -16,15 +16,14 @@ export interface LocalMcpVaultSummary {
  * an addressed vault and for enumerating vaults, so the MCP endpoint never holds
  * a second vault map.
  *
- * `default` is the vault used when a tool call omits `vaultId`; it keeps the
- * single-vault MCP surface byte-for-byte backward compatible. `resolve` returns
- * the service for a given slug, or `undefined` when no vault carries that slug.
+ * There is no default vault: every data tool requires a `vaultId`. `resolve`
+ * returns the service for a given slug, or `undefined` when no vault carries
+ * that slug (the tool then returns a clean error). `list` powers `list_vaults`,
+ * the discovery entry point, and may be empty (zero vaults is a valid state).
  */
 export interface LocalMcpVaultProvider {
-  /** The vault served when a tool call omits `vaultId`. */
-  default(): LocalMcpVaultService;
   /** Resolve a vault's service by slug, or `undefined` when unknown. */
   resolve(id: string): LocalMcpVaultService | undefined;
-  /** Every addressable vault as `{ id, displayName }`. */
+  /** Every addressable vault as `{ id, displayName }`; may be empty. */
   list(): LocalMcpVaultSummary[];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@kb-2/vault-service':
         specifier: workspace:*
         version: link:../../packages/vault-service
+      github-slugger:
+        specifier: 2.0.0
+        version: 2.0.0
       hono:
         specifier: 4.12.25
         version: 4.12.25
@@ -281,9 +284,6 @@ importers:
       svelte:
         specifier: 'catalog:'
         version: 5.55.5
-      y-protocols:
-        specifier: 1.0.7
-        version: 1.0.7(yjs@13.6.31)
       yjs:
         specifier: 13.6.31
         version: 13.6.31
@@ -2073,6 +2073,9 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -4616,6 +4619,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  github-slugger@2.0.0: {}
 
   gopd@1.2.0: {}
 


### PR DESCRIPTION
Every MCP data tool now takes a required vaultId; the optional default-vault
fallback is gone and list_vaults is the discovery entry point. Vault creation
requires an explicit, server-validated slug (well-formed and unique) rather than
inferring one from the display name, and slug handling moves to github-slugger.
The flat single-vault routes and the demo-document surface are retired: every
vault is reached through /api/vaults/:id/*. Zero vaults is a valid runtime
state, so the daemon boots, lists empty, and returns clean 404s with no default.