### PR TITLE
Stop following moved documents in web UI

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -529,11 +529,7 @@
 
   function handleSessionEvent(event: DocumentSessionEvent): void {
     if (event.kind === 'doc-moved') {
-      const nextPath = event.toPath ?? event.path;
-      docDeleted = false;
-      // Navigate to the moved path; the derived document path follows and
-      // the provider effect rebinds onto the new location.
-      void goto(vaultRoute(activeVaultId, nextPath), { replaceState: true, noScroll: true, keepFocus: true });
+      markDocumentNotFound(event.fromPath ?? documentPath);
       void refreshTree();
       return;
     }


### PR DESCRIPTION
Summary
- Treat doc-moved session events like stale-open safety events in the daemon web UI.
- Refresh the tree but keep the current URL/editor path non-editable as Document not found instead of auto-following the renamed/moved document.
- Keeps daemon UI behavior aligned with KB-1 Cloud FC-7759 stale-open acceptance criteria.

Evidence
- `corepack pnpm --dir local --filter @kb-2/web typecheck` from the cloud repo: 0 errors, existing PlaintextEditor Svelte warning only.
- Dev-port manual verification on KB-1 Cloud `9987/9988/7390`: Marcus, Olivia, and daemon UI opened `demo-self-hosted/demo-vault`; direct daemon filesystem create/delete synced to cloud and daemon UI; cloud folder create/delete synced to Olivia and daemon UI; note rename/move/delete and folder rename/move/delete synced; stale open note became Document not found in both Olivia and daemon UI after rename and delete.

Cloud follow-up
- Consumed by metatheoryinc/kb-1-cloud#107 for FC-7759.

No co-author lines.