### PR TITLE
Add typed relay transport controls

### DIFF
--- a/docs/plans/fc-1518-rpc-library-fit.md
+++ b/docs/plans/fc-1518-rpc-library-fit.md
@@ -1,0 +1,116 @@
+# FC-1518 RPC Library Fit Check
+
+Status: Slice 1 fit check, authored 2026-06-25 PT.
+
+## Question
+
+Before hand-writing the typed relay transport package, should KB-1 use an
+off-the-shelf RPC library for unary calls, stream framing, cancellation,
+timeouts, and errors?
+
+## Relay Requirements
+
+The library must fit this shape without making the architecture fight it:
+
+- Cloudflare Durable Object, browser, and daemon compatibility.
+- Daemon dials out to the relay; cloud does not connect directly to a daemon
+  listener.
+- Unary request/response with correlation ids, deadlines, cancellation, typed
+  errors, and bounded pending work.
+- Bidirectional stream frames for document sync and future long-lived flows.
+- Daemon-origin events through `OrgChannel`.
+- Binary or opaque payload support for Yjs/document bytes.
+- A clean capability boundary: the browser sends cloud intent, while
+  `OrgChannel` alone injects actor context and daemon-bound authority.
+
+## Candidates
+
+### Connect / gRPC-Style RPC
+
+Useful shapes to borrow:
+
+- type-safe service contracts;
+- unary calls;
+- deadlines, cancellation, metadata, status/error vocabulary;
+- per-RPC ordering semantics from the gRPC model.
+
+Why not adopt wholesale for this slice:
+
+- Connect is explicitly regular HTTP under the hood, with gRPC/gRPC-web/Connect
+  protocols and code-generated service clients.
+- gRPC's full model has bidirectional streams and deadlines, but browser
+  gRPC-Web does not support client-side or bidirectional streaming.
+- The relay is not a normal browser-to-server RPC endpoint. The daemon dials
+  outward to `OrgChannel`, and `OrgChannel` must perform admission, actor
+  injection, hosted lifecycle policy, and fanout.
+
+Sources:
+
+- https://github.com/connectrpc/connect-es
+- https://grpc.io/docs/what-is-grpc/core-concepts/
+- https://github.com/grpc/grpc-web
+
+### tRPC WebSockets
+
+Useful shapes to borrow:
+
+- JSON-RPC-like ids and response envelopes;
+- WebSocket subscriptions;
+- explicit `subscription.stop` cancellation shape;
+- reconnect/tracked-event ideas for subscriptions.
+
+Why not adopt wholesale for this slice:
+
+- tRPC is an application RPC framework. It wants to own routers, procedures,
+  clients, input/output serialization, and subscription semantics.
+- Our shared package should be a low-level relay frame protocol that both
+  daemon and cloud can compose. It must not define product procedures or make
+  browser procedure names equivalent to daemon authority.
+- tRPC subscriptions are server-to-client event streams, not the full
+  bidirectional stream/data/cancel/event relay we need for daemon-bound document
+  sync and daemon-origin events.
+
+Sources:
+
+- https://trpc.io/docs/server/subscriptions
+- https://trpc.io/docs/server/websockets
+
+### JSON-RPC 2.0 Shape
+
+Useful shapes to borrow:
+
+- transport-agnostic request/response ids;
+- notifications;
+- `result` versus `error` response separation;
+- standard error object shape;
+- batch/concurrent processing precedent.
+
+Why not adopt as the whole protocol:
+
+- JSON-RPC does not define stream open/data/close frames.
+- It does not define backpressure, binary payload handling, per-stream limits,
+  or hosted lifecycle semantics.
+- Notifications are not confirmable, which is a bad default for many
+  daemon-bound operations.
+
+Source:
+
+- https://www.jsonrpc.org/specification
+
+## Decision
+
+Do not adopt a full RPC framework for Slice 1. Evolve
+`@kb-2/tunnel-protocol` into a small shared relay frame package and borrow the
+boring proven parts:
+
+- JSON-RPC-like correlation ids and error separation for unary calls.
+- gRPC-inspired deadlines, cancellation, and per-stream ordering semantics.
+- Explicit `stream.open`, `stream.data`, and `stream.close` frames for
+  bidirectional flows.
+- Explicit event frames for daemon-origin fanout.
+- Closed typed error codes and named limits.
+
+This keeps the package small and testable while avoiding a square-peg framework
+fit. Revisit this decision if a later slice finds a library that can provide
+the transport core without taking over product capability routing.
+

--- a/docs/plans/fc-1518-rpc-library-fit.md
+++ b/docs/plans/fc-1518-rpc-library-fit.md
@@ -113,4 +113,3 @@ boring proven parts:
 This keeps the package small and testable while avoiding a square-peg framework
 fit. Revisit this decision if a later slice finds a library that can provide
 the transport core without taking over product capability routing.
-

