### PR TITLE
Port editor byline

### DIFF
--- a/apps/web/src/lib/yjs/demo-document-provider.test.ts
+++ b/apps/web/src/lib/yjs/demo-document-provider.test.ts
@@ -22,6 +22,7 @@ import {
   DEMO_DOCUMENT_TEXT_NAME,
   DEMO_DOCUMENT_YJS_PATH,
   isDemoDocumentProviderOpenError,
+  type DemoDocumentProviderSaveState,
 } from './demo-document-provider';
 
 const messageSync = 0;
@@ -84,7 +85,11 @@ describe('demo document provider', () => {
     const port = (server.address() as AddressInfo).port;
 
     const url = `ws://127.0.0.1:${port}${DEMO_DOCUMENT_YJS_PATH}`;
-    const provider = createDemoDocumentProvider({ url });
+    const saveStates: DemoDocumentProviderSaveState[] = [];
+    const provider = createDemoDocumentProvider({
+      url,
+      onSaveState: (state) => saveStates.push(state),
+    });
     const raw = await connectRawYjsClient(url);
 
     await waitForContent(
@@ -103,6 +108,12 @@ describe('demo document provider', () => {
     await waitForDiskContent(
       filePath,
       (content) => content.includes('provider edit') && content.includes('raw client edit'),
+    );
+    await waitUntil(
+      () =>
+        saveStates.some((state) => state.status === 'saving') &&
+        saveStates[saveStates.length - 1]?.status === 'saved',
+      () => `Timed out waiting for ack-backed save state: ${JSON.stringify(saveStates)}`
     );
 
     raw.close();

--- a/apps/web/src/lib/yjs/demo-document-provider.ts
+++ b/apps/web/src/lib/yjs/demo-document-provider.ts
@@ -5,8 +5,11 @@ import * as Y from 'yjs';
 import {
   MESSAGE_SESSION_EVENT,
   MESSAGE_SYNC,
+  MESSAGE_SYNC_UPDATE_ACK,
   MESSAGE_SYNCED,
   decodeSessionEvent,
+  decodeSyncUpdateAck,
+  encodeAckedSyncUpdate,
   type DocumentSessionEvent,
 } from '@kb-2/doc-session/protocol';
 
@@ -23,8 +26,13 @@ export type DemoDocumentProviderStatus =
 export interface DemoDocumentProvider {
   doc: Y.Doc;
   text: Y.Text;
-  destroy: () => void;
+  destroy: () => DemoDocumentProviderSaveState;
 }
+
+export type DemoDocumentProviderSaveState =
+  | { status: 'saved'; pending: 0 }
+  | { status: 'saving'; pending: number }
+  | { status: 'failed'; pending: number; message: string };
 
 export interface DemoDocumentProviderOpenFailure {
   ok: false;
@@ -46,9 +54,19 @@ export interface DemoDocumentProviderOptions {
   path?: string;
   onStatus?: (status: DemoDocumentProviderStatus) => void;
   onError?: (error: unknown) => void;
+  onSaveState?: (state: DemoDocumentProviderSaveState) => void;
   onSessionEvent?: (event: DocumentSessionEvent) => void;
   onSynced?: () => void;
 }
+
+interface PendingSaveAck {
+  ackId: string;
+  update: Uint8Array;
+  timedOut: boolean;
+  timeout?: ReturnType<typeof setTimeout>;
+}
+
+export const DOCUMENT_SAVE_ACK_TIMEOUT_MS = 10_000;
 
 export function createDemoDocumentProvider(
   options: DemoDocumentProviderOptions = {},
@@ -59,7 +77,89 @@ export function createDemoDocumentProvider(
   socket.binaryType = 'arraybuffer';
 
   let destroyed = false;
+  let latestSaveState: DemoDocumentProviderSaveState = { status: 'saved', pending: 0 };
+  let nextSaveAckSeq = 0;
+  const saveAckPrefix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  const pendingSaveAcks = new Map<string, PendingSaveAck>();
   options.onStatus?.('connecting');
+
+  const publishSaveState = (): void => {
+    if (pendingSaveAcks.size === 0) {
+      latestSaveState = { status: 'saved', pending: 0 };
+      options.onSaveState?.(latestSaveState);
+      return;
+    }
+    const timedOut = Array.from(pendingSaveAcks.values()).some((pending) => pending.timedOut);
+    if (timedOut) {
+      latestSaveState = {
+        status: 'failed',
+        pending: pendingSaveAcks.size,
+        message:
+          'KB-2 has not confirmed your latest edit is saved. Keep this tab open while the connection recovers.',
+      };
+      options.onSaveState?.(latestSaveState);
+      return;
+    }
+    latestSaveState = { status: 'saving', pending: pendingSaveAcks.size };
+    options.onSaveState?.(latestSaveState);
+  };
+
+  const saveStateOnDestroy = (): DemoDocumentProviderSaveState => {
+    if (pendingSaveAcks.size === 0) return latestSaveState;
+    if (latestSaveState.status === 'failed') return latestSaveState;
+    return { status: 'saving', pending: pendingSaveAcks.size };
+  };
+
+  const armSaveAckTimeout = (pending: PendingSaveAck): void => {
+    if (pending.timeout || pending.timedOut || destroyed) return;
+    pending.timeout = setTimeout(() => {
+      const activePending = pendingSaveAcks.get(pending.ackId);
+      if (!activePending || destroyed) return;
+      activePending.timedOut = true;
+      activePending.timeout = undefined;
+      publishSaveState();
+    }, DOCUMENT_SAVE_ACK_TIMEOUT_MS);
+  };
+
+  const sendAckedUpdate = (pending: PendingSaveAck): boolean => {
+    if (socket.readyState !== WebSocket.OPEN) return false;
+    socket.send(new Uint8Array(encodeAckedSyncUpdate({ ackId: pending.ackId, update: pending.update })));
+    armSaveAckTimeout(pending);
+    return true;
+  };
+
+  const drainPendingSaveAcks = (): void => {
+    for (const pending of pendingSaveAcks.values()) {
+      sendAckedUpdate(pending);
+    }
+  };
+
+  const acknowledgeSave = (ackId: string): void => {
+    const pending = pendingSaveAcks.get(ackId);
+    if (!pending) return;
+    if (pending.timeout) clearTimeout(pending.timeout);
+    pendingSaveAcks.delete(ackId);
+    publishSaveState();
+  };
+
+  const trackLocalUpdate = (update: Uint8Array): void => {
+    const ackId = `${saveAckPrefix}:${++nextSaveAckSeq}`;
+    const pending: PendingSaveAck = {
+      ackId,
+      update,
+      timedOut: false,
+    };
+    pendingSaveAcks.set(ackId, pending);
+    sendAckedUpdate(pending);
+    publishSaveState();
+  };
+
+  const clearPendingSaveAcks = (): void => {
+    for (const pending of pendingSaveAcks.values()) {
+      if (pending.timeout) clearTimeout(pending.timeout);
+    }
+    pendingSaveAcks.clear();
+  };
 
   const sendSync = (write: (encoder: encoding.Encoder) => void): void => {
     if (socket.readyState !== WebSocket.OPEN) return;
@@ -71,9 +171,7 @@ export function createDemoDocumentProvider(
 
   const updateHandler = (update: Uint8Array, origin: unknown): void => {
     if (origin === socket || destroyed) return;
-    sendSync((encoder) => {
-      syncProtocol.writeUpdate(encoder, update);
-    });
+    trackLocalUpdate(update);
   };
 
   doc.on('update', updateHandler);
@@ -83,6 +181,7 @@ export function createDemoDocumentProvider(
     sendSync((encoder) => {
       syncProtocol.writeSyncStep1(encoder, doc);
     });
+    drainPendingSaveAcks();
   });
 
   socket.addEventListener('message', (event) => {
@@ -98,6 +197,12 @@ export function createDemoDocumentProvider(
         if (event) {
           options.onSessionEvent?.(event);
         }
+        return;
+      }
+
+      if (messageType === MESSAGE_SYNC_UPDATE_ACK) {
+        const ack = decodeSyncUpdateAck(decoder);
+        if (ack) acknowledgeSave(ack.ackId);
         return;
       }
 
@@ -138,11 +243,14 @@ export function createDemoDocumentProvider(
     doc,
     text,
     destroy: () => {
+      const finalSaveState = saveStateOnDestroy();
       destroyed = true;
+      clearPendingSaveAcks();
       doc.off('update', updateHandler);
       socket.close(1000, 'Editor unmounted');
       doc.destroy();
       options.onStatus?.('closed');
+      return finalSaveState;
     },
   };
 }

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -9,6 +9,7 @@
   } from '$lib/yjs/demo-document-provider';
   import type {
     DemoDocumentProvider,
+    DemoDocumentProviderSaveState,
     DemoDocumentProviderStatus,
   } from '$lib/yjs/demo-document-provider';
   import {
@@ -20,6 +21,7 @@
   } from '@kb-2/editor';
   import {
     ConfirmDialog,
+    DocumentByline,
     DocumentNotFoundState,
     EditorSaveNotifications,
     EmptyVaultsState,
@@ -161,6 +163,7 @@
   let providerGeneration = 0;
   let providerSynced = $state(false);
   let status = $state<DemoDocumentProviderStatus>('connecting');
+  let saveState = $state<DemoDocumentProviderSaveState>({ status: 'saved', pending: 0 });
   let error = $state<string | null>(null);
   let externalMergeVisible = $state(false);
   let externalChangeVisible = $state(false);
@@ -454,11 +457,14 @@
           ? 'Daemon · error'
           : 'Daemon · closed',
   );
+  const saveFailureActive = $derived(saveState.status === 'failed');
   const daemonStatus = $derived<'open' | 'connecting' | 'closed' | 'error'>(
-    persistFailureActive || status === 'error'
+    persistFailureActive || saveFailureActive || status === 'error'
       ? 'error'
       : status === 'open'
-        ? 'open'
+        ? saveState.status === 'saving'
+          ? 'connecting'
+          : 'open'
         : status === 'connecting' || status === 'syncing'
           ? 'connecting'
           : 'closed',
@@ -477,7 +483,7 @@
   // no label either.
   const statusLabel = $derived.by<string | undefined>(() => {
     if (viewingFolder) return undefined;
-    if (persistFailureActive) return 'Not saving';
+    if (persistFailureActive || saveFailureActive) return 'Not saving';
     switch (status) {
       // Success + optimistic states stay silent — nothing rendered.
       case 'open':
@@ -491,6 +497,31 @@
         return 'Disconnected';
     }
   });
+
+  const bylineStatusLabel = $derived.by<string | undefined>(() => {
+    if (viewingFolder) return undefined;
+    if (persistFailureActive || saveFailureActive) return 'Not saving';
+    switch (status) {
+      case 'open':
+        return saveState.status === 'saving' ? 'Saving…' : 'Saved';
+      case 'syncing':
+      case 'connecting':
+        return 'Connecting…';
+      case 'error':
+        return 'Connection error';
+      default:
+        return 'Disconnected';
+    }
+  });
+
+  const bylineStatusTone = $derived<'normal' | 'error'>(
+    persistFailureActive ||
+    saveFailureActive ||
+    status === 'error' ||
+    status === 'closed'
+      ? 'error'
+      : 'normal',
+  );
 
   // The document header breadcrumb trail. Built in the app from the
   // active path so the package stays free of path-parsing policy
@@ -639,6 +670,7 @@
     providerGeneration = generation;
     providerSynced = false;
     status = 'connecting';
+    saveState = { status: 'saved', pending: 0 };
     error = null;
     notFoundPath = null;
     docDeleted = false;
@@ -658,6 +690,10 @@
           return;
         }
         error = caught instanceof Error ? caught.message : String(caught);
+      },
+      onSaveState: (nextSaveState) => {
+        if (generation !== providerGeneration) return;
+        saveState = nextSaveState;
       },
       onSessionEvent: (event) => {
         if (generation !== providerGeneration) return;
@@ -733,6 +769,7 @@
     provider = null;
     providerSynced = false;
     status = 'connecting';
+    saveState = { status: 'saved', pending: 0 };
     notFoundPath = null;
     docDeleted = false;
   }
@@ -1553,6 +1590,7 @@
       provider?.destroy();
       provider = null;
       providerSynced = false;
+      saveState = { status: 'saved', pending: 0 };
     };
   });
 </script>
@@ -1569,7 +1607,7 @@
   <EditorSaveNotifications
     externalMergeVisible={externalMergeVisible}
     externalChangeVisible={externalChangeVisible}
-    persistFailureActive={persistFailureActive}
+    persistFailureActive={persistFailureActive || saveFailureActive}
     persistRecoveredVisible={persistRecoveredVisible}
     docDeleted={docDeleted}
     copy={editorSaveNotificationCopy}
@@ -1620,6 +1658,10 @@
           <DocumentNotFoundState path={documentPath} />
         {:else if provider && providerSynced}
           <div class="doc-column">
+            <DocumentByline
+              statusLabel={bylineStatusLabel}
+              statusTone={bylineStatusTone}
+            />
             {#key provider}
               <PlaintextEditor
                 ydoc={provider.doc}
@@ -1855,10 +1897,6 @@
      band. */
   .doc-body :global(.vault-editor) {
     background: transparent;
-  }
-
-  .doc-body :global(.plaintext-editor .cm-content) {
-    padding-top: 28px;
   }
 
   .loading {

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -45,6 +45,7 @@ export type {
   HealthResponse,
 } from "./layout/LocalStatusShell.svelte";
 export { default as DocumentSaveBanner } from "./notifications/DocumentSaveBanner.svelte";
+export { default as DocumentByline } from "./local-editor/DocumentByline.svelte";
 export { default as DocumentHeader } from "./local-editor/DocumentHeader.svelte";
 export { default as DocumentHeaderMenu } from "./local-editor/DocumentHeaderMenu.svelte";
 export { default as FolderCanvas } from "./local-editor/FolderCanvas.svelte";

--- a/packages/ui/src/lib/local-editor/DocumentByline.stories.ts
+++ b/packages/ui/src/lib/local-editor/DocumentByline.stories.ts
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/svelte';
+import DocumentByline from './DocumentByline.svelte';
+
+const meta = {
+  title: 'App/Local Editor/DocumentByline',
+  component: DocumentByline,
+  args: {
+    statusLabel: 'Saved',
+    statusTone: 'normal'
+  }
+} satisfies Meta<typeof DocumentByline>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Saved: Story = {};
+
+export const Saving: Story = {
+  args: { statusLabel: 'Saving…' }
+};
+
+export const Error: Story = {
+  args: { statusLabel: 'Not saving', statusTone: 'error' }
+};

--- a/packages/ui/src/lib/local-editor/DocumentByline.svelte
+++ b/packages/ui/src/lib/local-editor/DocumentByline.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  /**
+   * Ported from KB-1:
+   * apps/@kb-1/web/src/lib/components/app/canvas/document/DocumentByline.svelte
+   *
+   * Local daemon delta: metadata/history links are intentionally omitted until
+   * those surfaces exist here. The right-side snippet lets cloud pass presence
+   * avatars while the daemon uses the same byline minus presence.
+   */
+  interface Props {
+    statusLabel?: string;
+    statusTone?: "normal" | "error";
+    right?: import("svelte").Snippet;
+  }
+
+  let {
+    statusLabel,
+    statusTone = "normal",
+    right,
+  }: Props = $props();
+</script>
+
+<div class="strip" data-testid="document-byline">
+  <div class="left">
+    {#if statusLabel}
+      <span class="status" class:error={statusTone === "error"}>{statusLabel}</span>
+    {/if}
+  </div>
+
+  {#if right}
+    <div class="right">
+      {@render right()}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .strip {
+    /* Scrolls with the document — reads as the doc's own preamble,
+       not floating chrome. */
+
+    /* `position: relative` + `z-index: 1` lifts this strip into its
+       own stacking context above DocumentHeader's `border-bottom`, so
+       hover popovers opened from any right-side content paint over the
+       chrome rule rather than clipping under it. Same containment-context
+       shape as KB-1's byline. */
+    position: relative;
+    z-index: 1;
+
+    /* The wrapping `.doc-column` owns horizontal geometry; this strip
+       fills it width:100%. Drop horizontal padding entirely so the
+       byline text aligns flush with the editor's column-left edge. */
+    padding: 32px 0 6px 0;
+
+    display: flex;
+    align-items: center;
+    column-gap: 14px;
+
+    color: var(--rd-ink-3);
+    font-family: var(--rd-mono);
+    font-size: 11px;
+    letter-spacing: 0.02em;
+  }
+
+  .left,
+  .right {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .left {
+    flex: 1;
+    min-width: 0;
+    flex-wrap: wrap;
+  }
+
+  .right {
+    flex-shrink: 0;
+    margin-left: auto;
+  }
+
+  .status {
+    color: var(--rd-ink-4);
+  }
+
+  .status.error {
+    color: rgb(220 38 38);
+  }
+
+  @media (max-width: 880px) {
+    .strip {
+      padding: 16px 0 6px;
+    }
+  }
+</style>


### PR DESCRIPTION
Part of KB-1 Cloud FC-4245.

Summary:
- Add the KB-1-style DocumentByline component to the daemon UI package.
- Render it in the daemon editor route without presence, per the daemon content-not-people boundary.
- Back the saved indicator with ack-tracked local Yjs update confirmation instead of socket-open status.

Verification:
- pnpm --filter @kb-2/web test -- demo-document-provider.test.ts
- pnpm --filter @kb-2/web test -- local-editor-route.test.ts
- Cloud parent branch also ran pnpm check and full pnpm test:e2e green.