### PR TITLE
Broadcast file tree dirty events

### DIFF
--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -3,6 +3,7 @@ import { serve } from '@hono/node-server';
 import { bindYjsWebSocket, type DocumentSessionManager, type DocumentUpdateAttribution } from '@kb-2/doc-session';
 import { createLocalMcpEndpoint } from '@kb-2/local-mcp';
 import { TunnelClient, type TunnelClientLogger } from '@kb-2/tunnel-client';
+import type { VaultChangeEventKind } from '@kb-2/vault-service';
 import type { IncomingMessage } from 'node:http';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -21,8 +22,21 @@ import { writeDaemonStatus, type DaemonStatus } from './status.js';
 import {
   migrateLegacyVaultLayout,
   VAULT_TRASH_DIRNAME,
-  VaultRegistry
+  VaultRegistry,
+  type VaultRegistryChangeEvent
 } from './vault-registry.js';
+
+const VAULT_TREE_CHANGED_TOPIC = 'vault.tree.changed';
+const TREE_DIRTY_EVENT_KINDS = new Set<VaultChangeEventKind>([
+  'file_created',
+  'folder_created',
+  'file_deleted',
+  'folder_deleted',
+  'file_moved',
+  'folder_moved',
+  'folder_metadata_changed',
+  'external_change_detected'
+]);
 
 export interface StartedDaemon {
   config: DaemonConfig;
@@ -61,7 +75,7 @@ export async function startDaemon(): Promise<StartedDaemon> {
   // go through the SAME live registry the HTTP layer uses — no second vault map.
   // Every data tool requires a vaultId; there is no default vault.
   const mcpEndpoint = createLocalMcpEndpoint(mcpVaultProvider(registry));
-  const relay = createRelayLifecycleController(config);
+  const relay = createRelayLifecycleController(config, registry);
 
   const app = createApp({
     statusFile: config.statusFile,
@@ -173,7 +187,10 @@ export async function startDaemon(): Promise<StartedDaemon> {
   });
 }
 
-function createRelayLifecycleController(config: DaemonConfig): RelayLifecycleController | undefined {
+function createRelayLifecycleController(
+  config: DaemonConfig,
+  registry: VaultRegistry
+): RelayLifecycleController | undefined {
   if (!config.relay) {
     return undefined;
   }
@@ -185,19 +202,42 @@ function createRelayLifecycleController(config: DaemonConfig): RelayLifecycleCon
     token: config.relay.token,
     logger: daemonRelayLogger,
   });
+  let unsubscribeVaultEvents: (() => void) | undefined;
+  const ensureVaultEventSubscription = () => {
+    if (unsubscribeVaultEvents) return;
+    unsubscribeVaultEvents = registry.onVaultEvent((event) => {
+      if (!isTreeDirtyVaultEvent(event)) return;
+
+      client.sendRelayEvent({
+        topic: VAULT_TREE_CHANGED_TOPIC,
+        resource: { vaultSlug: event.vaultSlug },
+      });
+    });
+  };
+  const releaseVaultEventSubscription = () => {
+    unsubscribeVaultEvents?.();
+    unsubscribeVaultEvents = undefined;
+  };
   return {
     status() {
       return { configured: true, ...client.status() };
     },
     connect() {
       client.start();
+      ensureVaultEventSubscription();
       return { configured: true, ...client.status() };
     },
     disconnect() {
+      releaseVaultEventSubscription();
       client.stop();
       return { configured: true, ...client.status() };
     },
   };
+}
+
+function isTreeDirtyVaultEvent(event: VaultRegistryChangeEvent): boolean {
+  return TREE_DIRTY_EVENT_KINDS.has(event.event.kind)
+    && (event.event.kind !== 'external_change_detected' || event.event.path === '');
 }
 
 const daemonRelayLogger: TunnelClientLogger = {

--- a/apps/daemon/src/vault-registry.test.ts
+++ b/apps/daemon/src/vault-registry.test.ts
@@ -9,7 +9,8 @@ import {
   readOrMintVaultIdentity,
   slugify,
   VAULT_TRASH_DIRNAME,
-  VaultRegistry
+  VaultRegistry,
+  type VaultRegistryChangeEvent
 } from './vault-registry.js';
 
 describe('vault registry', () => {
@@ -223,6 +224,40 @@ describe('vault registry', () => {
 
       await registry.close();
       await reloaded.close();
+    });
+
+    it('forwards service change events for vaults created after subscription', async () => {
+      await mkdir(vaultsHome, { recursive: true });
+      const registry = await loadRegistry();
+      const events: VaultRegistryChangeEvent[] = [];
+      const unsubscribe = registry.onVaultEvent((event) => events.push(event));
+
+      await registry.create({ displayName: 'Project X', slug: 'project-x' });
+      const instance = registry.get('project-x');
+      if (!instance) throw new Error('expected live vault instance');
+
+      await expect(instance.service.createFolder({
+        path: 'event-test-folder',
+        actor: { kind: 'user' }
+      })).resolves.toMatchObject({ ok: true, path: 'event-test-folder' });
+
+      expect(events).toContainEqual(expect.objectContaining({
+        vaultSlug: 'project-x',
+        event: expect.objectContaining({
+          kind: 'folder_created',
+          path: 'event-test-folder'
+        })
+      }));
+
+      unsubscribe();
+      const countAfterUnsubscribe = events.length;
+      await expect(instance.service.createFolder({
+        path: 'later',
+        actor: { kind: 'user' }
+      })).resolves.toMatchObject({ ok: true, path: 'later' });
+      expect(events).toHaveLength(countAfterUnsubscribe);
+
+      await registry.close();
     });
 
     it('rejects creating a vault whose slug collides with an existing one', async () => {

--- a/apps/daemon/src/vault-registry.ts
+++ b/apps/daemon/src/vault-registry.ts
@@ -2,7 +2,7 @@ import { cp, mkdir, readFile, readdir, rename, rm, stat, writeFile } from 'node:
 import { join, relative } from 'node:path';
 
 import { DocumentSessionManager } from '@kb-2/doc-session';
-import { createVaultService, type VaultService } from '@kb-2/vault-service';
+import { createVaultService, type VaultChangeEvent, type VaultService } from '@kb-2/vault-service';
 import { slug as githubSlug } from 'github-slugger';
 
 import { seedVaultFromStarterKit } from './starter-kit.js';
@@ -34,6 +34,13 @@ export interface VaultInstance {
   service: VaultService;
   manager: DocumentSessionManager;
 }
+
+export interface VaultRegistryChangeEvent {
+  vaultSlug: string;
+  event: VaultChangeEvent;
+}
+
+export type VaultRegistryChangeEventHandler = (event: VaultRegistryChangeEvent) => void;
 
 /**
  * Normalize a string into a vault slug using github-slugger (battle-tested, not
@@ -260,6 +267,8 @@ export type VaultRegistryResult<T extends object = object> =
  */
 export class VaultRegistry {
   private readonly instances: Map<string, VaultInstance>;
+  private readonly eventHandlers = new Set<VaultRegistryChangeEventHandler>();
+  private readonly eventUnsubscribers = new Map<string, () => void>();
 
   private constructor(
     private readonly vaultsHome: string,
@@ -286,6 +295,22 @@ export class VaultRegistry {
   /** Resolve a vault's live instance by slug, or `undefined` when unknown. */
   get(id: string): VaultInstance | undefined {
     return this.instances.get(id);
+  }
+
+  onVaultEvent(handler: VaultRegistryChangeEventHandler): () => void {
+    this.eventHandlers.add(handler);
+    if (this.eventHandlers.size === 1) {
+      for (const instance of this.instances.values()) {
+        this.subscribeInstance(instance);
+      }
+    }
+
+    return () => {
+      this.eventHandlers.delete(handler);
+      if (this.eventHandlers.size === 0) {
+        this.unsubscribeAllInstances();
+      }
+    };
   }
 
   /**
@@ -332,7 +357,9 @@ export class VaultRegistry {
     await seedVaultFromStarterKit(root);
 
     const entry: VaultRegistryEntry = { slug, displayName, root };
-    this.instances.set(slug, buildVaultInstance(entry));
+    const instance = buildVaultInstance(entry);
+    this.instances.set(slug, instance);
+    this.subscribeInstance(instance);
 
     return { ok: true, vault: { id: slug, displayName } };
   }
@@ -372,6 +399,7 @@ export class VaultRegistry {
       return { ok: false, error: 'not_found', message: `No vault with id "${id}".` };
     }
 
+    this.unsubscribeInstance(id);
     await instance.manager.close();
 
     await mkdir(this.trashHome, { recursive: true });
@@ -385,7 +413,38 @@ export class VaultRegistry {
 
   /** Close every vault's document session manager (used on daemon shutdown). */
   async close(): Promise<void> {
+    this.unsubscribeAllInstances();
     await Promise.all([...this.instances.values()].map((instance) => instance.manager.close()));
+  }
+
+  private subscribeInstance(instance: VaultInstance): void {
+    if (this.eventHandlers.size === 0 || this.eventUnsubscribers.has(instance.entry.slug)) return;
+
+    const unsubscribe = instance.service.onEvent((event) => {
+      const registryEvent = { vaultSlug: instance.entry.slug, event };
+      for (const handler of this.eventHandlers) {
+        try {
+          handler(registryEvent);
+        } catch (error) {
+          console.warn('KB-2 vault registry event handler failed.', error);
+        }
+      }
+    });
+    this.eventUnsubscribers.set(instance.entry.slug, unsubscribe);
+  }
+
+  private unsubscribeInstance(slug: string): void {
+    const unsubscribe = this.eventUnsubscribers.get(slug);
+    if (!unsubscribe) return;
+
+    this.eventUnsubscribers.delete(slug);
+    unsubscribe();
+  }
+
+  private unsubscribeAllInstances(): void {
+    for (const slug of [...this.eventUnsubscribers.keys()]) {
+      this.unsubscribeInstance(slug);
+    }
   }
 }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@kb-2/doc-session": "workspace:*",
     "@kb-2/editor": "workspace:*",
     "@kb-2/ui": "workspace:*",
+    "@tanstack/svelte-query": "^6.1.18",
     "lib0": "0.2.117",
     "svelte": "catalog:",
     "y-protocols": "1.0.7",

--- a/apps/web/src/lib/realtime/index.ts
+++ b/apps/web/src/lib/realtime/index.ts
@@ -1,0 +1,3 @@
+export { createKbQueryClient } from './query-client';
+export type { KbQueryClient } from './query-client';
+export { queryKeys } from './query-keys';

--- a/apps/web/src/lib/realtime/query-client.ts
+++ b/apps/web/src/lib/realtime/query-client.ts
@@ -1,0 +1,18 @@
+import { QueryClient } from '@tanstack/svelte-query';
+
+export interface KbQueryClient {
+  client: QueryClient;
+}
+
+export function createKbQueryClient(): KbQueryClient {
+  return {
+    client: new QueryClient({
+      defaultOptions: {
+        queries: {
+          refetchOnWindowFocus: false,
+          staleTime: 0,
+        },
+      },
+    }),
+  };
+}

--- a/apps/web/src/lib/realtime/query-keys.ts
+++ b/apps/web/src/lib/realtime/query-keys.ts
@@ -1,0 +1,5 @@
+export const queryKeys = {
+  vaults: () => ['vaults'] as const,
+  vault: (vaultId: string) => ['vault', vaultId] as const,
+  tree: (vaultId: string) => ['vault', vaultId, 'tree'] as const,
+} as const;

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { QueryClientProvider } from '@tanstack/svelte-query';
   import { createAppState, setAppStateContext } from '$lib/app-state';
+  import { createKbQueryClient } from '$lib/realtime';
   import '../app.css';
 
   let { children } = $props();
@@ -11,6 +13,7 @@
   // store instance.
   const appState = createAppState({ storage: window.localStorage });
   setAppStateContext(appState);
+  const { client: queryClient } = createKbQueryClient();
 
   // Color-mode resolver. Subscribes to the persisted `colorMode`, then
   // resolves `'system'` against `prefers-color-scheme` and writes:
@@ -55,4 +58,6 @@
   });
 </script>
 
-{@render children()}
+<QueryClientProvider client={queryClient}>
+  {@render children()}
+</QueryClientProvider>

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -52,12 +52,40 @@
   import { buildStarredViewData } from '$lib/favorites-data';
   import { createViewportStore } from '$lib/viewport.svelte';
   import { onMount, untrack } from 'svelte';
+  import { createQueries, createQuery, useQueryClient } from '@tanstack/svelte-query';
+  import { queryKeys } from '$lib/realtime';
 
   interface TreeEntry {
     path: string;
     kind: 'file' | 'folder';
     metadata?: { color?: AccentName; icon?: string | null };
   }
+
+  type TreeDirtyEventKind =
+    | 'file_created'
+    | 'folder_created'
+    | 'file_deleted'
+    | 'folder_deleted'
+    | 'file_moved'
+    | 'folder_moved'
+    | 'folder_metadata_changed'
+    | 'external_change_detected';
+
+  interface VaultChangeEvent {
+    kind: string;
+    path?: string;
+  }
+
+  const TREE_DIRTY_EVENT_KINDS = new Set<string>([
+    'file_created',
+    'folder_created',
+    'file_deleted',
+    'folder_deleted',
+    'file_moved',
+    'folder_moved',
+    'folder_metadata_changed',
+    'external_change_detected',
+  ] satisfies TreeDirtyEventKind[]);
 
   // The dialog the orchestration layer currently has open. Each variant
   // carries the operation it will perform on submit; `busy`/`error`
@@ -207,6 +235,32 @@
   // owns mutation + localStorage; the template builds its view model from
   // this list plus the live tree.
   let favorites = $state<FavoriteEntry[]>(appState.getState().favorites);
+  const queryClient = useQueryClient();
+  const vaultsQuery = createQuery<VaultSummary[]>(() => ({
+    queryKey: queryKeys.vaults(),
+    queryFn: () => kbService.listVaults(),
+    staleTime: 30_000,
+  }));
+  type TreeQueryShape = { queryFnData: LocalTreeNode[] };
+  const treeQueries = createQueries<TreeQueryShape[], Record<string, LocalTreeNode[]>>(() => {
+    const ids = knownVaults.map((vault) => vault.id);
+    return {
+      queries: ids.map((id) => ({
+        queryKey: queryKeys.tree(id),
+        queryFn: () => fetchVaultTree(id),
+        staleTime: 30_000,
+      })),
+      combine: (results): Record<string, LocalTreeNode[]> => {
+        const next: Record<string, LocalTreeNode[]> = {};
+        for (let i = 0; i < ids.length; i += 1) {
+          const id = ids[i];
+          const data = results[i]?.data;
+          if (id !== undefined) next[id] = data ?? [];
+        }
+        return next;
+      },
+    };
+  });
 
   // Render-ready starred rows + the path sets the tree menus read to
   // pick Favorite vs Unfavorite. Recomputed when favorites or the tree
@@ -685,12 +739,25 @@
   // caller can pick a default vault on first load.
   async function refreshVaults(): Promise<VaultSummary[]> {
     try {
-      knownVaults = await kbService.listVaults();
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.vaults(),
+        exact: true,
+      });
+      knownVaults = await queryClient.fetchQuery({
+        queryKey: queryKeys.vaults(),
+        queryFn: () => kbService.listVaults(),
+        staleTime: 30_000,
+      });
       return knownVaults;
     } catch (caught) {
       error = caught instanceof Error ? caught.message : String(caught);
       return knownVaults;
     }
+  }
+
+  async function fetchVaultTree(vaultId: string): Promise<LocalTreeNode[]> {
+    const entries = await kbService.tree(vaultId);
+    return buildTree(entries as TreeEntry[]);
   }
 
   // Fetch one vault's tree into the per-vault cache. The rail groups by
@@ -699,8 +766,12 @@
   async function loadVaultTree(vaultId: string): Promise<void> {
     if (!vaultId) return;
     try {
-      const entries = await kbService.tree(vaultId);
-      vaultTrees = { ...vaultTrees, [vaultId]: buildTree(entries as TreeEntry[]) };
+      const tree = await queryClient.fetchQuery({
+        queryKey: queryKeys.tree(vaultId),
+        queryFn: () => fetchVaultTree(vaultId),
+        staleTime: 30_000,
+      });
+      vaultTrees = { ...vaultTrees, [vaultId]: tree };
     } catch (caught) {
       error = caught instanceof Error ? caught.message : String(caught);
     }
@@ -713,7 +784,16 @@
 
   // Refresh the ACTIVE vault's tree — used after a file/folder mutation.
   async function refreshTree(): Promise<void> {
-    await loadVaultTree(activeVaultId);
+    await refreshTreeForVault(activeVaultId);
+  }
+
+  async function refreshTreeForVault(vaultId: string): Promise<void> {
+    if (!vaultId) return;
+    await queryClient.invalidateQueries({
+      queryKey: queryKeys.tree(vaultId),
+      exact: true,
+    });
+    await loadVaultTree(vaultId);
   }
 
   // ---- Path helpers for the file-management operations ----------------
@@ -1146,6 +1226,56 @@
   function nameFromPath(path: string): string {
     return path.split('/').filter(Boolean).at(-1) ?? path;
   }
+
+  function isTreeDirtyEvent(event: VaultChangeEvent): boolean {
+    return TREE_DIRTY_EVENT_KINDS.has(event.kind)
+      && (event.kind !== 'external_change_detected' || event.path === '');
+  }
+
+  // TanStack query data is the source of truth for vault list + trees.
+  // The route keeps the existing `$state` mirrors so the rest of the
+  // editor shell can stay prop-driven while query invalidation handles
+  // freshness.
+  $effect(() => {
+    if (vaultsQuery.data !== undefined) {
+      knownVaults = vaultsQuery.data;
+    }
+    if (vaultsQuery.error) {
+      error = vaultsQuery.error instanceof Error
+        ? vaultsQuery.error.message
+        : 'Failed to load vaults.';
+    }
+  });
+
+  $effect(() => {
+    vaultTrees = treeQueries;
+  });
+
+  $effect(() => {
+    const ids = knownVaults.map((vault) => vault.id);
+    if (ids.length === 0 || typeof EventSource === 'undefined') return undefined;
+
+    const sources = ids.map((id) => {
+      const source = new EventSource(`/api/vaults/${encodeURIComponent(id)}/events`);
+      source.addEventListener('change', (message) => {
+        try {
+          const event = JSON.parse((message as MessageEvent).data) as VaultChangeEvent;
+          if (isTreeDirtyEvent(event)) {
+            void refreshTreeForVault(id);
+          }
+        } catch (caught) {
+          console.warn('Failed to process vault change event.', caught);
+        }
+      });
+      return source;
+    });
+
+    return () => {
+      for (const source of sources) {
+        source.close();
+      }
+    };
+  });
 
   // Mirror the store's persisted choice so the toggle icon reflects the
   // live preference. The root layout owns applying the mode to the DOM.

--- a/apps/web/src/test/AppStateHarness.svelte
+++ b/apps/web/src/test/AppStateHarness.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { QueryClientProvider } from '@tanstack/svelte-query';
   import { createAppState, setAppStateContext } from '$lib/app-state';
+  import { createKbQueryClient } from '$lib/realtime';
   import Page from '../routes/+page.svelte';
 
   // Mirror the root layout: build the app-state store once and publish it
@@ -8,6 +10,9 @@
   // so the harness stands in for the layout.
   const appState = createAppState({ storage: window.localStorage });
   setAppStateContext(appState);
+  const { client: queryClient } = createKbQueryClient();
 </script>
 
-<Page />
+<QueryClientProvider client={queryClient}>
+  <Page />
+</QueryClientProvider>

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -161,6 +161,33 @@ describe('ChunkedHttpRequestAssembler', () => {
 });
 
 describe('TunnelClient typed relay RPC', () => {
+  it('sends daemon-origin relay event frames over the control socket', () => {
+    const control = new FakeSocket();
+    control.open();
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+    });
+    (client as unknown as { control: FakeSocket }).control = control;
+
+    expect(client.sendRelayEvent({
+      topic: 'vault.tree.changed',
+      resource: { vaultSlug: 'demo-vault' },
+    })).toBe(true);
+
+    expect(control.sent).toHaveLength(1);
+    expect(JSON.parse(Buffer.from(control.sent[0].data as Uint8Array).toString('utf8'))).toEqual({
+      type: 'relay.frame',
+      frame: {
+        type: 'event',
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+        topic: 'vault.tree.changed',
+        resource: { vaultSlug: 'demo-vault' },
+      },
+    });
+  });
+
   it('handles the vault.list capability through the daemon vault API', async () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       expect(String(input)).toBe('http://daemon.test/api/vaults');

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -14,6 +14,7 @@ import {
   encodeTunnelMessage,
   parseRelayFrame,
   type RelayFrame,
+  type RelayJsonObject,
   type RelayJsonValue,
   type RelayRpcRequestFrame,
   type RelayRpcResponseFrame,
@@ -49,6 +50,13 @@ export type TunnelClientStatus = {
   started: boolean;
   controlConnected: boolean;
   reconnectScheduled: boolean;
+};
+
+export type TunnelRelayEventInput = {
+  topic: string;
+  id?: string;
+  payload?: RelayJsonValue;
+  resource?: RelayJsonObject;
 };
 
 export type BackoffOptions = {
@@ -131,6 +139,37 @@ export class TunnelClient {
       controlConnected: this.control?.readyState === WebSocket.OPEN,
       reconnectScheduled: this.reconnectTimer !== undefined,
     };
+  }
+
+  sendRelayEvent(event: TunnelRelayEventInput): boolean {
+    const control = this.control;
+    if (!control || control.readyState !== WebSocket.OPEN) {
+      this.logger.log('debug', 'relay event skipped because control is not open', {
+        topic: event.topic,
+      });
+      return false;
+    }
+
+    try {
+      control.send(encodeJsonBytes({
+        type: 'relay.frame',
+        frame: {
+          type: 'event',
+          version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+          topic: event.topic,
+          ...(event.id !== undefined ? { id: event.id } : {}),
+          ...(event.payload !== undefined ? { payload: { encoding: 'json', value: event.payload } } : {}),
+          ...(event.resource !== undefined ? { resource: event.resource } : {}),
+        },
+      }));
+      return true;
+    } catch (error) {
+      this.logger.log('warn', 'relay event send failed', {
+        topic: event.topic,
+        error: String(error),
+      });
+      return false;
+    }
   }
 
   private connectControl(): void {

--- a/packages/vault-service/src/index.test.ts
+++ b/packages/vault-service/src/index.test.ts
@@ -263,13 +263,23 @@ describe('vault service failure mapping', () => {
 
     const session = sessions.getSession('notes/a.md');
     await session.open();
+    await expect(service.createNote({
+      path: 'notes/a.md',
+      content: 'live overwrite\n',
+      overwrite: true,
+      actor: { kind: 'user' }
+    })).resolves.toMatchObject({
+      ok: true,
+      path: 'notes/a.md',
+      live: true
+    });
     session.ydoc.getText('markdown').insert(session.ydoc.getText('markdown').length, 'SECRET_SERVICE_EVENT');
     await expect(service.flushDirtySessions()).resolves.toMatchObject({
       ok: true,
       flushed: 1,
       durableAsOf: expect.any(String)
     });
-    await expect(readFile(join(root, 'notes', 'a.md'), 'utf8')).resolves.toBe('overwritten\nSECRET_SERVICE_EVENT');
+    await expect(readFile(join(root, 'notes', 'a.md'), 'utf8')).resolves.toBe('live overwrite\nSECRET_SERVICE_EVENT');
 
     await expect(service.moveNote({
       fromPath: 'notes/a.md',
@@ -294,6 +304,7 @@ describe('vault service failure mapping', () => {
       'content_persisted',
       'folder_metadata_changed',
       'content_persisted',
+      'content_persisted',
       'file_moved',
       'file_deleted'
     ]);
@@ -310,6 +321,10 @@ describe('vault service failure mapping', () => {
       actor: { kind: 'system' }
     });
     expect(events[5]).toMatchObject({
+      path: 'notes/a.md',
+      actor: { kind: 'system' }
+    });
+    expect(events[6]).toMatchObject({
       path: 'notes/moved.md',
       fromPath: 'notes/a.md',
       toPath: 'notes/moved.md'
@@ -342,6 +357,20 @@ describe('vault service failure mapping', () => {
       actor: { kind: 'system' }
     }));
     await expect(session.getContent()).resolves.toBe('external\n');
+  });
+
+  it('emits a root-level external event when the cold file tree changes on disk', async () => {
+    const service = createVaultService({ vaultRoot: root, documentSessions: sessions });
+    const events: VaultChangeEvent[] = [];
+    const unsubscribe = service.onEvent((event) => events.push(event));
+
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await writeFileWithParents(join(root, 'external-tree', 'added.md'), 'added\n');
+
+    await waitUntil(() => events.some((event) =>
+      event.kind === 'external_change_detected' && event.path === ''
+    ), () => `Timed out waiting for external tree event; events=${JSON.stringify(events)}`);
+    unsubscribe();
   });
 
   it('uses cold disk paths for file move and delete when no session is open', async () => {

--- a/packages/vault-service/src/index.ts
+++ b/packages/vault-service/src/index.ts
@@ -29,6 +29,7 @@ import {
   type AuditChangeEventOptions,
   type AuditEntry,
   type FolderMetadataInput,
+  type VaultEntry,
   type VaultActor,
   type VaultErrorCode,
   type VaultResult
@@ -84,6 +85,8 @@ export interface VaultChangeEvent {
 
 export type VaultChangeEventHandler = (event: VaultChangeEvent) => void;
 
+const TREE_WATCH_INTERVAL_MS = 1_000;
+
 export interface EditNoteInput {
   path: string;
   baseline: string;
@@ -127,6 +130,9 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
   const ctx = (actor?: VaultActor) => ({ root: options.vaultRoot, ...(actor ? { actor } : {}) });
   const eventHandlers = new Set<VaultChangeEventHandler>();
   const emitChange = (event: VaultChangeEvent) => {
+    if (event.kind !== 'external_change_detected') {
+      treeWatchSnapshot = undefined;
+    }
     for (const handler of eventHandlers) {
       try {
         handler(event);
@@ -136,6 +142,9 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
     }
   };
   let unsubscribeAudit: (() => void) | undefined;
+  let treeWatchTimer: ReturnType<typeof setInterval> | undefined;
+  let treeWatchSnapshot: string | undefined;
+  let treeWatchInFlight = false;
   const ensureAuditSubscription = () => {
     if (unsubscribeAudit) return;
     unsubscribeAudit = onVaultAudit((audit, input) => {
@@ -143,10 +152,65 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       emitAuditChange(emitChange, audit, input.changeEvent);
     });
   };
+  const pollTreeWatch = async () => {
+    if (treeWatchInFlight) return;
+
+    treeWatchInFlight = true;
+    try {
+      const result = await listVaultTree(ctx(), { depth: Number.MAX_SAFE_INTEGER });
+      if (!result.ok) return;
+
+      const nextSnapshot = treeSnapshot(result.value.entries);
+      if (treeWatchSnapshot === undefined) {
+        treeWatchSnapshot = nextSnapshot;
+        return;
+      }
+
+      if (treeWatchSnapshot === nextSnapshot) return;
+
+      treeWatchSnapshot = nextSnapshot;
+      emitChange({
+        kind: 'external_change_detected',
+        path: '',
+        actor: { kind: 'system' },
+        ts: new Date().toISOString()
+      });
+    } catch (error) {
+      console.warn('KB-2 vault tree watch failed.', error);
+    } finally {
+      treeWatchInFlight = false;
+    }
+  };
+  const ensureTreeWatch = () => {
+    if (treeWatchTimer) return;
+
+    treeWatchSnapshot = undefined;
+    void pollTreeWatch();
+    treeWatchTimer = setInterval(() => {
+      void pollTreeWatch();
+    }, TREE_WATCH_INTERVAL_MS);
+  };
+  const releaseTreeWatch = () => {
+    if (!treeWatchTimer) return;
+
+    clearInterval(treeWatchTimer);
+    treeWatchTimer = undefined;
+    treeWatchSnapshot = undefined;
+    treeWatchInFlight = false;
+  };
+  const ensureEventSources = () => {
+    ensureAuditSubscription();
+    ensureTreeWatch();
+  };
   const releaseAuditSubscription = () => {
     if (eventHandlers.size > 0) return;
     unsubscribeAudit?.();
     unsubscribeAudit = undefined;
+  };
+  const releaseEventSources = () => {
+    if (eventHandlers.size > 0) return;
+    releaseAuditSubscription();
+    releaseTreeWatch();
   };
   options.documentSessions.onEvent((event) => {
     const change = changeEventFromDocumentSessionEvent(event);
@@ -156,10 +220,10 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
   return {
     onEvent(handler) {
       eventHandlers.add(handler);
-      ensureAuditSubscription();
+      ensureEventSources();
       return () => {
         eventHandlers.delete(handler);
-        releaseAuditSubscription();
+        releaseEventSources();
       };
     },
 
@@ -542,6 +606,18 @@ function auditChangeEventKind(
   }
   /* v8 ignore next -- Exhaustive switch guard for future audit operation codes. */
   return assertNever(audit.operation);
+}
+
+function treeSnapshot(entries: VaultEntry[]): string {
+  return JSON.stringify(
+    entries
+      .map((entry) => ({
+        path: entry.path,
+        kind: entry.kind,
+        ...(entry.metadata !== undefined ? { metadata: entry.metadata } : {})
+      }))
+      .sort((a, b) => a.path.localeCompare(b.path) || a.kind.localeCompare(b.kind))
+  );
 }
 
 /* v8 ignore next -- Called only by exhaustive guards when a future union member is missing above. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       '@kb-2/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@tanstack/svelte-query':
+        specifier: ^6.1.18
+        version: 6.1.36(svelte@5.55.5)
       lib0:
         specifier: 0.2.117
         version: 0.2.117
@@ -1461,6 +1464,14 @@ packages:
     resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@tanstack/query-core@5.101.2':
+    resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+
+  '@tanstack/svelte-query@6.1.36':
+    resolution: {integrity: sha512-AVyvXPzBh5OQnWFB7rk9gskciPouayAhU9Vm24uMai+Imf+ZfBEbjOAEtdM41oexFK/cdXmpAIySDSVaAzy9zw==}
+    peerDependencies:
+      svelte: ^5.25.0
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -3966,6 +3977,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
       vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/svelte-query@6.1.36(svelte@5.55.5)':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
+      svelte: 5.55.5
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Summary
- emit daemon-origin `vault.tree.changed` relay events for file-tree structure mutations
- add a cold tree watcher so local filesystem structure changes produce the same dirty signal
- add daemon web TanStack query cache wiring and SSE invalidation for vault tree refreshes

## Verification
- `pnpm --filter @kb-2/tunnel-client test`
- `pnpm --filter @kb-2/vault-service test`
- `pnpm --filter @kb-2/daemon test -- --runInBand src/vault-registry.test.ts`
- `pnpm --filter @kb-2/tunnel-client typecheck`
- `pnpm --filter @kb-2/vault-service typecheck`
- `pnpm --filter @kb-2/daemon typecheck`
- `pnpm --filter @kb-2/web typecheck`
- `pnpm --filter @kb-2/web test`
- `pnpm check`