### PR TITLE
Make the files rail derive from the URL and respect each vault's identity

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { afterNavigate, goto } from '$app/navigation';
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
   import {
     createDemoDocumentProvider,
     isDemoDocumentProviderOpenError,
@@ -120,16 +121,26 @@
   let persistRecoveredVisible = $state(false);
   let docDeleted = $state(false);
   let notFoundPath = $state<string | null>(null);
-  let documentPath = $state('');
-  // The vaults the daemon serves (id = stable slug, displayName = label),
-  // and the active vault's slug — the URL's first segment. The active id
-  // keys every data call and the collaborative socket.
+  // The vaults the daemon serves (id = stable slug, displayName = label).
+  // The active id keys every data call and the collaborative socket.
   let knownVaults = $state<VaultSummary[]>([]);
-  let activeVaultId = $state<string>('');
   // Each vault's file tree, fetched lazily over the scoped tree route and
   // cached by vault id. The rail groups by vault, so it needs all trees;
   // the active vault's tree also drives the canvas + wikilink resolution.
   let vaultTrees = $state<Record<string, LocalTreeNode[]>>({});
+
+  // The URL is the single source of truth for the active vault and the
+  // open document. Mirroring KB-1's derive-from-route pattern, both are
+  // DERIVED from `page.url` via the catch-all route parser, never
+  // imperatively assigned. Every navigation (a tree pick, a vault switch,
+  // a delete that lands in a survivor, a bootstrap redirect) happens by
+  // `goto`-ing the URL; these values then follow. A root or unknown-vault
+  // URL yields a null vaultId, which bootstrap normalizes to a real
+  // vault. Until that redirect lands the derived id is empty (zero-vault
+  // empty state, or the pre-redirect tick).
+  const route = $derived(parseVaultRoute(page.url.pathname));
+  const activeVaultId = $derived<string>(route.vaultId ?? '');
+  const documentPath = $derived<string>(route.vaultId ? route.path : '');
 
   // The active vault's display name (header + breadcrumb root) and its
   // tree (the canvas + folder resolution operate on the active vault).
@@ -210,10 +221,14 @@
     new Set(favorites.filter((e) => e.kind === 'folder' && e.vaultId === vaultId).map((e) => e.path)),
   );
   // Vaults default open: the persisted shape is a collapse deny-list, so
-  // the expanded set is its complement over the one local vault.
+  // the expanded set is its complement over every known vault. Deriving it
+  // across all vaults (not just the active one) keeps each vault's
+  // expansion independent, so opening one never collapses another.
   const expandedVaultIds = $derived.by<Set<string>>(() => {
     const out = new Set<string>();
-    if (!collapsedVaultIds.has(vaultId)) out.add(expansionKey('vault', vaultId));
+    for (const v of knownVaults) {
+      if (!collapsedVaultIds.has(v.id)) out.add(expansionKey('vault', v.id));
+    }
     return out;
   });
   let externalMergeTimer: ReturnType<typeof setTimeout> | undefined;