--- a/packages/doc-session/src/websocket.ts
+++ b/packages/doc-session/src/websocket.ts
@@ -42,6 +42,7 @@ export async function bindYjsWebSocket(
   let cleanupStarted = false;
   let sessionReady = false;
   const pendingMessages: unknown[] = [];
+  let syncedMessageSent = false;
   let resolveClosed!: () => void;
   let rejectClosed!: (error: unknown) => void;
   const closed = new Promise<void>((resolve, reject) => {
@@ -87,6 +88,14 @@ export async function bindYjsWebSocket(
     processSyncMessage(data);
   };
 
+  const sendSyncedOnce = () => {
+    if (syncedMessageSent) {
+      return;
+    }
+    syncedMessageSent = true;
+    sendBytes(socket, encodeSyncedMessage());
+  };
+
   const processSyncMessage = (data: unknown) => {
     try {
       const message = toUint8Array(data);
@@ -125,12 +134,16 @@ export async function bindYjsWebSocket(
       }
 
       encoding.writeVarUint(encoder, MESSAGE_SYNC);
-      if (!processYjsSyncPayload(session, socket, decoder, encoder)) {
+      const syncResult = processYjsSyncPayload(session, socket, decoder, encoder);
+      if (syncResult === 'closed') {
         return;
       }
 
       if (encoding.length(encoder) > 1) {
         sendEncoded(socket, encoder);
+      }
+      if (syncResult === 'answered-sync-step1') {
+        sendSyncedOnce();
       }
     } catch {
       socket.close(1003, 'Invalid Yjs sync message');
@@ -176,7 +189,6 @@ export async function bindYjsWebSocket(
   sendSync(socket, (encoder) => {
     syncProtocol.writeSyncStep1(encoder, session.ydoc);
   });
-  sendBytes(socket, encodeSyncedMessage());
 
   return { closed };
 }
@@ -200,27 +212,29 @@ function sendBytes(socket: YjsWebSocketLike, bytes: Uint8Array): void {
   socket.send(bytes);
 }
 
+type SyncMessageResult = 'answered-sync-step1' | 'processed' | 'closed';
+
 function processYjsSyncPayload(
   session: OneFileDocumentSession,
   socket: YjsWebSocketLike,
   decoder: decoding.Decoder,
   encoder: encoding.Encoder
-): boolean {
+): SyncMessageResult {
   const syncMessageType = decoding.readVarUint(decoder);
   if (syncMessageType === syncProtocol.messageYjsSyncStep1) {
     const remoteStateVector = decoding.readVarUint8Array(decoder);
     syncProtocol.writeSyncStep2(encoder, session.ydoc, remoteStateVector);
-    return true;
+    return 'answered-sync-step1';
   }
 
   if (syncMessageType === syncProtocol.messageYjsSyncStep2 || syncMessageType === syncProtocol.messageYjsUpdate) {
     const update = decoding.readVarUint8Array(decoder);
     if (hasUnsafeIndependentUpdate(session, update)) {
       closeUnsafeDivergence(socket);
-      return false;
+      return 'closed';
     }
     Y.applyUpdate(session.ydoc, update, socket);
-    return true;
+    return 'processed';
   }
 
   throw new Error('Unknown Yjs sync message type');

--- a/packages/tunnel-client/src/heartbeat.test.ts
+++ b/packages/tunnel-client/src/heartbeat.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { encodeTunnelMessage } from '@kb-2/tunnel-protocol';
+import { TUNNEL_FEATURES, encodeTunnelMessage } from '@kb-2/tunnel-protocol';
 
 class MockWebSocket extends EventEmitter {
   static readonly OPEN = 1;
@@ -76,6 +76,7 @@ describe('TunnelClient control heartbeat', () => {
       type: 'control.hello',
       version: 2,
       token: 'token-1',
+      features: [TUNNEL_FEATURES.RELAY_FRAMES_V1],
     }));
 
     await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_INTERVAL_MS);

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -1,6 +1,8 @@
 import { EventEmitter } from 'node:events';
 import { gzipSync } from 'node:zlib';
 import {
+  RELAY_ERROR_CODES,
+  RELAY_TRANSPORT_PROTOCOL_VERSION,
   TUNNEL_CLOSE_CODES,
   TUNNEL_PENDING_STREAM_FRAME_LIMIT,
   TUNNEL_WS_FRAME_BYTE_LIMIT,
@@ -8,6 +10,7 @@ import {
 import {
   ChunkedHttpRequestAssembler,
   DialbackBridge,
+  TunnelClient,
   createBackoffDelay,
   materializedResponseBody,
   relayInternalUrl,
@@ -153,6 +156,84 @@ describe('ChunkedHttpRequestAssembler', () => {
     });
     assembler.chunk({ type: 'http.request.chunk', id: 'req-2', sequence: 0, bodyB64: Buffer.from([1]).toString('base64') });
     expect(assembler.end({ type: 'http.request.end', id: 'req-2', chunks: 2 })).toBeUndefined();
+  });
+});
+
+describe('TunnelClient typed relay RPC', () => {
+  it('handles the vault.list capability through the daemon vault API', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe('http://daemon.test/api/vaults');
+      expect(init?.method).toBe('GET');
+      return Response.json({ ok: true, vaults: [{ id: 'ledger', displayName: 'Ledger' }] });
+    });
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+
+    const response = await (
+      client as unknown as {
+        handleRelayRpcRequest(request: {
+          type: 'rpc.request';
+          version: typeof RELAY_TRANSPORT_PROTOCOL_VERSION;
+          id: string;
+          capability: string;
+        }): Promise<unknown>;
+      }
+    ).handleRelayRpcRequest({
+      type: 'rpc.request',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-1',
+      capability: 'vault.list',
+    });
+
+    expect(response).toEqual({
+      type: 'rpc.response',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-1',
+      ok: true,
+      payload: {
+        encoding: 'json',
+        value: { ok: true, vaults: [{ id: 'ledger', displayName: 'Ledger' }] },
+      },
+    });
+  });
+
+  it('rejects unknown typed relay RPC capabilities without proxying arbitrary paths', async () => {
+    const fetchImpl = vi.fn();
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+
+    const response = await (
+      client as unknown as {
+        handleRelayRpcRequest(request: {
+          type: 'rpc.request';
+          version: typeof RELAY_TRANSPORT_PROTOCOL_VERSION;
+          id: string;
+          capability: string;
+        }): Promise<unknown>;
+      }
+    ).handleRelayRpcRequest({
+      type: 'rpc.request',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-2',
+      capability: 'admin.disconnect',
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(response).toMatchObject({
+      type: 'rpc.response',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-2',
+      ok: false,
+      error: { code: RELAY_ERROR_CODES.UNKNOWN_CAPABILITY },
+    });
   });
 });
 

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -6,6 +6,7 @@ import {
   TUNNEL_CLOSE_CODES,
   TUNNEL_PENDING_STREAM_FRAME_LIMIT,
   TUNNEL_WS_FRAME_BYTE_LIMIT,
+  encodeTunnelMessage,
 } from '@kb-2/tunnel-protocol';
 import {
   ChunkedHttpRequestAssembler,
@@ -234,6 +235,57 @@ describe('TunnelClient typed relay RPC', () => {
       ok: false,
       error: { code: RELAY_ERROR_CODES.UNKNOWN_CAPABILITY },
     });
+  });
+});
+
+describe('TunnelClient HTTP proxy cancellation', () => {
+  it('aborts an in-flight daemon HTTP fetch when the relay sends http.cancel', async () => {
+    let observedSignal: AbortSignal | undefined;
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      observedSignal = init?.signal as AbortSignal | undefined;
+      await new Promise((_resolve, reject) => {
+        observedSignal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+      });
+      return new Response('late');
+    });
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+    const control = new FakeSocket();
+    const handleControlMessage = (
+      client as unknown as {
+        handleControlMessage(control: unknown, data: Buffer): Promise<void>;
+      }
+    ).handleControlMessage.bind(client);
+
+    const request = handleControlMessage(
+      control,
+      Buffer.from(encodeTunnelMessage({
+        type: 'http.request',
+        id: 'req-1',
+        method: 'POST',
+        path: '/api/vaults/ledger/tree',
+        headers: {},
+        bodyB64: null,
+      })),
+    );
+    await vi.waitFor(() => expect(observedSignal).toBeDefined());
+
+    await handleControlMessage(
+      control,
+      Buffer.from(encodeTunnelMessage({
+        type: 'http.cancel',
+        id: 'req-1',
+        reason: 'browser timeout',
+      })),
+    );
+
+    await request;
+    expect(observedSignal?.aborted).toBe(true);
+    expect(control.sent).toEqual([]);
   });
 });
 

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -1,6 +1,9 @@
 import {
   PendingFrameBuffer,
+  RELAY_ERROR_CODES,
+  RELAY_TRANSPORT_PROTOCOL_VERSION,
   TUNNEL_CLOSE_CODES,
+  TUNNEL_FEATURES,
   TUNNEL_HTTP_BODY_CHUNK_BYTES,
   TUNNEL_HTTP_PENDING_BYTE_LIMIT,
   TUNNEL_HTTP_REQUEST_TIMEOUT_MS,
@@ -9,6 +12,11 @@ import {
   TUNNEL_PENDING_STREAM_PAIR_TIMEOUT_MS,
   decodeTunnelMessage,
   encodeTunnelMessage,
+  parseRelayFrame,
+  type RelayFrame,
+  type RelayJsonValue,
+  type RelayRpcRequestFrame,
+  type RelayRpcResponseFrame,
   type TunnelControlServerMessage,
   type TunnelHttpRequestChunkEnvelope,
   type TunnelHttpRequestEndEnvelope,
@@ -129,6 +137,7 @@ export class TunnelClient {
         type: 'control.hello',
         version: TUNNEL_PROTOCOL_VERSION,
         token: this.config.token,
+        features: [TUNNEL_FEATURES.RELAY_FRAMES_V1],
       }));
       this.startControlHeartbeat(control);
       this.logger.log('info', 'relay control connected', {
@@ -191,6 +200,9 @@ export class TunnelClient {
           relayMessage: message.message,
         });
         return;
+      case 'relay.frame':
+        await this.handleRelayFrame(control, parseRelayFrame(message.frame));
+        return;
       case 'http.request':
         this.sendHttpResponse(control, await this.proxyHttp(message));
         return;
@@ -210,6 +222,62 @@ export class TunnelClient {
       case 'ws.open':
         this.openDialback(message);
         return;
+    }
+  }
+
+  private async handleRelayFrame(control: WebSocket, frame: RelayFrame): Promise<void> {
+    if (frame.type !== 'rpc.request') {
+      this.logger.log('warn', 'relay frame type is not handled by tunnel client', { frameType: frame.type });
+      return;
+    }
+
+    control.send(encodeJsonBytes({
+      type: 'relay.frame',
+      frame: await this.handleRelayRpcRequest(frame),
+    }));
+  }
+
+  private async handleRelayRpcRequest(request: RelayRpcRequestFrame): Promise<RelayRpcResponseFrame> {
+    switch (request.capability) {
+      case 'vault.list':
+        return this.handleVaultListRpc(request);
+      default:
+        return relayRpcError(request.id, RELAY_ERROR_CODES.UNKNOWN_CAPABILITY, `Unknown relay capability: ${request.capability}`);
+    }
+  }
+
+  private async handleVaultListRpc(request: RelayRpcRequestFrame): Promise<RelayRpcResponseFrame> {
+    const abort = new AbortController();
+    const timeout = setTimeout(
+      () => abort.abort(),
+      request.deadlineMs ?? TUNNEL_HTTP_REQUEST_TIMEOUT_MS,
+    );
+
+    try {
+      const response = await this.fetchImpl(new URL('/api/vaults', this.config.daemonUrl), {
+        method: 'GET',
+        headers: { accept: 'application/json' },
+        signal: abort.signal,
+      });
+      if (!response.ok) {
+        return relayRpcError(request.id, RELAY_ERROR_CODES.INTERNAL, `Daemon vault list failed with status ${response.status}`);
+      }
+
+      return {
+        type: 'rpc.response',
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+        id: request.id,
+        ok: true,
+        payload: { encoding: 'json', value: await response.json() as RelayJsonValue },
+      };
+    } catch (error) {
+      return relayRpcError(
+        request.id,
+        abort.signal.aborted ? RELAY_ERROR_CODES.DEADLINE_EXCEEDED : RELAY_ERROR_CODES.INTERNAL,
+        `Daemon vault list RPC failed: ${String(error)}`,
+      );
+    } finally {
+      clearTimeout(timeout);
     }
   }
 
