### PR TITLE
Bundle the starter-kit template into the build output and gate the seeder

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && node scripts/bundle-starter-kit.mjs",
     "dev": "tsx src/main.ts",
     "test": "vitest run --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit"

--- a/apps/daemon/scripts/bundle-starter-kit.mjs
+++ b/apps/daemon/scripts/bundle-starter-kit.mjs
@@ -1,0 +1,13 @@
+import { cpSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// `tsc` emits only the compiled JS, but the seeder reads the starter-kit
+// template tree at runtime (resolved relative to the compiled module). Copy the
+// template into dist so a built artifact (e.g. the Docker image that ships dist)
+// finds it, not just `tsx`/dev running against src. Recursive + overwriting, so
+// the kit can grow by dropping files in with no change here.
+cpSync(
+  fileURLToPath(new URL('../src/starter-kit-template', import.meta.url)),
+  fileURLToPath(new URL('../dist/starter-kit-template', import.meta.url)),
+  { recursive: true }
+);

--- a/apps/daemon/src/starter-kit.test.ts
+++ b/apps/daemon/src/starter-kit.test.ts
@@ -1,0 +1,85 @@
+import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { collectTemplateFiles, seedVaultFromStarterKit } from './starter-kit.js';
+
+describe('seedVaultFromStarterKit', () => {
+  let vaultRoot: string;
+
+  beforeEach(async () => {
+    vaultRoot = await mkdtemp(join(tmpdir(), 'kb2-starter-kit-'));
+  });
+
+  afterEach(async () => {
+    await rm(vaultRoot, { force: true, recursive: true });
+  });
+
+  it('copies the whole bundled kit into an empty vault, recursively', async () => {
+    const seeded = await seedVaultFromStarterKit(vaultRoot);
+
+    // Dual assertion: the return value AND the bytes on disk.
+    expect(seeded).toBe(true);
+    await expect(readFile(join(vaultRoot, 'README.md'), 'utf8')).resolves.toContain('Welcome to your vault');
+    await expect(readFile(join(vaultRoot, 'notes', 'getting-started.md'), 'utf8')).resolves.toContain('Getting started');
+  });
+
+  it('is a no-op on a vault that already holds user content', async () => {
+    await writeFile(join(vaultRoot, 'mine.md'), 'my note\n', 'utf8');
+
+    const seeded = await seedVaultFromStarterKit(vaultRoot);
+
+    expect(seeded).toBe(false);
+    // The user's file is untouched and the kit was not copied over it.
+    await expect(readFile(join(vaultRoot, 'mine.md'), 'utf8')).resolves.toBe('my note\n');
+    await expect(access(join(vaultRoot, 'README.md'))).rejects.toBeTruthy();
+  });
+
+  it('still seeds when only the .kb2 identity dir is present (it is not user content)', async () => {
+    await mkdir(join(vaultRoot, '.kb2'), { recursive: true });
+    await writeFile(join(vaultRoot, '.kb2', 'vault.json'), '{}\n', 'utf8');
+
+    const seeded = await seedVaultFromStarterKit(vaultRoot);
+
+    expect(seeded).toBe(true);
+    await expect(readFile(join(vaultRoot, 'README.md'), 'utf8')).resolves.toContain('Welcome to your vault');
+  });
+
+  it('seeds a vault whose root does not exist yet', async () => {
+    const fresh = join(vaultRoot, 'nested', 'new-vault');
+
+    const seeded = await seedVaultFromStarterKit(fresh);
+
+    expect(seeded).toBe(true);
+    await expect(readFile(join(fresh, 'README.md'), 'utf8')).resolves.toContain('Welcome to your vault');
+  });
+
+  it('fails loudly with an actionable message when the bundled template is missing', async () => {
+    // This is the safety net for a build that forgot to bundle the template
+    // into dist: a clear error, not a bare ENOENT.
+    await expect(collectTemplateFiles(join(vaultRoot, 'no-such-template'))).rejects.toThrow(
+      /Starter-kit template not found/
+    );
+  });
+
+  it('surfaces a seeding write failure rather than swallowing it', async () => {
+    // A read-only vault root makes the first template write fail.
+    await chmod(vaultRoot, 0o500);
+    try {
+      // Whether the write path returns a failure result or throws raw, seeding
+      // must surface it, never silently leave a half-seeded vault.
+      await expect(seedVaultFromStarterKit(vaultRoot)).rejects.toThrow();
+    } finally {
+      await chmod(vaultRoot, 0o700);
+    }
+  });
+
+  it('rethrows an unexpected error while checking for existing content', async () => {
+    // A path that is a file, not a directory, makes the content check fail with
+    // ENOTDIR (not ENOENT), which must propagate rather than read as "empty".
+    const notADir = join(vaultRoot, 'a-file');
+    await writeFile(notADir, 'x', 'utf8');
+
+    await expect(seedVaultFromStarterKit(notADir)).rejects.toBeTruthy();
+  });
+});

--- a/apps/daemon/src/starter-kit.ts
+++ b/apps/daemon/src/starter-kit.ts
@@ -76,11 +76,25 @@ interface TemplateFile {
  * and so are not represented, which keeps the seeder driven purely by the files
  * present in the kit.
  */
-async function collectTemplateFiles(templateDir: string): Promise<TemplateFile[]> {
+export async function collectTemplateFiles(templateDir: string): Promise<TemplateFile[]> {
   const files: TemplateFile[] = [];
 
   async function walk(absoluteDir: string, relativeDir: string): Promise<void> {
-    const entries = await readdir(absoluteDir, { withFileTypes: true });
+    let entries;
+    try {
+      entries = await readdir(absoluteDir, { withFileTypes: true });
+    } catch (error) {
+      // A missing template at the root means the build did not bundle
+      // starter-kit-template/ into dist — fail loudly with an actionable
+      // message rather than a bare ENOENT.
+      if (relativeDir.length === 0 && isNodeErrorCode(error, 'ENOENT')) {
+        throw new Error(
+          `Starter-kit template not found at ${absoluteDir}. The build must copy ` +
+            `starter-kit-template/ into dist alongside the compiled module.`
+        );
+      }
+      throw error;
+    }
     for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
       const absolute = join(absoluteDir, entry.name);
       const relative = relativeDir.length > 0 ? `${relativeDir}/${entry.name}` : entry.name;

--- a/apps/daemon/vitest.config.ts
+++ b/apps/daemon/vitest.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text'],
-      include: ['src/app.ts', 'src/request-helpers.ts', 'src/ui-static.ts', 'src/vault-registry.ts'],
+      include: ['src/app.ts', 'src/request-helpers.ts', 'src/starter-kit.ts', 'src/ui-static.ts', 'src/vault-registry.ts'],
       thresholds: {
         lines: 90,
         perFile: true


### PR DESCRIPTION
tsc emits only compiled JS, so the starter-kit template the seeder reads at
runtime (resolved relative to the compiled module) was absent from a built
artifact — and the Docker image ships dist — which would make first boot and
vault creation throw. The build now copies the template into dist, the seeder
fails loudly with an actionable message if it is ever missing, and starter-kit.ts
joins the daemon coverage gate with direct real-fs tests.