### PR TITLE
Use KB1 Actor Header

### DIFF
--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -29,7 +29,7 @@ import type {
   VaultRegistryErrorCode
 } from './vault-registry.js';
 
-export const ACTOR_HEADER = 'x-kb2-actor';
+export const ACTOR_HEADER = 'x-kb1-actor';
 const MAX_ACTOR_HEADER_BYTES = 1024;
 
 export interface CreateAppOptions {

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -291,7 +291,7 @@ describe('daemon routing', () => {
     await expect(response.json()).resolves.toMatchObject({ ok: false, error: 'not_found' });
   });
 
-  it('attributes REST writes from the x-kb2-actor header in responses and audit JSONL', async () => {
+  it('attributes REST writes from the x-kb1-actor header in responses and audit JSONL', async () => {
     const { app, vaultRoot } = await setupScopedVault();
     const suppliedActor = {
       kind: 'integration',
@@ -304,7 +304,7 @@ describe('daemon routing', () => {
       method: 'PUT',
       headers: {
         'content-type': 'text/plain',
-        'x-kb2-actor': JSON.stringify(suppliedActor)
+        'x-kb1-actor': JSON.stringify(suppliedActor)
       },
       body: 'attributed\n'
     });
@@ -374,7 +374,7 @@ describe('daemon routing', () => {
       method: 'PUT',
       headers: {
         'content-type': 'text/plain',
-        'x-kb2-actor': header
+        'x-kb1-actor': header
       },
       body: 'must not write\n'
     });


### PR DESCRIPTION
## Summary
- rename the daemon actor attribution header from `x-kb2-actor` to `x-kb1-actor`
- update daemon routing tests to lock the public KB1 header name

## Verification
- `pnpm --dir local --filter @kb-2/daemon test -- --runInBand`
- `pnpm --dir local --filter @kb-2/daemon typecheck`
- `git -C local diff --check`
