### PR TITLE
Make the web comfortable with many vaults, no vaults, and explicit slugs

### DIFF
--- a/apps/web/src/lib/app-state/last-opened-vault.test.ts
+++ b/apps/web/src/lib/app-state/last-opened-vault.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { createAppState } from './store';
+
+function memoryStorage(): Pick<Storage, 'getItem' | 'setItem'> & { dump: () => string | null } {
+  let value: string | null = null;
+  return {
+    getItem: () => value,
+    setItem: (_key, next) => {
+      value = next;
+    },
+    dump: () => value,
+  };
+}
+
+describe('lastOpenedVaultId slice', () => {
+  it('defaults to null', () => {
+    expect(createAppState().getState().lastOpenedVaultId).toBe(null);
+  });
+
+  it('setLastOpenedVaultId records the slug', () => {
+    const store = createAppState();
+    store.setLastOpenedVaultId('field-notes');
+    expect(store.getState().lastOpenedVaultId).toBe('field-notes');
+  });
+
+  it('is a no-op when unchanged', () => {
+    const store = createAppState();
+    let notified = 0;
+    store.subscribe(() => {
+      notified += 1;
+    });
+    store.setLastOpenedVaultId(null);
+    expect(notified).toBe(0);
+    store.setLastOpenedVaultId('demo-vault');
+    expect(notified).toBe(1);
+    store.setLastOpenedVaultId('demo-vault');
+    expect(notified).toBe(1);
+  });
+
+  it('null forgets the last-opened (e.g. the last vault was deleted)', () => {
+    const store = createAppState();
+    store.setLastOpenedVaultId('demo-vault');
+    store.setLastOpenedVaultId(null);
+    expect(store.getState().lastOpenedVaultId).toBe(null);
+  });
+
+  it('persists and rehydrates the slug', () => {
+    const storage = memoryStorage();
+    const a = createAppState({ storage });
+    a.setLastOpenedVaultId('field-notes');
+    const b = createAppState({ storage });
+    expect(b.getState().lastOpenedVaultId).toBe('field-notes');
+  });
+
+  it('ignores a non-string persisted value', () => {
+    const storage = memoryStorage();
+    storage.setItem('kb2:app-state', JSON.stringify({ lastOpenedVaultId: 42 }));
+    expect(createAppState({ storage }).getState().lastOpenedVaultId).toBe(null);
+  });
+});

--- a/apps/web/src/lib/app-state/store.ts
+++ b/apps/web/src/lib/app-state/store.ts
@@ -79,6 +79,12 @@ interface PersistedState {
   railCollapsed: boolean;
   /** Pinned notes/folders. Persisted verbatim — see {@link FavoriteEntry}. */
   favorites: FavoriteEntry[];
+  /**
+   * The vault the user last had open (its slug), or `null` if none yet.
+   * First load reopens this vault; switching vaults updates it. There is
+   * no "default vault" — this is purely the remembered last-opened.
+   */
+  lastOpenedVaultId: string | null;
 }
 
 /** The live, in-memory app state. Mirrors the persisted slice plus actions. */