@@ -663,6 +731,20 @@ export function sendableCloseCode(code: number): number {
   return code >= 1000 && code <= 4999 && code !== 1005 && code !== 1006
     ? code
     : 1011;
+}
+
+function relayRpcError(
+  id: string,
+  code: (typeof RELAY_ERROR_CODES)[keyof typeof RELAY_ERROR_CODES],
+  message: string,
+): RelayRpcResponseFrame {
+  return {
+    type: 'rpc.response',
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    id,
+    ok: false,
+    error: { code, message },
+  };
 }
 
 export function relayInternalUrl(relayUrl: URL, internalPath: string): URL {

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -18,6 +18,7 @@ import {
   type RelayRpcRequestFrame,
   type RelayRpcResponseFrame,
   type TunnelControlServerMessage,
+  type TunnelHttpCancelEnvelope,
   type TunnelHttpRequestChunkEnvelope,
   type TunnelHttpRequestEndEnvelope,
   type TunnelHttpRequestEnvelope,
@@ -79,6 +80,11 @@ const responseBodyTransformHeaders = new Set([
   'content-encoding',
 ]);
 
+type PendingDaemonHttpRequest = {
+  abort: AbortController;
+  canceled: boolean;
+};
+
 /* v8 ignore start -- Live relay socket orchestration is covered by Stage A wrangler/daemon/browser drills; unit tests cover the deterministic backoff, close-code, URL, and dial-back bridge logic below. */
 export class TunnelClient {
   private readonly logger: TunnelClientLogger;
@@ -89,6 +95,7 @@ export class TunnelClient {
   private controlHeartbeatInterval: ReturnType<typeof setInterval> | undefined;
   private controlHeartbeatDeadline: ReturnType<typeof setTimeout> | undefined;
   private readonly httpAssembler = new ChunkedHttpRequestAssembler();
+  private readonly pendingHttpRequests = new Map<string, PendingDaemonHttpRequest>();
   private stopped = true;
   private reconnectAttempt = 0;
 
@@ -113,6 +120,7 @@ export class TunnelClient {
       this.reconnectTimer = undefined;
     }
     this.clearControlHeartbeat();
+    this.abortPendingHttpRequests();
     this.control?.close(1001, 'Tunnel client stopping');
     this.control = undefined;
   }
@@ -156,6 +164,7 @@ export class TunnelClient {
       if (this.control === control) {
         this.control = undefined;
         this.clearControlHeartbeat();
+        this.abortPendingHttpRequests();
       }
 
       if (this.stopped) return;
@@ -204,7 +213,10 @@ export class TunnelClient {
         await this.handleRelayFrame(control, parseRelayFrame(message.frame));
         return;
       case 'http.request':
-        this.sendHttpResponse(control, await this.proxyHttp(message));
+        {
+          const response = await this.proxyHttp(message);
+          if (response) this.sendHttpResponse(control, response);
+        }
         return;
       case 'http.request.start':
         this.httpAssembler.start(message);
@@ -215,10 +227,14 @@ export class TunnelClient {
       case 'http.request.end': {
         const assembled = this.httpAssembler.end(message);
         if (assembled) {
-          this.sendHttpResponse(control, await this.proxyHttp(assembled));
+          const response = await this.proxyHttp(assembled);
+          if (response) this.sendHttpResponse(control, response);
         }
         return;
       }
+      case 'http.cancel':
+        this.cancelHttpRequest(message);
+        return;
       case 'ws.open':
         this.openDialback(message);
         return;
@@ -314,10 +330,12 @@ export class TunnelClient {
     }
   }
 
-  private async proxyHttp(envelope: TunnelHttpRequestEnvelope): Promise<TunnelHttpResponseEnvelope> {
+  private async proxyHttp(envelope: TunnelHttpRequestEnvelope): Promise<TunnelHttpResponseEnvelope | null> {
     const upstreamUrl = new URL(envelope.path, this.config.daemonUrl);
     const abort = new AbortController();
     const timeout = setTimeout(() => abort.abort(), TUNNEL_HTTP_REQUEST_TIMEOUT_MS);
+    const pending: PendingDaemonHttpRequest = { abort, canceled: false };
+    this.pendingHttpRequests.set(envelope.id, pending);
 
     try {
       const response = await this.fetchImpl(upstreamUrl, {
@@ -335,6 +353,9 @@ export class TunnelClient {
         bodyB64: (await materializedResponseBody(response)).toString('base64'),
       };
     } catch (error) {
+      if (pending.canceled) {
+        return null;
+      }
       return {
         type: 'http.response',
         id: envelope.id,
@@ -344,7 +365,25 @@ export class TunnelClient {
       };
     } finally {
       clearTimeout(timeout);
+      this.pendingHttpRequests.delete(envelope.id);
     }
+  }
+
+  private cancelHttpRequest(message: TunnelHttpCancelEnvelope): void {
+    this.httpAssembler.cancel(message.id);
+    const pending = this.pendingHttpRequests.get(message.id);
+    if (!pending) return;
+
+    pending.canceled = true;
+    pending.abort.abort(message.reason ?? 'relay cancelled HTTP request');
+  }
+
+  private abortPendingHttpRequests(): void {
+    for (const pending of this.pendingHttpRequests.values()) {
+      pending.canceled = true;
+      pending.abort.abort('relay control closed');
+    }
+    this.pendingHttpRequests.clear();
   }
 
   private sendHttpResponse(control: WebSocket, envelope: TunnelHttpResponseEnvelope): void {

--- a/packages/tunnel-protocol/src/index.test.ts
+++ b/packages/tunnel-protocol/src/index.test.ts
@@ -93,6 +93,16 @@ it("round-trips chunked HTTP request envelopes", () => {
   expect(decodeTunnelMessage(encodeTunnelMessage(end))).toEqual(end);
 });
 
+it("round-trips HTTP cancellation envelopes", () => {
+  const cancel = {
+    type: "http.cancel",
+    id: "req-1",
+    reason: "browser timeout"
+  } as const;
+
+  expect(decodeTunnelMessage(encodeTunnelMessage(cancel))).toEqual(cancel);
+});
+
 it("round-trips chunked HTTP response envelopes", () => {
   const start = {
     type: "http.response.start",

--- a/packages/tunnel-protocol/src/index.test.ts
+++ b/packages/tunnel-protocol/src/index.test.ts
@@ -504,6 +504,40 @@ it("validates relay JSON payload edges before serialization", () => {
   ).toThrow("Relay payload.value must be JSON-compatible");
   expect(() =>
     parseRelayFrame({
+      type: "event",
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      topic: "bad.date",
+      payload: {
+        encoding: "json",
+        value: new Date("2026-06-25T00:00:00.000Z")
+      }
+    })
+  ).toThrow("Relay payload.value must be JSON-compatible");
+  expect(() =>
+    parseRelayFrame({
+      type: "event",
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      topic: "bad.map",
+      resource: new Map([["vaultSlug", "demo-vault"]])
+    })
+  ).toThrow("Relay resource must be a JSON object");
+  expect(
+    parseRelayFrame({
+      type: "event",
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      topic: "null.prototype",
+      resource: Object.assign(Object.create(null), {
+        vaultSlug: "demo-vault"
+      })
+    })
+  ).toEqual({
+    type: "event",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    topic: "null.prototype",
+    resource: { vaultSlug: "demo-vault" }
+  });
+  expect(() =>
+    parseRelayFrame({
       type: "rpc.response",
       version: RELAY_TRANSPORT_PROTOCOL_VERSION,
       id: "req-1",

--- a/packages/tunnel-protocol/src/index.test.ts
+++ b/packages/tunnel-protocol/src/index.test.ts
@@ -1,10 +1,22 @@
 import {
   PendingFrameBuffer,
+  RELAY_DEFAULT_REQUEST_TIMEOUT_MS,
+  RELAY_ERROR_CODES,
+  RELAY_FRAME_BYTE_LIMIT,
+  RELAY_PENDING_REQUEST_LIMIT,
+  RELAY_STREAM_CLOSE_CODES,
+  RELAY_TRANSPORT_PROTOCOL_VERSION,
+  RelayPendingRequestTable,
+  assertRelayFrameSize,
+  parseRelayFrame,
+  relayFrameByteLength,
   TUNNEL_CLOSE_CODES,
   TUNNEL_PENDING_STREAM_BYTE_LIMIT,
   TUNNEL_PENDING_STREAM_FRAME_LIMIT,
   TUNNEL_PROTOCOL_VERSION,
+  decodeRelayFrame,
   decodeTunnelMessage,
+  encodeRelayFrame,
   encodeTunnelMessage
 } from "./index.js";
 
@@ -178,4 +190,392 @@ it("clears pending stream frames without draining them", () => {
   expect(buffer.frameCount).toBe(0);
   expect(buffer.byteCount).toBe(0);
   expect(buffer.drain()).toEqual([]);
+});
+
+it("round-trips relay rpc request and response frames", () => {
+  const request = {
+    type: "rpc.request",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    id: "req-1",
+    capability: "vault.file.read",
+    deadlineMs: 5000,
+    payload: {
+      encoding: "json",
+      value: { vaultSlug: "demo-vault", path: "README.md" }
+    },
+    context: {
+      actorId: "user-1",
+      orgId: "org-1"
+    }
+  } as const;
+  const success = {
+    type: "rpc.response",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    id: "req-1",
+    ok: true,
+    payload: {
+      encoding: "base64",
+      dataB64: "b2s="
+    }
+  } as const;
+  const failure = {
+    type: "rpc.response",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    id: "req-2",
+    ok: false,
+    error: {
+      code: RELAY_ERROR_CODES.DEADLINE_EXCEEDED,
+      message: "Request timed out",
+      data: { deadlineMs: 5000 }
+    }
+  } as const;
+
+  expect(decodeRelayFrame(encodeRelayFrame(request))).toEqual(request);
+  expect(decodeRelayFrame(encodeRelayFrame(success))).toEqual(success);
+  expect(decodeRelayFrame(encodeRelayFrame(failure))).toEqual(failure);
+});
+
+it("round-trips relay stream, event, cancel, and error frames", () => {
+  const open = {
+    type: "stream.open",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    streamId: "stream-1",
+    capability: "doc.sync",
+    payload: {
+      encoding: "json",
+      value: { path: "README.md" }
+    }
+  } as const;
+  const data = {
+    type: "stream.data",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    streamId: "stream-1",
+    sequence: 0,
+    payload: {
+      encoding: "base64",
+      dataB64: "AQI="
+    }
+  } as const;
+  const close = {
+    type: "stream.close",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    streamId: "stream-1",
+    code: RELAY_STREAM_CLOSE_CODES.NORMAL,
+    reason: "done"
+  } as const;
+  const event = {
+    type: "event",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    id: "event-1",
+    topic: "vault.tree.changed",
+    resource: { vaultSlug: "demo-vault" },
+    payload: {
+      encoding: "json",
+      value: { cursor: "cursor-1" }
+    }
+  } as const;
+  const cancel = {
+    type: "cancel",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    target: { kind: "stream", streamId: "stream-1" },
+    reason: "navigated away"
+  } as const;
+  const error = {
+    type: "error",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    target: { kind: "rpc", id: "req-1" },
+    error: {
+      code: RELAY_ERROR_CODES.UNAUTHORIZED,
+      message: "Not authorized"
+    }
+  } as const;
+
+  for (const frame of [open, data, close, event, cancel, error]) {
+    expect(decodeRelayFrame(encodeRelayFrame(frame))).toEqual(frame);
+  }
+});
+
+it("rejects malformed relay frames", () => {
+  expect(() => decodeRelayFrame("null")).toThrow(
+    "Relay frame must be an object"
+  );
+  expect(() =>
+    decodeRelayFrame(
+      JSON.stringify({
+        type: "rpc.request",
+        version: 999,
+        id: "req-1",
+        capability: "vault.file.read"
+      })
+    )
+  ).toThrow("Unsupported relay protocol version");
+  expect(() =>
+    decodeRelayFrame(
+      JSON.stringify({
+        type: "unknown",
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION
+      })
+    )
+  ).toThrow("Unsupported relay frame type: unknown");
+  expect(() =>
+    decodeRelayFrame(
+      JSON.stringify({
+        type: "rpc.request",
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+        id: "",
+        capability: "vault.file.read"
+      })
+    )
+  ).toThrow("Relay id must not be empty");
+  expect(() =>
+    decodeRelayFrame(
+      JSON.stringify({
+        type: "rpc.request",
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+        id: "req-1",
+        capability: "vault.file.read",
+        payload: { encoding: "xml", value: "<nope />" }
+      })
+    )
+  ).toThrow("Relay payload.encoding must be json or base64");
+  expect(() =>
+    decodeRelayFrame(
+      JSON.stringify({
+        type: "stream.data",
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+        streamId: "stream-1",
+        sequence: -1,
+        payload: { encoding: "base64", dataB64: "AQI=" }
+      })
+    )
+  ).toThrow("Relay sequence must be a non-negative integer");
+});
+
+it("rejects relay frames above the configured byte limit", () => {
+  const frame = encodeRelayFrame({
+    type: "event",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    topic: "large",
+    payload: {
+      encoding: "json",
+      value: { text: "hello" }
+    }
+  });
+
+  expect(relayFrameByteLength(frame)).toBeLessThan(RELAY_FRAME_BYTE_LIMIT);
+  expect(() => decodeRelayFrame(frame, { maxBytes: 10 })).toThrow(
+    "Relay frame exceeds byte limit"
+  );
+  expect(() => assertRelayFrameSize(frame, { maxBytes: 10 })).toThrow(
+    "Relay frame exceeds byte limit"
+  );
+});
+
+it("counts relay frame bytes as UTF-8, not string code units", () => {
+  expect(relayFrameByteLength("é")).toBe(2);
+});
+
+it("rejects malformed relay error, target, and payload details", () => {
+  expect(() =>
+    decodeRelayFrame(
+      JSON.stringify({
+        type: "rpc.response",
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+        id: "req-1",
+        ok: "yes"
+      })
+    )
+  ).toThrow("Relay rpc.response ok must be boolean");
+  expect(() =>
+    decodeRelayFrame(
+      JSON.stringify({
+        type: "rpc.response",
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+        id: "req-1",
+        ok: false,
+        error: { code: "made-up", message: "Bad" }
+      })
+    )
+  ).toThrow("Relay error.code is not a known error code");
+  expect(() =>
+    decodeRelayFrame(
+      JSON.stringify({
+        type: "stream.close",
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+        streamId: "stream-1",
+        code: "made-up"
+      })
+    )
+  ).toThrow("Relay code is not a known stream close code");
+  expect(() =>
+    decodeRelayFrame(
+      JSON.stringify({
+        type: "cancel",
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+        target: { kind: "other", id: "req-1" }
+      })
+    )
+  ).toThrow("Relay target.kind must be rpc or stream");
+  expect(() =>
+    decodeRelayFrame(
+      JSON.stringify({
+        type: "stream.data",
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+        streamId: "stream-1",
+        sequence: 0,
+        payload: { encoding: "base64", dataB64: "not base64" }
+      })
+    )
+  ).toThrow("Relay payload.dataB64 must be base64");
+  expect(() =>
+    decodeRelayFrame(
+      JSON.stringify({
+        type: 1,
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION
+      })
+    )
+  ).toThrow("Relay type must be a string");
+  expect(() =>
+    decodeRelayFrame(
+      JSON.stringify({
+        type: "rpc.request",
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+        id: "req-1",
+        capability: "vault.file.read",
+        deadlineMs: 0
+      })
+    )
+  ).toThrow("Relay deadlineMs must be a positive integer");
+  expect(() =>
+    decodeRelayFrame(
+      JSON.stringify({
+        type: "rpc.request",
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+        id: "req-1",
+        capability: "vault.file.read",
+        context: []
+      })
+    )
+  ).toThrow("Relay context must be a JSON object");
+});
+
+it("validates relay JSON payload edges before serialization", () => {
+  expect(
+    parseRelayFrame({
+      type: "event",
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      topic: "array.payload",
+      payload: {
+        encoding: "json",
+        value: ["ok", 1, null, { nested: true }]
+      }
+    })
+  ).toEqual({
+    type: "event",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    topic: "array.payload",
+    payload: {
+      encoding: "json",
+      value: ["ok", 1, null, { nested: true }]
+    }
+  });
+
+  expect(() =>
+    parseRelayFrame({
+      type: "event",
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      topic: "bad.array",
+      payload: {
+        encoding: "json",
+        value: ["ok", undefined]
+      }
+    })
+  ).toThrow("Relay payload.value must be JSON-compatible");
+  expect(() =>
+    parseRelayFrame({
+      type: "event",
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      topic: "bad.symbol",
+      payload: {
+        encoding: "json",
+        value: Symbol("nope")
+      }
+    })
+  ).toThrow("Relay payload.value must be JSON-compatible");
+  expect(() =>
+    parseRelayFrame({
+      type: "rpc.response",
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: "req-1",
+      ok: false,
+      error: {
+        code: RELAY_ERROR_CODES.INTERNAL,
+        message: "Internal",
+        data: { value: Number.NaN }
+      }
+    })
+  ).toThrow("Relay error.data must be JSON-compatible");
+});
+
+it("tracks relay pending rpc requests with deadlines", () => {
+  let now = 1000;
+  const pending = new RelayPendingRequestTable({
+    maxPending: 2,
+    defaultTimeoutMs: 100,
+    now: () => now
+  });
+
+  expect(pending.add("req-1")).toEqual({
+    ok: true,
+    pending: 1,
+    deadlineAt: 1100
+  });
+  expect(pending.add("req-2", { timeoutMs: 250 })).toEqual({
+    ok: true,
+    pending: 2,
+    deadlineAt: 1250
+  });
+  expect(pending.size).toBe(2);
+  expect(pending.has("req-1")).toBe(true);
+  expect(pending.deadlineFor("req-2")).toBe(1250);
+  expect(pending.add("req-1")).toEqual({
+    ok: false,
+    reason: "duplicate",
+    pending: 2
+  });
+  expect(pending.add("req-3")).toEqual({
+    ok: false,
+    reason: "limit",
+    pending: 2
+  });
+  expect(pending.resolve("req-2")).toBe(true);
+  expect(pending.add("req-3")).toEqual({
+    ok: true,
+    pending: 2,
+    deadlineAt: 1100
+  });
+
+  now = 1100;
+  expect(pending.expire()).toEqual(["req-1", "req-3"]);
+  expect(pending.has("req-1")).toBe(false);
+  expect(pending.resolve("req-2")).toBe(false);
+  expect(pending.size).toBe(0);
+});
+
+it("cancels and clears relay pending rpc requests", () => {
+  const pending = new RelayPendingRequestTable();
+
+  expect(pending.maxPending).toBe(RELAY_PENDING_REQUEST_LIMIT);
+  expect(pending.defaultTimeoutMs).toBe(RELAY_DEFAULT_REQUEST_TIMEOUT_MS);
+  expect(pending.add("req-1", { deadlineAt: 123 })).toEqual({
+    ok: true,
+    pending: 1,
+    deadlineAt: 123
+  });
+  expect(pending.deadlineFor("missing")).toBeNull();
+  expect(pending.cancel("missing")).toBe(false);
+  expect(pending.cancel("req-1")).toBe(true);
+  expect(pending.add("req-2")).toMatchObject({ ok: true, pending: 1 });
+  pending.clear();
+  expect(pending.size).toBe(0);
 });

--- a/packages/tunnel-protocol/src/index.test.ts
+++ b/packages/tunnel-protocol/src/index.test.ts
@@ -11,6 +11,7 @@ import {
   parseRelayFrame,
   relayFrameByteLength,
   TUNNEL_CLOSE_CODES,
+  TUNNEL_FEATURES,
   TUNNEL_PENDING_STREAM_BYTE_LIMIT,
   TUNNEL_PENDING_STREAM_FRAME_LIMIT,
   TUNNEL_PROTOCOL_VERSION,
@@ -38,6 +39,32 @@ it("round-trips control heartbeat envelopes", () => {
 
   expect(decodeTunnelMessage(encodeTunnelMessage(ping))).toEqual(ping);
   expect(decodeTunnelMessage(encodeTunnelMessage(pong))).toEqual(pong);
+});
+
+it("round-trips control hello feature advertisement", () => {
+  const hello = {
+    type: "control.hello",
+    version: TUNNEL_PROTOCOL_VERSION,
+    token: "test-token",
+    features: [TUNNEL_FEATURES.RELAY_FRAMES_V1]
+  } as const;
+
+  expect(decodeTunnelMessage(encodeTunnelMessage(hello))).toEqual(hello);
+});
+
+it("round-trips typed relay frames over the tunnel control socket", () => {
+  const message = {
+    type: "relay.frame",
+    frame: {
+      type: "rpc.request",
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: "rpc-1",
+      capability: "vault.list",
+      deadlineMs: 1_000
+    }
+  } as const;
+
+  expect(decodeTunnelMessage(encodeTunnelMessage(message))).toEqual(message);
 });
 
 it("round-trips chunked HTTP request envelopes", () => {

--- a/packages/tunnel-protocol/src/index.ts
+++ b/packages/tunnel-protocol/src/index.ts
@@ -741,7 +741,7 @@ function expectRelayJsonObject(
   value: unknown,
   field: string
 ): RelayJsonObject {
-  if (!isRecord(value) || !isRelayJsonValue(value)) {
+  if (!isPlainRecord(value) || !isRelayJsonValue(value)) {
     throw new Error(`Relay ${field} must be a JSON object`);
   }
   return value as RelayJsonObject;
@@ -820,6 +820,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
 function isRelayJsonValue(value: unknown): value is RelayJsonValue {
   if (
     value === null ||
@@ -837,7 +846,7 @@ function isRelayJsonValue(value: unknown): value is RelayJsonValue {
     return value.every(isRelayJsonValue);
   }
 
-  if (isRecord(value)) {
+  if (isPlainRecord(value)) {
     return Object.values(value).every(isRelayJsonValue);
   }
 

--- a/packages/tunnel-protocol/src/index.ts
+++ b/packages/tunnel-protocol/src/index.ts
@@ -21,6 +21,12 @@ export const RELAY_FRAME_BYTE_LIMIT = 256 * 1024;
 export const RELAY_PENDING_REQUEST_LIMIT = 128 as const;
 export const RELAY_DEFAULT_REQUEST_TIMEOUT_MS = 15_000 as const;
 
+export const TUNNEL_FEATURES = {
+  RELAY_FRAMES_V1: "relay.frame.v1"
+} as const;
+
+export type TunnelFeature = (typeof TUNNEL_FEATURES)[keyof typeof TUNNEL_FEATURES];
+
 export const RELAY_ERROR_CODES = {
   BAD_MESSAGE: "bad-message",
   UNSUPPORTED_VERSION: "unsupported-version",
@@ -345,6 +351,7 @@ export type TunnelControlClientHello = {
   type: "control.hello";
   version: TunnelProtocolVersion;
   token: string;
+  features?: readonly TunnelFeature[];
 };
 
 export type TunnelControlServerReady = {
@@ -447,10 +454,16 @@ export type TunnelWebSocketCloseEnvelope = {
   reason: string;
 };
 
+export type TunnelRelayFrameEnvelope = {
+  type: "relay.frame";
+  frame: RelayFrame;
+};
+
 export type TunnelControlClientMessage =
   | TunnelControlClientHello
   | TunnelControlPing
   | TunnelWebSocketCloseEnvelope
+  | TunnelRelayFrameEnvelope
   | TunnelHttpResponseEnvelope
   | TunnelHttpResponseStartEnvelope
   | TunnelHttpResponseChunkEnvelope
@@ -460,6 +473,7 @@ export type TunnelControlServerMessage =
   | TunnelControlServerReady
   | TunnelControlPong
   | TunnelControlServerError
+  | TunnelRelayFrameEnvelope
   | TunnelHttpRequestEnvelope
   | TunnelHttpRequestStartEnvelope
   | TunnelHttpRequestChunkEnvelope

--- a/packages/tunnel-protocol/src/index.ts
+++ b/packages/tunnel-protocol/src/index.ts
@@ -4,6 +4,11 @@ export type TunnelProtocolVersion = typeof TUNNEL_PROTOCOL_VERSION;
 
 export type TunnelRole = "control" | "dialback";
 
+export const RELAY_TRANSPORT_PROTOCOL_VERSION = 1 as const;
+
+export type RelayTransportProtocolVersion =
+  typeof RELAY_TRANSPORT_PROTOCOL_VERSION;
+
 export const TUNNEL_PENDING_STREAM_FRAME_LIMIT = 64 as const;
 export const TUNNEL_PENDING_STREAM_BYTE_LIMIT = 1024 * 1024;
 export const TUNNEL_PENDING_STREAM_PAIR_TIMEOUT_MS = 10_000 as const;
@@ -12,6 +17,37 @@ export const TUNNEL_HTTP_PENDING_BYTE_LIMIT = 8 * 1024 * 1024;
 export const TUNNEL_HTTP_REQUEST_TIMEOUT_MS = 15_000 as const;
 export const TUNNEL_HTTP_BODY_CHUNK_BYTES = 256 * 1024;
 export const TUNNEL_WS_FRAME_BYTE_LIMIT = 256 * 1024;
+export const RELAY_FRAME_BYTE_LIMIT = 256 * 1024;
+export const RELAY_PENDING_REQUEST_LIMIT = 128 as const;
+export const RELAY_DEFAULT_REQUEST_TIMEOUT_MS = 15_000 as const;
+
+export const RELAY_ERROR_CODES = {
+  BAD_MESSAGE: "bad-message",
+  UNSUPPORTED_VERSION: "unsupported-version",
+  UNKNOWN_CAPABILITY: "unknown-capability",
+  UNAUTHORIZED: "unauthorized",
+  DEADLINE_EXCEEDED: "deadline-exceeded",
+  CANCELLED: "cancelled",
+  PAYLOAD_TOO_LARGE: "payload-too-large",
+  BACKPRESSURE: "backpressure",
+  INTERNAL: "internal"
+} as const;
+
+export type RelayErrorCode =
+  (typeof RELAY_ERROR_CODES)[keyof typeof RELAY_ERROR_CODES];
+
+export const RELAY_STREAM_CLOSE_CODES = {
+  NORMAL: "normal",
+  CANCELLED: "cancelled",
+  DEADLINE_EXCEEDED: "deadline-exceeded",
+  PAYLOAD_TOO_LARGE: "payload-too-large",
+  BACKPRESSURE: "backpressure",
+  BAD_MESSAGE: "bad-message",
+  INTERNAL: "internal"
+} as const;
+
+export type RelayStreamCloseCode =
+  (typeof RELAY_STREAM_CLOSE_CODES)[keyof typeof RELAY_STREAM_CLOSE_CODES];
 
 export const TUNNEL_CLOSE_CODES = {
   CONTROL_REPLACED: 4000,
@@ -26,6 +62,125 @@ export const TUNNEL_CLOSE_CODES = {
 
 export type TunnelCloseCode =
   (typeof TUNNEL_CLOSE_CODES)[keyof typeof TUNNEL_CLOSE_CODES];
+
+export type RelayJsonPrimitive = string | number | boolean | null;
+
+export type RelayJsonValue =
+  | RelayJsonPrimitive
+  | RelayJsonValue[]
+  | { [key: string]: RelayJsonValue };
+
+export type RelayJsonObject = { [key: string]: RelayJsonValue };
+
+export type RelayJsonPayload = {
+  encoding: "json";
+  value: RelayJsonValue;
+};
+
+export type RelayBinaryPayload = {
+  encoding: "base64";
+  dataB64: string;
+};
+
+export type RelayPayload = RelayJsonPayload | RelayBinaryPayload;
+
+export type RelayFrameError = {
+  code: RelayErrorCode;
+  message: string;
+  data?: RelayJsonValue;
+};
+
+export type RelayRpcRequestFrame = {
+  type: "rpc.request";
+  version: RelayTransportProtocolVersion;
+  id: string;
+  capability: string;
+  deadlineMs?: number;
+  payload?: RelayPayload;
+  context?: RelayJsonObject;
+};
+
+export type RelayRpcResponseFrame =
+  | {
+      type: "rpc.response";
+      version: RelayTransportProtocolVersion;
+      id: string;
+      ok: true;
+      payload: RelayPayload;
+    }
+  | {
+      type: "rpc.response";
+      version: RelayTransportProtocolVersion;
+      id: string;
+      ok: false;
+      error: RelayFrameError;
+    };
+
+export type RelayStreamOpenFrame = {
+  type: "stream.open";
+  version: RelayTransportProtocolVersion;
+  streamId: string;
+  capability: string;
+  payload?: RelayPayload;
+  context?: RelayJsonObject;
+};
+
+export type RelayStreamDataFrame = {
+  type: "stream.data";
+  version: RelayTransportProtocolVersion;
+  streamId: string;
+  sequence: number;
+  payload: RelayPayload;
+};
+
+export type RelayStreamCloseFrame = {
+  type: "stream.close";
+  version: RelayTransportProtocolVersion;
+  streamId: string;
+  code: RelayStreamCloseCode;
+  reason?: string;
+};
+
+export type RelayEventFrame = {
+  type: "event";
+  version: RelayTransportProtocolVersion;
+  topic: string;
+  id?: string;
+  payload?: RelayPayload;
+  resource?: RelayJsonObject;
+};
+
+export type RelayCancelTarget =
+  | { kind: "rpc"; id: string }
+  | { kind: "stream"; streamId: string };
+
+export type RelayCancelFrame = {
+  type: "cancel";
+  version: RelayTransportProtocolVersion;
+  target: RelayCancelTarget;
+  reason?: string;
+};
+
+export type RelayErrorFrame = {
+  type: "error";
+  version: RelayTransportProtocolVersion;
+  error: RelayFrameError;
+  target?: RelayCancelTarget;
+};
+
+export type RelayFrame =
+  | RelayRpcRequestFrame
+  | RelayRpcResponseFrame
+  | RelayStreamOpenFrame
+  | RelayStreamDataFrame
+  | RelayStreamCloseFrame
+  | RelayEventFrame
+  | RelayCancelFrame
+  | RelayErrorFrame;
+
+export type RelayFrameCodecOptions = {
+  maxBytes?: number;
+};
 
 export type PendingFrameBufferOverflowReason = "frames" | "bytes";
 
@@ -101,6 +256,88 @@ export class PendingFrameBuffer {
   clear(): void {
     this.frames.length = 0;
     this.queuedBytes = 0;
+  }
+}
+
+export type RelayPendingRequestAddResult =
+  | { ok: true; pending: number; deadlineAt: number }
+  | { ok: false; reason: "duplicate" | "limit"; pending: number };
+
+export type RelayPendingRequestTableOptions = {
+  maxPending?: number;
+  defaultTimeoutMs?: number;
+  now?: () => number;
+};
+
+export type RelayPendingRequestAddOptions = {
+  timeoutMs?: number;
+  deadlineAt?: number;
+};
+
+export class RelayPendingRequestTable {
+  readonly maxPending: number;
+  readonly defaultTimeoutMs: number;
+  private readonly now: () => number;
+  private readonly deadlines = new Map<string, number>();
+
+  constructor(options: RelayPendingRequestTableOptions = {}) {
+    this.maxPending = options.maxPending ?? RELAY_PENDING_REQUEST_LIMIT;
+    this.defaultTimeoutMs =
+      options.defaultTimeoutMs ?? RELAY_DEFAULT_REQUEST_TIMEOUT_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  get size(): number {
+    return this.deadlines.size;
+  }
+
+  add(
+    id: string,
+    options: RelayPendingRequestAddOptions = {}
+  ): RelayPendingRequestAddResult {
+    if (this.deadlines.has(id)) {
+      return { ok: false, reason: "duplicate", pending: this.size };
+    }
+
+    if (this.deadlines.size >= this.maxPending) {
+      return { ok: false, reason: "limit", pending: this.size };
+    }
+
+    const deadlineAt =
+      options.deadlineAt ?? this.now() + (options.timeoutMs ?? this.defaultTimeoutMs);
+    this.deadlines.set(id, deadlineAt);
+    return { ok: true, pending: this.size, deadlineAt };
+  }
+
+  has(id: string): boolean {
+    return this.deadlines.has(id);
+  }
+
+  deadlineFor(id: string): number | null {
+    return this.deadlines.get(id) ?? null;
+  }
+
+  resolve(id: string): boolean {
+    return this.deadlines.delete(id);
+  }
+
+  cancel(id: string): boolean {
+    return this.deadlines.delete(id);
+  }
+
+  expire(now = this.now()): string[] {
+    const expired: string[] = [];
+    for (const [id, deadlineAt] of this.deadlines) {
+      if (deadlineAt <= now) {
+        expired.push(id);
+        this.deadlines.delete(id);
+      }
+    }
+    return expired;
+  }
+
+  clear(): void {
+    this.deadlines.clear();
   }
 }
 
@@ -248,4 +485,361 @@ export function decodeTunnelMessage(data: string): TunnelJsonMessage {
   }
 
   return parsed as TunnelJsonMessage;
+}
+
+export function encodeRelayFrame(frame: RelayFrame): string {
+  return JSON.stringify(frame);
+}
+
+export function decodeRelayFrame(
+  data: string,
+  options: RelayFrameCodecOptions = {}
+): RelayFrame {
+  assertRelayFrameSize(data, options);
+  return parseRelayFrame(JSON.parse(data));
+}
+
+export function relayFrameByteLength(data: string): number {
+  return new TextEncoder().encode(data).byteLength;
+}
+
+export function assertRelayFrameSize(
+  data: string,
+  options: RelayFrameCodecOptions = {}
+): void {
+  const maxBytes = options.maxBytes ?? RELAY_FRAME_BYTE_LIMIT;
+  if (relayFrameByteLength(data) > maxBytes) {
+    throw new Error("Relay frame exceeds byte limit");
+  }
+}
+
+export function parseRelayFrame(frame: unknown): RelayFrame {
+  if (!isRecord(frame)) {
+    throw new Error("Relay frame must be an object");
+  }
+
+  const type = expectString(frame.type, "type");
+  expectVersion(frame.version);
+
+  switch (type) {
+    case "rpc.request":
+      return parseRelayRpcRequestFrame(frame);
+    case "rpc.response":
+      return parseRelayRpcResponseFrame(frame);
+    case "stream.open":
+      return parseRelayStreamOpenFrame(frame);
+    case "stream.data":
+      return parseRelayStreamDataFrame(frame);
+    case "stream.close":
+      return parseRelayStreamCloseFrame(frame);
+    case "event":
+      return parseRelayEventFrame(frame);
+    case "cancel":
+      return parseRelayCancelFrame(frame);
+    case "error":
+      return parseRelayErrorFrame(frame);
+    default:
+      throw new Error(`Unsupported relay frame type: ${type}`);
+  }
+}
+
+function parseRelayRpcRequestFrame(
+  frame: Record<string, unknown>
+): RelayRpcRequestFrame {
+  return {
+    type: "rpc.request",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    id: expectNonEmptyString(frame.id, "id"),
+    capability: expectNonEmptyString(frame.capability, "capability"),
+    ...(frame.deadlineMs === undefined
+      ? {}
+      : { deadlineMs: expectPositiveInteger(frame.deadlineMs, "deadlineMs") }),
+    ...(frame.payload === undefined
+      ? {}
+      : { payload: expectRelayPayload(frame.payload, "payload") }),
+    ...(frame.context === undefined
+      ? {}
+      : { context: expectRelayJsonObject(frame.context, "context") })
+  };
+}
+
+function parseRelayRpcResponseFrame(
+  frame: Record<string, unknown>
+): RelayRpcResponseFrame {
+  const base = {
+    type: "rpc.response" as const,
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    id: expectNonEmptyString(frame.id, "id")
+  };
+
+  if (frame.ok === true) {
+    return {
+      ...base,
+      ok: true,
+      payload: expectRelayPayload(frame.payload, "payload")
+    };
+  }
+
+  if (frame.ok === false) {
+    return {
+      ...base,
+      ok: false,
+      error: expectRelayFrameError(frame.error, "error")
+    };
+  }
+
+  throw new Error("Relay rpc.response ok must be boolean");
+}
+
+function parseRelayStreamOpenFrame(
+  frame: Record<string, unknown>
+): RelayStreamOpenFrame {
+  return {
+    type: "stream.open",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    streamId: expectNonEmptyString(frame.streamId, "streamId"),
+    capability: expectNonEmptyString(frame.capability, "capability"),
+    ...(frame.payload === undefined
+      ? {}
+      : { payload: expectRelayPayload(frame.payload, "payload") }),
+    ...(frame.context === undefined
+      ? {}
+      : { context: expectRelayJsonObject(frame.context, "context") })
+  };
+}
+
+function parseRelayStreamDataFrame(
+  frame: Record<string, unknown>
+): RelayStreamDataFrame {
+  return {
+    type: "stream.data",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    streamId: expectNonEmptyString(frame.streamId, "streamId"),
+    sequence: expectNonNegativeInteger(frame.sequence, "sequence"),
+    payload: expectRelayPayload(frame.payload, "payload")
+  };
+}
+
+function parseRelayStreamCloseFrame(
+  frame: Record<string, unknown>
+): RelayStreamCloseFrame {
+  return {
+    type: "stream.close",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    streamId: expectNonEmptyString(frame.streamId, "streamId"),
+    code: expectRelayStreamCloseCode(frame.code, "code"),
+    ...(frame.reason === undefined
+      ? {}
+      : { reason: expectString(frame.reason, "reason") })
+  };
+}
+
+function parseRelayEventFrame(frame: Record<string, unknown>): RelayEventFrame {
+  return {
+    type: "event",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    topic: expectNonEmptyString(frame.topic, "topic"),
+    ...(frame.id === undefined ? {} : { id: expectNonEmptyString(frame.id, "id") }),
+    ...(frame.payload === undefined
+      ? {}
+      : { payload: expectRelayPayload(frame.payload, "payload") }),
+    ...(frame.resource === undefined
+      ? {}
+      : { resource: expectRelayJsonObject(frame.resource, "resource") })
+  };
+}
+
+function parseRelayCancelFrame(
+  frame: Record<string, unknown>
+): RelayCancelFrame {
+  return {
+    type: "cancel",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    target: expectRelayCancelTarget(frame.target, "target"),
+    ...(frame.reason === undefined
+      ? {}
+      : { reason: expectString(frame.reason, "reason") })
+  };
+}
+
+function parseRelayErrorFrame(frame: Record<string, unknown>): RelayErrorFrame {
+  return {
+    type: "error",
+    version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+    error: expectRelayFrameError(frame.error, "error"),
+    ...(frame.target === undefined
+      ? {}
+      : { target: expectRelayCancelTarget(frame.target, "target") })
+  };
+}
+
+function expectVersion(version: unknown): void {
+  if (version !== RELAY_TRANSPORT_PROTOCOL_VERSION) {
+    throw new Error("Unsupported relay protocol version");
+  }
+}
+
+function expectRelayPayload(value: unknown, field: string): RelayPayload {
+  if (!isRecord(value)) {
+    throw new Error(`Relay ${field} must be an object`);
+  }
+
+  if (value.encoding === "json") {
+    if (!("value" in value) || !isRelayJsonValue(value.value)) {
+      throw new Error(`Relay ${field}.value must be JSON-compatible`);
+    }
+    return { encoding: "json", value: value.value };
+  }
+
+  if (value.encoding === "base64") {
+    return {
+      encoding: "base64",
+      dataB64: expectBase64(value.dataB64, `${field}.dataB64`)
+    };
+  }
+
+  throw new Error(`Relay ${field}.encoding must be json or base64`);
+}
+
+function expectRelayFrameError(value: unknown, field: string): RelayFrameError {
+  if (!isRecord(value)) {
+    throw new Error(`Relay ${field} must be an object`);
+  }
+
+  return {
+    code: expectRelayErrorCode(value.code, `${field}.code`),
+    message: expectNonEmptyString(value.message, `${field}.message`),
+    ...(value.data === undefined
+      ? {}
+      : { data: expectRelayJsonValue(value.data, `${field}.data`) })
+  };
+}
+
+function expectRelayCancelTarget(
+  value: unknown,
+  field: string
+): RelayCancelTarget {
+  if (!isRecord(value)) {
+    throw new Error(`Relay ${field} must be an object`);
+  }
+
+  if (value.kind === "rpc") {
+    return { kind: "rpc", id: expectNonEmptyString(value.id, `${field}.id`) };
+  }
+
+  if (value.kind === "stream") {
+    return {
+      kind: "stream",
+      streamId: expectNonEmptyString(value.streamId, `${field}.streamId`)
+    };
+  }
+
+  throw new Error(`Relay ${field}.kind must be rpc or stream`);
+}
+
+function expectRelayJsonObject(
+  value: unknown,
+  field: string
+): RelayJsonObject {
+  if (!isRecord(value) || !isRelayJsonValue(value)) {
+    throw new Error(`Relay ${field} must be a JSON object`);
+  }
+  return value as RelayJsonObject;
+}
+
+function expectRelayJsonValue(value: unknown, field: string): RelayJsonValue {
+  if (!isRelayJsonValue(value)) {
+    throw new Error(`Relay ${field} must be JSON-compatible`);
+  }
+  return value;
+}
+
+function expectRelayErrorCode(value: unknown, field: string): RelayErrorCode {
+  if (
+    typeof value === "string" &&
+    Object.values(RELAY_ERROR_CODES).includes(value as RelayErrorCode)
+  ) {
+    return value as RelayErrorCode;
+  }
+
+  throw new Error(`Relay ${field} is not a known error code`);
+}
+
+function expectRelayStreamCloseCode(
+  value: unknown,
+  field: string
+): RelayStreamCloseCode {
+  if (
+    typeof value === "string" &&
+    Object.values(RELAY_STREAM_CLOSE_CODES).includes(value as RelayStreamCloseCode)
+  ) {
+    return value as RelayStreamCloseCode;
+  }
+
+  throw new Error(`Relay ${field} is not a known stream close code`);
+}
+
+function expectString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`Relay ${field} must be a string`);
+  }
+  return value;
+}
+
+function expectNonEmptyString(value: unknown, field: string): string {
+  const stringValue = expectString(value, field);
+  if (stringValue.length === 0) {
+    throw new Error(`Relay ${field} must not be empty`);
+  }
+  return stringValue;
+}
+
+function expectNonNegativeInteger(value: unknown, field: string): number {
+  if (Number.isInteger(value) && typeof value === "number" && value >= 0) {
+    return value;
+  }
+  throw new Error(`Relay ${field} must be a non-negative integer`);
+}
+
+function expectPositiveInteger(value: unknown, field: string): number {
+  if (Number.isInteger(value) && typeof value === "number" && value > 0) {
+    return value;
+  }
+  throw new Error(`Relay ${field} must be a positive integer`);
+}
+
+function expectBase64(value: unknown, field: string): string {
+  const stringValue = expectString(value, field);
+  if (stringValue.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(stringValue)) {
+    throw new Error(`Relay ${field} must be base64`);
+  }
+  return stringValue;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isRelayJsonValue(value: unknown): value is RelayJsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return true;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.every(isRelayJsonValue);
+  }
+
+  if (isRecord(value)) {
+    return Object.values(value).every(isRelayJsonValue);
+  }
+
+  return false;
 }

--- a/packages/tunnel-protocol/src/index.ts
+++ b/packages/tunnel-protocol/src/index.ts
@@ -404,6 +404,12 @@ export type TunnelHttpRequestEndEnvelope = {
   chunks: number;
 };
 
+export type TunnelHttpCancelEnvelope = {
+  type: "http.cancel";
+  id: string;
+  reason?: string;
+};
+
 export type TunnelHttpResponseEnvelope = {
   type: "http.response";
   id: string;
@@ -478,6 +484,7 @@ export type TunnelControlServerMessage =
   | TunnelHttpRequestStartEnvelope
   | TunnelHttpRequestChunkEnvelope
   | TunnelHttpRequestEndEnvelope
+  | TunnelHttpCancelEnvelope
   | TunnelWebSocketOpenEnvelope;
 
 export type TunnelDialbackClientMessage = TunnelWebSocketDialbackHello;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,6 +284,9 @@ importers:
       svelte:
         specifier: 'catalog:'
         version: 5.55.5
+      y-protocols:
+        specifier: 1.0.7
+        version: 1.0.7(yjs@13.6.31)
       yjs:
         specifier: 13.6.31
         version: 13.6.31


### PR DESCRIPTION
## Summary
- Add typed relay transport frame validation and control bridge coverage.
- Add relay HTTP cancellation so aborted cloud requests can stop in-flight daemon work.
- Mark document sessions synced only after the daemon responds to the client sync step, preventing pre-baseline save acks.

## Verification
- `pnpm -C local check`
- Cloud integration coverage via `pnpm check` in the consuming cloud worktree
- Cloud full e2e gate via `pnpm test:e2e` in the consuming cloud worktree: 12/12 passed

Cloud companion branch: `fc-1518-part-1-typed-orgchannel-transport`.