@@ -294,6 +309,18 @@
   // is a slug (no colon); the path is whatever follows the second colon.
   function folderKeyParts(key: string): { vaultId: string; path: string } {
     const withoutKind = key.startsWith('folder:') ? key.slice('folder:'.length) : key;
+    const colon = withoutKind.indexOf(':');
+    if (colon === -1) return { vaultId: activeVaultId, path: withoutKind };
+    return {
+      vaultId: withoutKind.slice(0, colon),
+      path: withoutKind.slice(colon + 1),
+    };
+  }
+
+  // Pull `{ vaultId, path }` back out of an opaque file-row id
+  // (`note:<vaultId>:<path>`) — the file twin of folderKeyParts.
+  function noteKeyParts(key: string): { vaultId: string; path: string } {
+    const withoutKind = key.startsWith('note:') ? key.slice('note:'.length) : key;
     const colon = withoutKind.indexOf(':');
     if (colon === -1) return { vaultId: activeVaultId, path: withoutKind };
     return {
@@ -438,8 +465,9 @@
   function handleSessionEvent(event: DocumentSessionEvent): void {
     if (event.kind === 'doc-moved') {
       const nextPath = event.toPath ?? event.path;
-      documentPath = nextPath;
       docDeleted = false;
+      // Navigate to the moved path; the derived document path follows and
+      // the provider effect rebinds onto the new location.
       void goto(vaultRoute(activeVaultId, nextPath), { replaceState: true, noScroll: true, keepFocus: true });
       void refreshTree();
       return;
@@ -535,39 +563,33 @@
     provider = nextProvider;
   }
 
+  // Open a document by navigating to its URL. The derived document path
+  // follows, and the provider effect rebinds the Yjs provider (or tears
+  // it down for a folder/root). No state is mutated here.
   async function openDocument(path: string): Promise<void> {
     if (path === documentPath && notFoundPath !== path) return;
-    rebindDocument(path);
     await goto(vaultRoute(activeVaultId, path), { noScroll: true, keepFocus: true });
   }
 
-  // Switch the active vault: navigate to its root. The afterNavigate hook
-  // rebinds state (active id, document, tree) off the new URL. Remember it
-  // as the last-opened so the next cold load reopens here.
+  // Switch the active vault: navigate to its root. The derived active id
+  // follows the new URL; the active-vault effect remembers it as the
+  // last-opened and loads its tree if uncached.
   async function openVault(vaultId: string): Promise<void> {
     if (vaultId === activeVaultId) return;
-    appState.setLastOpenedVaultId(vaultId);
     await goto(vaultRoute(vaultId, ''), { noScroll: true });
   }
 
-  // A file row reports only its path; the rail shows every vault's tree,
-  // so resolve which vault owns the path before routing. The active vault
-  // wins ties (the common case); otherwise the first vault whose tree
-  // carries the path. Routes there, switching the active vault if needed.
-  function openFileFromRow(path: string): void {
-    if (findNode(tree, path)) {
-      void openDocument(path);
+  // The file row hands its opaque id (`note:<vaultId>:<path>`), the same
+  // vault-bearing identity folder rows use. Decode the owning vault and
+  // route there, switching the active vault when it differs — so a note
+  // never opens in the wrong vault just because another vault is active.
+  // Mirrors openFolder.
+  function openFileFromRow(key: string): void {
+    const { vaultId: keyVaultId, path } = noteKeyParts(key);
+    if (keyVaultId !== activeVaultId) {
+      void goto(vaultRoute(keyVaultId, path), { noScroll: true, keepFocus: true });
       return;
     }
-    const owner = knownVaults.find(
-      (v) => v.id !== activeVaultId && findNode(vaultTrees[v.id] ?? [], path),
-    );
-    if (owner) {
-      void goto(vaultRoute(owner.id, path), { noScroll: true, keepFocus: true });
-      return;
-    }
-    // Not found in any loaded tree (e.g. a brand-new note) — open it in
-    // the active vault.
     void openDocument(path);
   }
 
@@ -595,25 +617,16 @@
     void openDocument(targetPath);
   }
 
-  function rebindDocument(path: string): void {
-    documentPath = path;
-    // A folder (or the vault root) renders the folder canvas, which
-    // needs no Yjs document. Tear down any open provider and skip
-    // opening a new one — mirrors KB-1's selector picking FolderCanvas
-    // over DocumentCanvas. The folder/file split is decided against the
-    // live tree; a path the tree doesn't carry falls through as a
-    // document so deep-linked notes still open.
-    const node = findNode(tree, path);
-    if (path === '' || node?.kind === 'folder') {
-      provider?.destroy();
-      provider = null;
-      providerSynced = false;
-      status = 'connecting';
-      notFoundPath = null;
-      docDeleted = false;
-      return;
-    }
-    openProvider(path);
+  // Tear down any open provider and reset the document-canvas state. Used
+  // when the derived path resolves to a folder (or vault root), which
+  // renders the folder canvas and needs no Yjs document.
+  function teardownProvider(): void {
+    provider?.destroy();
+    provider = null;
+    providerSynced = false;
+    status = 'connecting';
+    notFoundPath = null;
+    docDeleted = false;
   }
 
   function toggleFolder(key: string): void {
@@ -995,21 +1008,18 @@
       },
       // Drop the vault from the list. If it was the active one, land in a
       // survivor — or, when it was the LAST vault, in the empty state
-      // (zero vaults is valid). Deleting the active vault also clears its
-      // last-opened so a stale slug isn't reopened next cold load.
+      // (zero vaults is valid). Both land by NAVIGATING; the derived
+      // active vault + document follow, and the provider effect tears
+      // down the editor. Deleting the last vault also clears last-opened
+      // so a stale slug isn't reopened next cold load.
       afterSuccess: async () => {
         await refreshVaults();
         if (targetVaultId === activeVaultId) {
           const survivor = knownVaults[0];
           if (survivor) {
-            await openVault(survivor.id);
+            await goto(vaultRoute(survivor.id, ''), { noScroll: true });
           } else {
-            // No vaults left — fall to the empty state cleanly.
-            activeVaultId = '';
-            documentPath = '';
-            provider?.destroy();
-            provider = null;
-            providerSynced = false;
+            // No vaults left — navigate to the root empty state cleanly.
             appState.setLastOpenedVaultId(null);
             await goto('/', { replaceState: true, noScroll: true });
           }
@@ -1137,14 +1147,6 @@
     return path.split('/').filter(Boolean).at(-1) ?? path;
   }
 
-
-  // Parse the route into `{ vaultId, path }`. A root URL (`/`) yields a
-  // null vaultId, signalling "resolve a target on bootstrap" (last-opened
-  // else first vault — there is no default vault).
-  function routeFromUrl(url: URL): { vaultId: string | null; path: string } {
-    return parseVaultRoute(url.pathname);
-  }
-
   // Mirror the store's persisted choice so the toggle icon reflects the
   // live preference. The root layout owns applying the mode to the DOM.
   $effect(() => {
@@ -1178,13 +1180,55 @@
   // into the expanded set so a deep-linked note's row is visible. The
   // vault un-collapse keeps a refresh-into-a-collapsed-vault honest.
   // `untrack` keeps the store writes from re-triggering this effect.
+  // Keyed on the derived path + vault, so it tracks the URL.
   $effect(() => {
     const path = documentPath;
     const id = vaultId;
+    if (!id) return;
     untrack(() => {
       appState.setVaultCollapsed(id, false);
       const keys = ancestorKeysForPath(path, id);
       if (keys.length > 0) appState.expandFolders(keys);
+    });
+  });
+
+  // URL → active vault. Whenever the derived active vault changes (a
+  // vault-header click, a cross-vault file/folder open, a bootstrap
+  // redirect, a delete landing in a survivor), remember it as the
+  // last-opened so the next cold load reopens here, and load its tree if
+  // it isn't cached yet. Replaces the old `afterNavigate` vault branch;
+  // it fires for EVERY active-vault change, including cross-vault opens
+  // that never went through `openVault`.
+  $effect(() => {
+    const id = activeVaultId;
+    if (!id) return;
+    untrack(() => {
+      appState.setLastOpenedVaultId(id);
+      if (!vaultTrees[id]) void loadVaultTree(id);
+    });
+  });
+
+  // URL → Yjs provider. The derived document path owns the provider
+  // lifecycle: a file opens a provider; a folder (or the vault root)
+  // tears it down and renders the folder canvas — mirroring KB-1's
+  // selector picking FolderCanvas over DocumentCanvas. Keyed on the
+  // active vault + path so it reacts to navigation, NOT to tree
+  // refreshes (which would needlessly reopen the live provider); the
+  // folder/file split is read against the live tree via `untrack`. A
+  // path the tree doesn't carry yet falls through as a document so
+  // deep-linked notes still open; the folder-canvas teardown effect
+  // below corrects a stray provider once the tree resolves it to a
+  // folder.
+  $effect(() => {
+    const id = activeVaultId;
+    const path = documentPath;
+    if (!id) return;
+    untrack(() => {
+      if (path === '' || findNode(tree, path)?.kind === 'folder') {
+        teardownProvider();
+        return;
+      }
+      openProvider(path);
     });
   });
 
@@ -1201,10 +1245,13 @@
     });
   });
 
-  // First-load bootstrap. Load the vault list, resolve the active vault
-  // from the URL (or fall back to the last-opened vault, else the first in
-  // the list — there is NO default vault), normalize the URL to
-  // `/<vaultId>/<path>`, then open the document + load the rail's trees.
+  // First-load bootstrap. Load the vault list, then — when the URL is the
+  // root or an unknown vault — RESOLVE a target (last-opened vault if it
+  // still exists, else the first in the list; there is NO default vault)
+  // and REDIRECT to `/<vaultId>/<path>` via `goto`. The derived active
+  // vault + document follow the corrected URL; the active-vault and
+  // provider effects then persist last-opened, load trees, and bind the
+  // document. Bootstrap mutates no routing state — it only nudges the URL.
   // Zero vaults is a valid state: nothing to open, the empty state renders.
   async function bootstrap(): Promise<void> {
     const loaded = await refreshVaults();
@@ -1212,62 +1259,36 @@
       // No vaults to serve — a fresh daemon or every vault deleted. This
       // is normal, not an error; the empty "create your first vault" state
       // renders. Forget any stale last-opened so we don't reopen a gone
-      // vault when one is created.
-      activeVaultId = '';
+      // vault when one is created. The URL stays at the root, which the
+      // derived values read as the empty state.
       appState.setLastOpenedVaultId(null);
       return;
     }
 
-    const route = routeFromUrl(new URL(window.location.href));
-    const known = route.vaultId && loaded.some((v) => v.id === route.vaultId);
-    // Fall back to the last-opened vault if it still exists, else the
-    // first in the list. No "default vault" — just the remembered choice.
+    const current = parseVaultRoute(window.location.pathname);
+    const known = current.vaultId && loaded.some((v) => v.id === current.vaultId);
+    if (known) {
+      // The URL already names a real vault; the derived values already
+      // point at it. Just load the rail's trees (the active vault's tree
+      // load is also covered by the active-vault effect).
+      void loadAllTrees();
+      return;
+    }
+
+    // Root or unknown vault — resolve the fallback and redirect. The
+    // derived active vault + document follow the corrected URL.
     const remembered = appState.getState().lastOpenedVaultId;
     const fallbackId =
       remembered && loaded.some((v) => v.id === remembered)
         ? remembered
         : loaded[0].id;
-    const targetVaultId = known ? (route.vaultId as string) : fallbackId;
-    const targetPath = known ? route.path : '';
-
-    activeVaultId = targetVaultId;
-    documentPath = targetPath;
-    appState.setLastOpenedVaultId(targetVaultId);
-
-    // Normalize the URL when we redirected (root, or an unknown vault).
-    if (!known) {
-      await goto(vaultRoute(targetVaultId, targetPath), {
-        replaceState: true,
-        noScroll: true,
-        keepFocus: true,
-      });
-    }
-
-    rebindDocument(targetPath);
+    await goto(vaultRoute(fallbackId, ''), {
+      replaceState: true,
+      noScroll: true,
+      keepFocus: true,
+    });
     void loadAllTrees();
   }
-
-  afterNavigate((navigation) => {
-    if (!mounted || !navigation.to?.url) return;
-    const route = routeFromUrl(navigation.to.url);
-    // A root URL (no vault segment) means "resolve a target on bootstrap"
-    // or, with zero vaults, the empty state. Either way there's nothing to
-    // rebind off the URL here, so ignore it.
-    if (!route.vaultId) return;
-
-    const vaultChanged = route.vaultId !== activeVaultId;
-    if (vaultChanged) {
-      activeVaultId = route.vaultId;
-      // Remember the now-active vault (covers cross-vault navigation that
-      // doesn't go through `openVault`, e.g. opening a file in another
-      // vault's group). The next cold load reopens here.
-      appState.setLastOpenedVaultId(route.vaultId);
-      // Ensure the now-active vault's tree is loaded for the canvas.
-      if (!vaultTrees[route.vaultId]) void loadVaultTree(route.vaultId);
-    }
-    if (route.path === documentPath && !vaultChanged) return;
-    rebindDocument(route.path);
-  });
 
   onMount(() => {
     mounted = true;

--- a/apps/web/src/test/local-editor-route.test.ts
+++ b/apps/web/src/test/local-editor-route.test.ts
@@ -2,23 +2,36 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/sve
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as Y from 'yjs';
 import AppStateHarness from './AppStateHarness.svelte';
+import { setPageUrl } from './page-state.svelte';
 
 const mocks = vi.hoisted(() => ({
   goto: vi.fn(),
-  afterNavigateCallbacks: [] as Array<(navigation: { to: { url: URL } | null; type: string }) => void>,
   destroyProvider: vi.fn(),
   providers: [] as Array<{ path: string; doc: Y.Doc; text: Y.Text }>,
 }));
 
-vi.mock('$app/navigation', () => ({
-  goto: mocks.goto,
-  afterNavigate: vi.fn((callback) => {
-    mocks.afterNavigateCallbacks.push(callback);
-    return () => {
-      mocks.afterNavigateCallbacks = mocks.afterNavigateCallbacks.filter((candidate) => candidate !== callback);
-    };
-  }),
-}));
+// The route derives the active vault + open document from the URL, so the
+// `goto` mock NAVIGATES the reactive `page` mock (just like real SvelteKit:
+// a `goto` lands a new URL, the page's `$derived`s recompute). It still
+// records the call so navigation assertions hold. The helper is imported
+// inside the factory (not the hoisted top scope) so the mock stays valid.
+vi.mock('$app/navigation', async () => {
+  const { setPageUrl: navigate } = await import('./page-state.svelte');
+  return {
+    goto: vi.fn((url: string, opts?: unknown) => {
+      mocks.goto(url, opts);
+      navigate(url);
+      return Promise.resolve();
+    }),
+  };
+});
+
+// Reactive `page` stand-in (see page-state.svelte.ts) so `page.url` is the
+// single source of truth for the route under test.
+vi.mock('$app/state', async () => {
+  const { page } = await import('./page-state.svelte');
+  return { page };
+});
 
 vi.mock('@kb-2/editor', async () => {
   const { default: PlaintextEditor } = await import('./FakePlaintextEditor.svelte');
@@ -61,7 +74,6 @@ vi.mock('$lib/yjs/demo-document-provider', async () => {
 describe('local editor route', () => {
   beforeEach(() => {
     mocks.goto.mockReset();
-    mocks.afterNavigateCallbacks = [];
     mocks.destroyProvider.mockReset();
     mocks.providers = [];
     // The harness builds the app-state store against `localStorage`, which
@@ -72,7 +84,10 @@ describe('local editor route', () => {
     if (typeof window.localStorage?.clear === 'function') {
       window.localStorage.clear();
     }
-    // The route is now vault-segmented: `/<vaultId>/<path>`.
+    // The route is now vault-segmented: `/<vaultId>/<path>`. The page mock
+    // is the source of truth the route derives from; keep `window.history`
+    // in sync too so bootstrap's `window.location.pathname` read agrees.
+    setPageUrl('/demo-vault/hello-world.md');
     window.history.pushState(null, '', '/demo-vault/hello-world.md');
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
@@ -148,6 +163,7 @@ describe('local editor route', () => {
   });
 
   it('renders an in-shell not-found state for missing document navigation without creating it', async () => {
+    setPageUrl('/demo-vault/projects/missing.md');
     window.history.pushState(null, '', '/demo-vault/projects/missing.md');
 
     render(AppStateHarness);
@@ -211,13 +227,13 @@ function json(body: unknown, status = 200): Response {
   });
 }
 
+// History navigation (back/forward, deep-link) lands a new URL. The route
+// derives everything from `page.url`, so point the page mock at the new
+// pathname — the component's `$derived`s recompute exactly as they would
+// under a real popstate. Keep `window.history` in sync for any direct
+// `window.location` reads.
 async function simulateNavigation(pathname: string): Promise<void> {
+  setPageUrl(pathname);
   window.history.pushState(null, '', pathname);
-  for (const callback of mocks.afterNavigateCallbacks) {
-    callback({
-      to: { url: new URL(window.location.href) },
-      type: 'popstate',
-    });
-  }
   await Promise.resolve();
 }

--- a/apps/web/src/test/page-state.svelte.ts
+++ b/apps/web/src/test/page-state.svelte.ts
@@ -1,0 +1,21 @@
+// A reactive stand-in for SvelteKit's `$app/state` `page` store, scoped to
+// the route tests. The route derives the active vault + open document from
+// `page.url`, so the tests need a `page` whose `url` updates on every
+// navigation (a `goto`, a history pop) and re-runs the component's
+// `$derived`s — exactly what the real SvelteKit runtime does. A plain
+// object wouldn't be reactive; this `$state`-backed module is, so flipping
+// the URL drives the page the same way a real navigation would.
+let url = $state(new URL('http://localhost/'));
+
+export const page = {
+  get url() {
+    return url;
+  },
+};
+
+// Point the mock `page` at a new pathname, mirroring a navigation landing.
+// The test's `goto` mock and history-navigation helper both call this so
+// the URL is the single source of truth in tests too.
+export function setPageUrl(pathname: string): void {
+  url = new URL(pathname, 'http://localhost/');
+}

--- a/packages/ui/src/lib/local-editor/FileNode.stories.ts
+++ b/packages/ui/src/lib/local-editor/FileNode.stories.ts
@@ -6,6 +6,7 @@ const meta = {
   component: FileNode,
   args: {
     node: { kind: 'file', path: 'projects/active/editor-shell.md', name: 'editor-shell.md' },
+    vaultId: 'demo-vault',
     depth: 0,
     activePath: 'projects/active/editor-shell.md'
   }

--- a/packages/ui/src/lib/local-editor/FileNode.svelte
+++ b/packages/ui/src/lib/local-editor/FileNode.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
   import Icon from '../primitives/Icon.svelte';
   import ContextMenu from '../menus/ContextMenu.svelte';
+  import { noteKey } from './expansion';
   import type { LocalFileNode, LocalTreeAction } from './types';
   import type { MenuItem } from '../menus/ContextMenu.svelte';
 
   interface Props {
     node: LocalFileNode;
+    /** Vault id the row belongs to. Used to mint the opaque row id
+        (`note:<vaultId>:<path>`) the host decodes to route to the owning
+        vault — never the active one. Mirrors FolderNode. */
+    vaultId: string;
     /** Nesting depth — drives indentation so a file aligns under its
         folder's label rather than its caret. */
     depth?: number;
@@ -16,12 +21,17 @@
         right-click isn't available). When false (desktop), it only appears
         on row hover / keyboard focus. */
     kebabAlwaysVisible?: boolean;
-    onOpen?: (path: string) => void;
+    /** Open this file. Called with the opaque row id
+        (`note:<vaultId>:<path>`) — the same vault-bearing identity folder
+        rows use — so the host routes to the owning vault, not the active
+        one. */
+    onOpen?: (key: string) => void;
     onAction?: (action: LocalTreeAction) => void;
   }
 
   let {
     node,
+    vaultId,
     depth = 0,
     activePath = '',
     favoritedNotePaths,
@@ -77,7 +87,7 @@
       type="button"
       class="activate"
       aria-current={active ? 'page' : undefined}
-      onclick={() => onOpen?.(node.path)}
+      onclick={() => onOpen?.(noteKey(vaultId, node.path))}
     >
       <span class="spacer" aria-hidden="true"></span>
       <span class="file-icon" aria-hidden="true">

--- a/packages/ui/src/lib/local-editor/FilesPanel.svelte
+++ b/packages/ui/src/lib/local-editor/FilesPanel.svelte
@@ -53,7 +53,9 @@
     kebabAlwaysVisible?: boolean;
     onToggleFolder?: (key: string) => void;
     onToggleVault?: (key: string) => void;
-    onOpenFile?: (path: string) => void;
+    /** Open a file row — called with the opaque row id
+        (`note:<vaultId>:<path>`). */
+    onOpenFile?: (key: string) => void;
     /** Navigate to a folder (the three-state row click's open branch). */
     onOpenFolder?: (key: string) => void;
     /** Navigate to the vault root. */

--- a/packages/ui/src/lib/local-editor/FolderNode.svelte
+++ b/packages/ui/src/lib/local-editor/FolderNode.svelte
@@ -196,6 +196,7 @@
         {:else}
           <FileNode
             node={child}
+            {vaultId}
             depth={depth + 1}
             {activePath}
             {favoritedNotePaths}

--- a/packages/ui/src/lib/local-editor/LocalEditorMobileShell.svelte
+++ b/packages/ui/src/lib/local-editor/LocalEditorMobileShell.svelte
@@ -68,7 +68,9 @@
     onToggleColorMode?: () => void;
     onToggleFolder?: (key: string) => void;
     onToggleVault?: (key: string) => void;
-    onOpenFile?: (path: string) => void;
+    /** Open a file row — called with the opaque row id
+        (`note:<vaultId>:<path>`). */
+    onOpenFile?: (key: string) => void;
     onOpenFolder?: (key: string) => void;
     onOpenVault?: (key: string) => void;
     onTreeAction?: (action: LocalTreeAction) => void;
@@ -139,8 +141,8 @@
   //   - Folder row click         → routes to the folder canvas, but the
   //                                user is still drilling toward a file
   //   - Primary rail switch      → mode swap inside the flyout
-  const onOpenFileRow = (path: string) => {
-    onOpenFile?.(path);
+  const onOpenFileRow = (key: string) => {
+    onOpenFile?.(key);
     navOpen = false;
   };
   const onOpenFolderRow = (key: string) => {

--- a/packages/ui/src/lib/local-editor/LocalEditorShell.svelte
+++ b/packages/ui/src/lib/local-editor/LocalEditorShell.svelte
@@ -90,7 +90,9 @@
     onToggleRailCollapsed?: () => void;
     onToggleFolder?: (key: string) => void;
     onToggleVault?: (key: string) => void;
-    onOpenFile?: (path: string) => void;
+    /** Open a file row — called with the opaque row id
+        (`note:<vaultId>:<path>`). */
+    onOpenFile?: (key: string) => void;
     /** Navigate to a folder (three-state row click's open branch). */
     onOpenFolder?: (key: string) => void;
     /** Navigate to the vault root. */

--- a/packages/ui/src/lib/local-editor/VaultGroup.svelte
+++ b/packages/ui/src/lib/local-editor/VaultGroup.svelte
@@ -44,7 +44,9 @@
     onToggleFolder?: (key: string) => void;
     /** Toggle this vault group's expansion. Called with the vault key. */
     onToggleVault?: (key: string) => void;
-    onOpenFile?: (path: string) => void;
+    /** Open a file row. Called with the opaque row id
+        (`note:<vaultId>:<path>`) so the host routes to the owning vault. */
+    onOpenFile?: (key: string) => void;
     /** Navigate to the vault root. Called with the vault key on a header
         click, alongside the expansion toggle. When unset, the header
         click only toggles. */
@@ -164,6 +166,7 @@
         {:else}
           <FileNode
             {node}
+            {vaultId}
             {activePath}
             {favoritedNotePaths}
             {kebabAlwaysVisible}

--- a/packages/ui/src/lib/local-editor/expansion.ts
+++ b/packages/ui/src/lib/local-editor/expansion.ts
@@ -7,6 +7,7 @@
  *
  *   - `vault:<vaultId>`         — a vault group row
  *   - `folder:<vaultId>:<path>` — a folder row inside that vault
+ *   - `note:<vaultId>:<path>`   — a file row inside that vault
  *
  * These are pure string functions — no fetch, no storage. The shell
  * owns the expanded/collapsed sets and persistence; components only
@@ -21,4 +22,11 @@ export function vaultKey(vaultId: string): string {
 /** Mint the opaque expansion key for a folder row. */
 export function folderKey(vaultId: string, path: string): string {
   return `folder:${vaultId}:${path}`;
+}
+
+/** Mint the opaque row id for a file row — the file twin of
+    {@link folderKey}, so a file row carries its owning vault the same way
+    a folder row does. */
+export function noteKey(vaultId: string, path: string): string {
+  return `note:${vaultId}:${path}`;
 }


### PR DESCRIPTION
Realigns the multi-vault web to KB-1's URL-driven pattern, from live testing:
- The active vault and open document derive from the route (parseVaultRoute
  over the $app/state page), replacing the imperative state and afterNavigate.
  The Yjs provider, last-opened persistence, and tree loading run in effects
  keyed on the derived values; bootstrap and vault deletion act by navigating.
- File rows carry their owning vault id (note:<vaultId>:<path>), symmetric with
  folder rows, so a note opens in its own vault rather than whichever is active.
- The expanded-vault set derives over every vault, so opening one no longer
  collapses another.