@@ -118,6 +124,12 @@ export interface AppState {
    * inserted; the starred panel sorts by `addedAt` for display.
    */
   favorites: FavoriteEntry[];
+  /**
+   * The slug of the vault the user last opened, or `null` if none. First
+   * load reopens it (else the first vault in the list). NOT a default
+   * vault — just the remembered last-opened.
+   */
+  lastOpenedVaultId: string | null;
 }
 
 export interface AppStateStore {
@@ -145,6 +157,12 @@ export interface AppStateStore {
   toggleRailCollapsed: () => void;
   /** Set the primary rail's collapsed state directly. */
   setRailCollapsed: (collapsed: boolean) => void;
+  /**
+   * Remember the vault the user is now in (its slug). `null` forgets the
+   * last-opened (e.g. the last vault was deleted). First load reopens
+   * this; switching vaults updates it.
+   */
+  setLastOpenedVaultId: (vaultId: string | null) => void;
   /**
    * Star/unstar a note or folder. Adds the entry (stamped with
    * `addedAt`) when absent, removes it when present.
@@ -184,6 +202,7 @@ const DEFAULT_STATE: AppState = {
   secondaryRailWidth: SECONDARY_RAIL_WIDTH_DEFAULT,
   railCollapsed: false,
   favorites: [],
+  lastOpenedVaultId: null,
 };
 
 function sortedIds(ids: readonly string[]): string[] {
@@ -229,6 +248,7 @@ interface PersistedSlice {
   secondaryRailWidth: number;
   railCollapsed: boolean;
   favorites: FavoriteEntry[];
+  lastOpenedVaultId: string | null;
 }
 
 function readPersisted(
@@ -253,6 +273,7 @@ function readPersisted(
     }
     if (typeof blob.railCollapsed === 'boolean') out.railCollapsed = blob.railCollapsed;
     if ('favorites' in blob) out.favorites = favoriteArray(blob.favorites);
+    if (typeof blob.lastOpenedVaultId === 'string') out.lastOpenedVaultId = blob.lastOpenedVaultId;
     return out;
   } catch {
     // Corrupt blob — fall back to defaults rather than throwing.
@@ -279,6 +300,7 @@ export function createAppState(
     secondaryRailWidth: persisted.secondaryRailWidth ?? DEFAULT_STATE.secondaryRailWidth,
     railCollapsed: persisted.railCollapsed ?? DEFAULT_STATE.railCollapsed,
     favorites: persisted.favorites ?? [],
+    lastOpenedVaultId: persisted.lastOpenedVaultId ?? DEFAULT_STATE.lastOpenedVaultId,
   };
 
   const listeners = new Set<(state: AppState) => void>();
@@ -293,6 +315,7 @@ export function createAppState(
       secondaryRailWidth: state.secondaryRailWidth,
       railCollapsed: state.railCollapsed,
       favorites: state.favorites,
+      lastOpenedVaultId: state.lastOpenedVaultId,
     };
     try {
       storage.setItem(persistKey, JSON.stringify(blob));
@@ -360,6 +383,10 @@ export function createAppState(
     setRailCollapsed: (collapsed) => {
       if (collapsed === state.railCollapsed) return;
       commit({ ...state, railCollapsed: collapsed });
+    },
+    setLastOpenedVaultId: (vaultId) => {
+      if (vaultId === state.lastOpenedVaultId) return;
+      commit({ ...state, lastOpenedVaultId: vaultId });
     },
     toggleFavorite: (entry) => {
       const target = favoriteKey(entry);

--- a/apps/web/src/lib/kb-service.ts
+++ b/apps/web/src/lib/kb-service.ts
@@ -57,12 +57,14 @@ function messageForError(
   if (context === 'vault') {
     switch (code) {
       case 'already_exists':
-        // Slug collision: the inferred slug already names a vault. Surface
+        // Slug collision: the submitted slug already names a vault. Surface
         // the daemon's specific message when present (it names the slug),
         // otherwise a plain vault-collision sentence.
-        return fallback ?? 'A vault with that name already exists.';
+        return fallback ?? 'A vault with that slug already exists.';
       case 'invalid_request':
-        return fallback ?? 'That vault name is not allowed.';
+        // A malformed slug the server rejected. The daemon's message names
+        // the problem; fall back to a slug-shaped sentence.
+        return fallback ?? 'That slug is not allowed.';
       case 'not_found':
         return 'That vault no longer exists.';
       default:
@@ -127,17 +129,20 @@ export const kbService = {
   },
 
   /**
-   * Create a vault from a display name. The daemon infers the slug; a
-   * slug collision surfaces as a clean error (the daemon's 409), never a
-   * silent failure.
+   * Create a vault from an explicit display name + slug. Both are always
+   * sent; the daemon validates the slug (format + uniqueness) and never
+   * infers it. A bad slug (400) or a slug collision (409) surfaces as a
+   * clean error, never a silent failure. The caller suggests the slug
+   * with the SAME github-slugger definition the daemon uses, so a
+   * suggested slug is accepted verbatim.
    */
-  async createVault(displayName: string): Promise<VaultSummary> {
+  async createVault(displayName: string, slug: string): Promise<VaultSummary> {
     const result = await request<{ ok: true; vault: VaultSummary }>(
       '/api/vaults',
       {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ displayName }),
+        body: JSON.stringify({ displayName, slug }),
       },
       'vault',
     );

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -21,10 +21,12 @@
     ConfirmDialog,
     DocumentNotFoundState,
     EditorSaveNotifications,
+    EmptyVaultsState,
     FolderCanvas,
     LocalEditorShell,
     LocalEditorMobileShell,
     MovePickerDialog,
+    NewVaultDialog,
     TextInputDialog,
     type AccentName,
     type BreadcrumbItem,
@@ -32,6 +34,7 @@
     type LocalFolderNode,
     type LocalTreeAction,
     type LocalTreeNode,
+    type NewVaultSubmit,
     type RailNavId,
     type VaultFilterEntry,
     type VaultGroupData,
@@ -93,6 +96,15 @@
         run: (folderPath: string) => Promise<void>;
         busy: boolean;
         error: string | null;
+      }
+    // The "New vault" dialog. Carries the create op, which always submits
+    // both the display name and the (suggested, editable) slug. `busy`/
+    // `error` surface in-flight + server validation outcomes inline.
+    | {
+        kind: 'new-vault';
+        run: (value: NewVaultSubmit) => Promise<void>;
+        busy: boolean;
+        error: string | null;
       };
 
   let dialog = $state<DialogState>({ kind: 'none' });
@@ -142,6 +154,11 @@
       tree: vaultTrees[v.id] ?? [],
     })),
   );
+  // Whether the daemon serves any vaults. Zero vaults is a VALID state
+  // (a fresh daemon, or the user deleted the last one) — not an error.
+  // When false, the page shows the calm "create your first vault" empty
+  // state instead of the editor shell.
+  const hasVaults = $derived(knownVaults.length > 0);
   let mounted = $state(false);
   // Which secondary panel the rail has selected. 'files' shows the tree;
   // 'starred' shows the (currently empty) starred view.
@@ -525,9 +542,11 @@
   }
 
   // Switch the active vault: navigate to its root. The afterNavigate hook
-  // rebinds state (active id, document, tree) off the new URL.
+  // rebinds state (active id, document, tree) off the new URL. Remember it
+  // as the last-opened so the next cold load reopens here.
   async function openVault(vaultId: string): Promise<void> {
     if (vaultId === activeVaultId) return;
+    appState.setLastOpenedVaultId(vaultId);
     await goto(vaultRoute(vaultId, ''), { noScroll: true });
   }
 
@@ -754,6 +773,23 @@
     }
   }
 
+  // Run the new-vault create, keeping the dialog open with busy/error so a
+  // server validation outcome (bad slug, collision) surfaces inline. The
+  // create op already refreshes the list + navigates, so there's no tree
+  // follow-up here (and there may be no active tree on the first vault).
+  async function runNewVaultDialog(value: NewVaultSubmit): Promise<void> {
+    if (dialog.kind !== 'new-vault') return;
+    const run = dialog.run;
+    patchDialog({ busy: true, error: null });
+    try {
+      await run(value);
+      closeDialog();
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : String(caught);
+      patchDialog({ busy: false, error: message });
+    }
+  }
+
   function handleTreeAction(action: LocalTreeAction): void {
     if (action.kind === 'file') {
       openFileDialog(action);
@@ -957,41 +993,50 @@
       run: async () => {
         await kbService.deleteVault(targetVaultId);
       },
-      // Drop the vault from the list; if it was active, land in a survivor.
+      // Drop the vault from the list. If it was the active one, land in a
+      // survivor — or, when it was the LAST vault, in the empty state
+      // (zero vaults is valid). Deleting the active vault also clears its
+      // last-opened so a stale slug isn't reopened next cold load.
       afterSuccess: async () => {
         await refreshVaults();
         if (targetVaultId === activeVaultId) {
           const survivor = knownVaults[0];
-          if (survivor) await openVault(survivor.id);
+          if (survivor) {
+            await openVault(survivor.id);
+          } else {
+            // No vaults left — fall to the empty state cleanly.
+            activeVaultId = '';
+            documentPath = '';
+            provider?.destroy();
+            provider = null;
+            providerSynced = false;
+            appState.setLastOpenedVaultId(null);
+            await goto('/', { replaceState: true, noScroll: true });
+          }
         }
       },
     };
   }
 
-  // The footer "New vault" affordance. Collects a display name (matching
-  // the new-note/new-folder naming UX) and creates the vault; the daemon
-  // infers the slug. A slug collision surfaces the daemon's 409 cleanly
-  // in the dialog's error slot. On success the new vault appears in the
-  // rail and becomes active.
+  // The "New vault" affordance (footer + empty state). Opens the
+  // slug-suggest dialog, which auto-suggests a slug from the display name
+  // (client-side, the SAME github-slugger definition the daemon uses),
+  // lets the user edit it, and ALWAYS submits both `{ displayName, slug }`.
+  // The server validates the slug (format + uniqueness): a bad slug (400)
+  // or a collision (409) surfaces inline in the dialog's error slot, never
+  // a silent failure. On success the new vault appears in the rail and
+  // becomes active.
   function openNewVaultDialog(): void {
     dialog = {
-      kind: 'text',
-      title: 'New vault',
-      description: 'Create a new vault. A folder is created on disk from the name.',
-      fields: [{ type: 'text', label: 'Name', placeholder: 'untitled', required: true }],
-      submitLabel: 'Create',
+      kind: 'new-vault',
       busy: false,
       error: null,
-      run: async ([nextName]) => {
-        const trimmed = nextName.trim();
-        if (!trimmed) return;
-        const created = await kbService.createVault(trimmed);
+      run: async ({ displayName, slug }) => {
+        const created = await kbService.createVault(displayName, slug);
         // Reflect the new vault and switch to it.
         await refreshVaults();
         await openVault(created.id);
       },
-      // `run` already refreshed the list + navigated; no tree refresh.
-      afterSuccess: async () => undefined,
     };
   }
 
@@ -1094,7 +1139,8 @@
 
 
   // Parse the route into `{ vaultId, path }`. A root URL (`/`) yields a
-  // null vaultId, signalling "land in the default vault".
+  // null vaultId, signalling "resolve a target on bootstrap" (last-opened
+  // else first vault — there is no default vault).
   function routeFromUrl(url: URL): { vaultId: string | null; path: string } {
     return parseVaultRoute(url.pathname);
   }
@@ -1156,24 +1202,37 @@
   });
 
   // First-load bootstrap. Load the vault list, resolve the active vault
-  // from the URL (or fall back to the default = first vault), normalize
-  // the URL to `/<vaultId>/<path>`, then open the document + load the
-  // rail's trees. Visiting `/` lands in the default vault.
+  // from the URL (or fall back to the last-opened vault, else the first in
+  // the list — there is NO default vault), normalize the URL to
+  // `/<vaultId>/<path>`, then open the document + load the rail's trees.
+  // Zero vaults is a valid state: nothing to open, the empty state renders.
   async function bootstrap(): Promise<void> {
     const loaded = await refreshVaults();
     if (loaded.length === 0) {
-      // No vaults to serve — nothing to open. The rail shows its empty
-      // state; an explicit error (if any) already surfaced.
+      // No vaults to serve — a fresh daemon or every vault deleted. This
+      // is normal, not an error; the empty "create your first vault" state
+      // renders. Forget any stale last-opened so we don't reopen a gone
+      // vault when one is created.
+      activeVaultId = '';
+      appState.setLastOpenedVaultId(null);
       return;
     }
 
     const route = routeFromUrl(new URL(window.location.href));
     const known = route.vaultId && loaded.some((v) => v.id === route.vaultId);
-    const targetVaultId = known ? (route.vaultId as string) : loaded[0].id;
+    // Fall back to the last-opened vault if it still exists, else the
+    // first in the list. No "default vault" — just the remembered choice.
+    const remembered = appState.getState().lastOpenedVaultId;
+    const fallbackId =
+      remembered && loaded.some((v) => v.id === remembered)
+        ? remembered
+        : loaded[0].id;
+    const targetVaultId = known ? (route.vaultId as string) : fallbackId;
     const targetPath = known ? route.path : '';
 
     activeVaultId = targetVaultId;
     documentPath = targetPath;
+    appState.setLastOpenedVaultId(targetVaultId);
 
     // Normalize the URL when we redirected (root, or an unknown vault).
     if (!known) {
@@ -1191,13 +1250,18 @@
   afterNavigate((navigation) => {
     if (!mounted || !navigation.to?.url) return;
     const route = routeFromUrl(navigation.to.url);
-    // A root URL or an unknown vault redirects to the default vault; the
-    // bootstrap + this same hook handle that, so ignore until resolved.
+    // A root URL (no vault segment) means "resolve a target on bootstrap"
+    // or, with zero vaults, the empty state. Either way there's nothing to
+    // rebind off the URL here, so ignore it.
     if (!route.vaultId) return;
 
     const vaultChanged = route.vaultId !== activeVaultId;
     if (vaultChanged) {
       activeVaultId = route.vaultId;
+      // Remember the now-active vault (covers cross-vault navigation that
+      // doesn't go through `openVault`, e.g. opening a file in another
+      // vault's group). The next cold load reopens here.
+      appState.setLastOpenedVaultId(route.vaultId);
       // Ensure the now-active vault's tree is loaded for the canvas.
       if (!vaultTrees[route.vaultId]) void loadVaultTree(route.vaultId);
     }
@@ -1313,7 +1377,13 @@
   {/if}
 {/snippet}
 
-{#if viewport.mode === 'mobile'}
+{#if !hasVaults}
+  <!-- Zero vaults is a valid state (fresh daemon, or the last vault was
+       deleted). Show the calm "create your first vault" empty state with
+       a way to create one — no error, no blank void. The create button
+       opens the same slug-suggest dialog the footer uses. -->
+  <EmptyVaultsState onCreateVault={openNewVaultDialog} />
+{:else if viewport.mode === 'mobile'}
   <LocalEditorMobileShell
     bind:navOpen
     {vaultName}
@@ -1443,6 +1513,16 @@
     error={dialog.error}
     onsubmit={(destination) => {
       void runDialogOperation(() => dialog.kind === 'move' ? dialog.run(destination) : Promise.resolve());
+    }}
+    oncancel={closeDialog}
+  />
+{:else if dialog.kind === 'new-vault'}
+  <NewVaultDialog
+    open
+    busy={dialog.busy}
+    error={dialog.error}
+    onsubmit={(value) => {
+      void runNewVaultDialog(value);
     }}
     oncancel={closeDialog}
   />

--- a/apps/web/src/test/local-editor-route.test.ts
+++ b/apps/web/src/test/local-editor-route.test.ts
@@ -128,7 +128,10 @@ describe('local editor route', () => {
   it('hides the vault tree when the vault is toggled off in the filter', async () => {
     render(AppStateHarness);
 
-    const filesPanel = within(screen.getByRole('complementary', { name: 'Vault files' }));
+    // The rail (and the shell) only render once the vault list loads —
+    // zero vaults is a valid state that shows the empty "create your first
+    // vault" screen instead — so wait for the rail before querying it.
+    const filesPanel = within(await screen.findByRole('complementary', { name: 'Vault files' }));
     // The tree renders the vault's folders while the vault is visible.
     expect(await filesPanel.findByText('projects')).toBeTruthy();
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "github-slugger": "2.0.0",
     "phosphor-svelte": "^3.1.0",
     "svelte": "catalog:",
     "tailwind-merge": "^3.5.0"

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -41,6 +41,10 @@ export { default as VaultFilterPopover } from './local-editor/VaultFilterPopover
 export { default as RailResizeHandle } from './local-editor/RailResizeHandle.svelte';
 export { default as FolderNode } from './local-editor/FolderNode.svelte';
 export { default as VaultGroup } from './local-editor/VaultGroup.svelte';
+export { default as NewVaultDialog } from './local-editor/NewVaultDialog.svelte';
+export type { NewVaultSubmit } from './local-editor/NewVaultDialog.svelte';
+export { default as EmptyVaultsState } from './local-editor/EmptyVaultsState.svelte';
+export { suggestSlug, isWellFormedSlug } from './local-editor/slug';
 export { default as LocalEditorShell } from './local-editor/LocalEditorShell.svelte';
 export { default as LocalEditorMobileShell } from './local-editor/LocalEditorMobileShell.svelte';
 export { default as StarredPanel } from './local-editor/StarredPanel.svelte';

--- a/packages/ui/src/lib/local-editor/EmptyVaultsState.stories.ts
+++ b/packages/ui/src/lib/local-editor/EmptyVaultsState.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import EmptyVaultsStateDemo from '../stories/EmptyVaultsStateDemo.svelte';
+
+const meta = {
+  title: 'App/Local Editor/EmptyVaultsState',
+  component: EmptyVaultsStateDemo,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    mode: 'light'
+  }
+} satisfies Meta<typeof EmptyVaultsStateDemo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Light: Story = {};
+
+export const Dark: Story = {
+  args: {
+    mode: 'dark'
+  }
+};

--- a/packages/ui/src/lib/local-editor/EmptyVaultsState.svelte
+++ b/packages/ui/src/lib/local-editor/EmptyVaultsState.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import Button from '../button/button.svelte';
+  import Icon from '../primitives/Icon.svelte';
+
+  /**
+   * The calm "no vaults yet" screen. Zero vaults is a NORMAL state — a
+   * fresh daemon, or the user just deleted the last vault — never an
+   * error. This invites the user to create their first vault.
+   *
+   * Prop-driven and transport-free: the create action is the host's
+   * `onCreateVault` callback (the host opens the new-vault dialog and owns
+   * the network create).
+   */
+  interface Props {
+    /** Open the create-vault flow. */
+    onCreateVault?: () => void;
+  }
+
+  let { onCreateVault }: Props = $props();
+</script>
+
+<section class="empty-vaults" aria-label="No vaults yet">
+  <div class="card">
+    <span class="glyph" aria-hidden="true">
+      <Icon name="folder" size={28} weight="duotone" />
+    </span>
+    <h1>Create your first vault</h1>
+    <p class="message">
+      A vault is a folder of notes. You don’t have one yet — create one to
+      start writing. Your notes live as plain files on disk.
+    </p>
+    <Button onclick={() => onCreateVault?.()}>
+      <span class="btn-glyph" aria-hidden="true">
+        <Icon name="plus" size={14} weight="bold" />
+      </span>
+      New vault
+    </Button>
+  </div>
+</section>
+
+<style>
+  .empty-vaults {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    min-height: 100%;
+    padding: 48px 24px;
+    background: var(--rd-bg);
+    font-family: var(--rd-ui);
+  }
+
+  .card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    max-width: 30rem;
+    gap: 14px;
+  }
+
+  .glyph {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: 14px;
+    background: var(--rd-panel);
+    color: var(--rd-ink-3);
+  }
+
+  h1 {
+    margin: 0;
+    color: var(--rd-ink-1);
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  .message {
+    margin: 0;
+    color: var(--rd-ink-3);
+    font-size: 14px;
+    line-height: 1.6;
+  }
+
+  .btn-glyph {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 6px;
+  }
+</style>

--- a/packages/ui/src/lib/local-editor/NewVaultDialog.stories.ts
+++ b/packages/ui/src/lib/local-editor/NewVaultDialog.stories.ts
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import NewVaultDialogDemo from '../stories/NewVaultDialogDemo.svelte';
+
+const meta = {
+  title: 'App/Dialogs/NewVaultDialog',
+  component: NewVaultDialogDemo,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    mode: 'light'
+  }
+} satisfies Meta<typeof NewVaultDialogDemo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Light: Story = {};
+
+export const Dark: Story = {
+  args: {
+    mode: 'dark'
+  }
+};
+
+// The server reported a slug collision; the dialog keeps the typed values
+// and surfaces the message inline so the user can pick a different slug.
+export const WithError: Story = {
+  args: {
+    error: 'A vault with that slug already exists.'
+  }
+};

--- a/packages/ui/src/lib/local-editor/NewVaultDialog.svelte
+++ b/packages/ui/src/lib/local-editor/NewVaultDialog.svelte
@@ -1,0 +1,208 @@
+<script lang="ts" module>
+  export interface NewVaultSubmit {
+    /** Human-facing vault name. */
+    displayName: string;
+    /** The (editable) slug — the daemon's stable vault id. Always sent. */
+    slug: string;
+  }
+</script>
+
+<script lang="ts">
+  import { tick } from 'svelte';
+  import Button from '../button/button.svelte';
+  import FormField from '../primitives/forms/FormField.svelte';
+  import DialogShell from '../dialogs/DialogShell.svelte';
+  import { suggestSlug, isWellFormedSlug } from './slug';
+
+  /**
+   * "New vault" dialog. Collects a display name, auto-suggests a slug from
+   * it as the user types (client-side, via the SAME github-slugger
+   * definition the daemon uses, so a suggested slug is accepted verbatim),
+   * and lets the user edit the slug. On submit it ALWAYS emits both
+   * `{ displayName, slug }`.
+   *
+   * Owns no transport: the network create is the host's `onsubmit`
+   * callback; `busy` / `error` surface in-flight + failure state (an
+   * invalid slug or a slug collision the server reports) inline.
+   */
+  interface Props {
+    open: boolean;
+    title?: string;
+    description?: string;
+    submitLabel?: string;
+    cancelLabel?: string;
+    busy?: boolean;
+    /** Server-side failure (bad slug, collision) surfaced inline. */
+    error?: string | null;
+    onsubmit: (value: NewVaultSubmit) => void;
+    oncancel: () => void;
+  }
+
+  let {
+    open,
+    title = 'New vault',
+    description = 'Create a vault. The slug names its folder and URL; it is suggested from the name and you can edit it.',
+    submitLabel = 'Create',
+    cancelLabel = 'Cancel',
+    busy = false,
+    error = null,
+    onsubmit,
+    oncancel,
+  }: Props = $props();
+
+  let displayName = $state('');
+  let slug = $state('');
+  // Whether the user has hand-edited the slug. While false, the slug
+  // tracks the suggestion from the display name; once the user touches it,
+  // we stop overwriting their choice.
+  let slugEdited = $state(false);
+  let nameInput = $state<HTMLInputElement | null>(null);
+
+  $effect(() => {
+    if (open) {
+      displayName = '';
+      slug = '';
+      slugEdited = false;
+      void focusName();
+    }
+  });
+
+  async function focusName(): Promise<void> {
+    await tick();
+    nameInput?.focus();
+  }
+
+  // Re-suggest the slug from the name until the user takes the slug over.
+  // Read the live value off the event target so we don't depend on the
+  // `bind:value` listener firing first; `bind:value` then reflects any
+  // slug reassignment back into the slug input.
+  function onNameInput(event: Event): void {
+    const next = (event.currentTarget as HTMLInputElement).value;
+    if (!slugEdited) slug = suggestSlug(next);
+  }
+
+  // A manual slug edit pins the slug to the user's value. Clearing it back
+  // to empty re-arms the suggestion so the slot doesn't get stuck blank.
+  function onSlugInput(event: Event): void {
+    const next = (event.currentTarget as HTMLInputElement).value;
+    if (next === '') {
+      slugEdited = false;
+      slug = suggestSlug(displayName);
+      return;
+    }
+    slugEdited = true;
+  }
+
+  const trimmedName = $derived(displayName.trim());
+  // The well-formedness hint mirrors the daemon's server-side check, so a
+  // bad slug is caught before the round-trip. An empty slug is gated by
+  // `canSubmit`; this message only fires for a present-but-malformed slug.
+  const slugInvalid = $derived(slug.length > 0 && !isWellFormedSlug(slug));
+  const canSubmit = $derived(
+    !busy && trimmedName.length > 0 && slug.length > 0 && !slugInvalid,
+  );
+
+  function submit(): void {
+    if (!canSubmit) return;
+    onsubmit({ displayName: trimmedName, slug });
+  }
+
+  function handleKey(event: KeyboardEvent): void {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      submit();
+    }
+  }
+</script>
+
+<DialogShell {open} onclose={oncancel} {title} {description}>
+  {#snippet children()}
+    <form
+      class="dialog-form"
+      onsubmit={(e) => {
+        e.preventDefault();
+        submit();
+      }}
+    >
+      <label class="field">
+        <span class="field-label">Name</span>
+        <FormField
+          bind:value={displayName}
+          bind:ref={nameInput}
+          placeholder="My vault"
+          oninput={onNameInput}
+          onkeydown={handleKey}
+          disabled={busy}
+        />
+      </label>
+
+      <label class="field">
+        <span class="field-label">Slug</span>
+        <FormField
+          bind:value={slug}
+          placeholder="my-vault"
+          oninput={onSlugInput}
+          onkeydown={handleKey}
+          disabled={busy}
+        />
+        {#if slugInvalid}
+          <span class="field-hint field-hint-error">
+            A slug uses lowercase letters, numbers, and dashes. Try “{suggestSlug(slug)}”.
+          </span>
+        {:else}
+          <span class="field-hint">Used for the folder and the URL.</span>
+        {/if}
+      </label>
+
+      {#if error}
+        <p class="dialog-error">{error}</p>
+      {/if}
+    </form>
+  {/snippet}
+  {#snippet footer()}
+    <Button variant="ghost" size="sm" onclick={oncancel} disabled={busy}>
+      {cancelLabel}
+    </Button>
+    <Button size="sm" onclick={submit} disabled={!canSubmit}>
+      {busy ? 'Working…' : submitLabel}
+    </Button>
+  {/snippet}
+</DialogShell>
+
+<style>
+  .dialog-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-family: var(--rd-ui);
+    font-size: 14px;
+  }
+
+  .field-label {
+    font-weight: 500;
+    color: var(--foreground);
+  }
+
+  .field-hint {
+    color: var(--muted-foreground);
+    font-family: var(--rd-ui);
+    font-size: 12px;
+  }
+
+  .field-hint-error {
+    color: var(--destructive);
+  }
+
+  .dialog-error {
+    margin: 0;
+    color: var(--destructive);
+    font-family: var(--rd-ui);
+    font-size: 14px;
+  }
+</style>

--- a/packages/ui/src/lib/local-editor/slug.ts
+++ b/packages/ui/src/lib/local-editor/slug.ts
@@ -1,0 +1,33 @@
+import { slug as githubSlug } from 'github-slugger';
+
+/**
+ * Slug helpers shared with the daemon, defined identically so a slug the
+ * UI suggests is accepted by the server verbatim.
+ *
+ * These are PURE string transforms — no transport, no endpoint knowledge —
+ * so they are allowed to live in `packages/ui` (the `ui-packages-own-no-
+ * transport` invariant scopes only network/IO). The network submit stays
+ * in the app (`apps/web/src/lib/kb-service.ts`).
+ *
+ * The daemon normalizes with the SAME `github-slugger` library
+ * (`apps/daemon/src/vault-registry.ts`). Keep this in lockstep with it.
+ */
+
+/**
+ * Normalize a string into a vault slug via github-slugger (battle-tested,
+ * not hand-rolled). Stateless: the same input always yields the same
+ * output (it does not dedupe across calls).
+ */
+export function suggestSlug(value: string): string {
+  return githubSlug(value);
+}
+
+/**
+ * Whether a slug is well-formed: non-empty AND already normalized
+ * (idempotent under {@link suggestSlug} — slugging it again leaves it
+ * unchanged). Mirrors the daemon's server-side check so the UI can flag a
+ * bad slug before the round-trip.
+ */
+export function isWellFormedSlug(slug: string): boolean {
+  return slug.length > 0 && suggestSlug(slug) === slug;
+}

--- a/packages/ui/src/lib/primitives/forms/FormField.svelte
+++ b/packages/ui/src/lib/primitives/forms/FormField.svelte
@@ -17,6 +17,9 @@
     required?: boolean;
     ref?: HTMLInputElement | null;
     onkeydown?: (event: KeyboardEvent) => void;
+    /** Fires on every keystroke — used by callers that derive a live
+        value (e.g. the new-vault dialog's slug-suggest) from the input. */
+    oninput?: (event: Event) => void;
   }
 
   let {
@@ -29,6 +32,7 @@
     required = false,
     ref = $bindable(null),
     onkeydown,
+    oninput,
   }: Props = $props();
 </script>
 
@@ -39,6 +43,7 @@
   {type}
   {placeholder}
   {onkeydown}
+  {oninput}
   {disabled}
   {autocomplete}
   {name}

--- a/packages/ui/src/lib/stories/EmptyVaultsStateDemo.svelte
+++ b/packages/ui/src/lib/stories/EmptyVaultsStateDemo.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { EmptyVaultsState } from '../index';
+
+  interface Props {
+    mode?: 'light' | 'dark';
+  }
+
+  let { mode = 'light' }: Props = $props();
+
+  let created = $state(0);
+</script>
+
+<div class:dark={mode === 'dark'} data-rd-mode={mode} class="preview">
+  <EmptyVaultsState onCreateVault={() => (created += 1)} />
+  {#if created > 0}
+    <p class="result">Create clicked {created}×</p>
+  {/if}
+</div>
+
+<style>
+  .preview {
+    position: relative;
+    min-height: 100vh;
+    background: var(--rd-bg);
+  }
+
+  .result {
+    position: absolute;
+    bottom: 16px;
+    left: 16px;
+    margin: 0;
+    font-family: var(--rd-ui);
+    font-size: 13px;
+    color: var(--rd-ink-3);
+  }
+</style>

--- a/packages/ui/src/lib/stories/NewVaultDialogDemo.svelte
+++ b/packages/ui/src/lib/stories/NewVaultDialogDemo.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { Button, NewVaultDialog } from '../index';
+  import type { NewVaultSubmit } from '../index';
+
+  interface Props {
+    mode?: 'light' | 'dark';
+    error?: string | null;
+    busy?: boolean;
+  }
+
+  let { mode = 'light', error = null, busy = false }: Props = $props();
+
+  let open = $state(true);
+  let lastSubmit = $state<NewVaultSubmit | null>(null);
+</script>
+
+<div class:dark={mode === 'dark'} data-rd-mode={mode} class="preview">
+  <div class="story-pad">
+    <Button onclick={() => (open = true)}>Open dialog</Button>
+    {#if lastSubmit}
+      <p class="result">
+        Submitted: name “{lastSubmit.displayName}”, slug “{lastSubmit.slug}”
+      </p>
+    {/if}
+  </div>
+
+  <NewVaultDialog
+    {open}
+    {error}
+    {busy}
+    onsubmit={(value) => {
+      lastSubmit = value;
+      open = false;
+    }}
+    oncancel={() => (open = false)}
+  />
+</div>
+
+<style>
+  .preview {
+    min-height: 100vh;
+    background: var(--rd-bg);
+  }
+
+  .story-pad {
+    padding: 32px;
+  }
+
+  .result {
+    margin-top: 12px;
+    font-family: var(--rd-ui);
+    font-size: 13px;
+    color: var(--rd-ink-3);
+  }
+</style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      github-slugger:
+        specifier: 2.0.0
+        version: 2.0.0
       phosphor-svelte:
         specifier: ^3.1.0
         version: 3.1.0(svelte@5.55.5)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))


### PR DESCRIPTION
First load resolves to the last-opened vault (else the first), with no
default-vault concept, and persists the choice across reloads and cross-vault
navigation. Zero vaults is a calm 'create your first vault' empty state rather
than an error, and deleting the last vault lands there cleanly. The New vault
dialog suggests an editable slug from the display name using the same slugger
the daemon validates with, always submits both display name and slug, and
surfaces server validation (bad slug, collision) inline.