### PR TITLE
Add daemon file history store

### DIFF
--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -294,6 +294,15 @@ function registerVaultDataRoutes(
   router.get(`${basePath}/files/*`, async (context) => {
     const resolved = scope.resolve(context);
     if (!resolved.ok) return mapServiceResult(context, resolved);
+    if (context.req.path.endsWith('/history')) {
+      const filePath = filePathParam(context.req.path, scope.filesPrefix(context), '/history');
+      return mapServiceResult(context, await resolved.service.listNoteHistory({
+        path: filePath,
+        before: context.req.query('before'),
+        beforeId: context.req.query('beforeId'),
+        limit: queryNumber(context, 'limit')
+      }));
+    }
     const filePath = filePathParam(context.req.path, scope.filesPrefix(context));
     return mapServiceResult(context, await resolved.service.readNote({ path: filePath }));
   });

--- a/apps/daemon/src/config.test.ts
+++ b/apps/daemon/src/config.test.ts
@@ -4,7 +4,9 @@ import {
   DEFAULT_HOST,
   DEFAULT_PORT,
   createDaemonConfig,
+  DEFAULT_HISTORY_COALESCE_WINDOW_MS,
   resolveActorDefault,
+  resolveHistoryCoalesceWindowMs,
   resolveKb2Home,
   resolvePort,
   resolveRelayConfig,
@@ -56,6 +58,7 @@ describe('daemon config', () => {
         token: 'test-token'
       },
       actorDefault: 'user',
+      historyCoalesceWindowMs: DEFAULT_HISTORY_COALESCE_WINDOW_MS,
       kb2Home,
       daemonHome: join(kb2Home, 'daemon'),
       vaultsHome: join(kb2Home, 'vaults'),
@@ -72,6 +75,7 @@ describe('daemon config', () => {
     expect(config.host).toBe(DEFAULT_HOST);
     expect(config.port).toBe(DEFAULT_PORT);
     expect(config.actorDefault).toBe('user');
+    expect(config.historyCoalesceWindowMs).toBe(DEFAULT_HISTORY_COALESCE_WINDOW_MS);
   });
 
   it('rejects invalid ports', () => {
@@ -109,5 +113,13 @@ describe('daemon config', () => {
     expect(resolveActorDefault({ KB2_ACTOR_DEFAULT: ' unknown ' })).toBe('unknown');
     expect(resolveActorDefault({ KB2_ACTOR_DEFAULT: 'user' })).toBe('user');
     expect(() => resolveActorDefault({ KB2_ACTOR_DEFAULT: 'system' })).toThrow(/KB2_ACTOR_DEFAULT/);
+  });
+
+  it('resolves the history coalescing window', () => {
+    expect(resolveHistoryCoalesceWindowMs({})).toBe(DEFAULT_HISTORY_COALESCE_WINDOW_MS);
+    expect(resolveHistoryCoalesceWindowMs({ KB2_HISTORY_COALESCE_WINDOW_MS: ' 0 ' })).toBe(0);
+    expect(resolveHistoryCoalesceWindowMs({ KB2_HISTORY_COALESCE_WINDOW_MS: '120000' })).toBe(120000);
+    expect(() => resolveHistoryCoalesceWindowMs({ KB2_HISTORY_COALESCE_WINDOW_MS: '-1' })).toThrow(/KB2_HISTORY_COALESCE_WINDOW_MS/);
+    expect(() => resolveHistoryCoalesceWindowMs({ KB2_HISTORY_COALESCE_WINDOW_MS: 'five' })).toThrow(/KB2_HISTORY_COALESCE_WINDOW_MS/);
   });
 });

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -5,6 +5,7 @@ export const SERVICE_NAME = 'kb2d';
 export const DEFAULT_PORT = 7382;
 export const DEFAULT_HOST = '127.0.0.1';
 export const DEFAULT_ACTOR_DEFAULT = 'user';
+export const DEFAULT_HISTORY_COALESCE_WINDOW_MS = 5 * 60 * 1000;
 
 export type ActorDefault = 'user' | 'unknown';
 
@@ -19,6 +20,7 @@ export interface DaemonConfig {
   webProxyTarget?: string;
   relay?: DaemonRelayConfig;
   actorDefault: ActorDefault;
+  historyCoalesceWindowMs: number;
   kb2Home: string;
   daemonHome: string;
   /** Directory that holds every vault: `<home>/vaults/<slug>/`. */
@@ -115,6 +117,21 @@ export function resolveActorDefault(env: NodeJS.ProcessEnv = process.env): Actor
   throw new Error(`KB2_ACTOR_DEFAULT must be "user" or "unknown". Received: ${configuredDefault}`);
 }
 
+export function resolveHistoryCoalesceWindowMs(env: NodeJS.ProcessEnv = process.env): number {
+  const configuredWindow = env.KB2_HISTORY_COALESCE_WINDOW_MS?.trim();
+
+  if (!configuredWindow) {
+    return DEFAULT_HISTORY_COALESCE_WINDOW_MS;
+  }
+
+  const windowMs = Number(configuredWindow);
+  if (!Number.isInteger(windowMs) || windowMs < 0) {
+    throw new Error(`KB2_HISTORY_COALESCE_WINDOW_MS must be a non-negative integer. Received: ${configuredWindow}`);
+  }
+
+  return windowMs;
+}
+
 export function createDaemonConfig(options: ResolveConfigOptions = {}): DaemonConfig {
   const env = options.env ?? process.env;
   const homeDir = options.homeDir ?? homedir();
@@ -130,6 +147,7 @@ export function createDaemonConfig(options: ResolveConfigOptions = {}): DaemonCo
     webProxyTarget: resolveWebProxyTarget(env),
     relay: resolveRelayConfig(env),
     actorDefault: resolveActorDefault(env),
+    historyCoalesceWindowMs: resolveHistoryCoalesceWindowMs(env),
     kb2Home,
     daemonHome,
     vaultsHome,

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -59,7 +59,9 @@ export async function startDaemon(): Promise<StartedDaemon> {
   // and mutable at runtime (create/rename/soft-delete) with no restart.
   await mkdir(config.vaultsHome, { recursive: true });
   const trashHome = join(config.kb2Home, VAULT_TRASH_DIRNAME);
-  const registry = await VaultRegistry.load(config.vaultsHome, trashHome);
+  const registry = await VaultRegistry.load(config.vaultsHome, trashHome, {
+    historyCoalesceWindowMs: config.historyCoalesceWindowMs
+  });
 
   // First boot: with no legacy vault to migrate and nothing discovered, stand up
   // a single starter vault seeded from the bundled kit. `create` performs the

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -414,6 +414,34 @@ describe("daemon routing", () => {
       path: "notes/attributed.md",
       actor: suppliedActor,
     });
+
+    const read = await app.request(filePath("notes/attributed.md"));
+    expect(read.status).toBe(200);
+    await expect(read.json()).resolves.toMatchObject({
+      ok: true,
+      content: "attributed\n",
+    });
+
+    const history = await app.request(`${filePath("notes/attributed.md")}/history`);
+    expect(history.status).toBe(200);
+    await expect(history.json()).resolves.toMatchObject({
+      ok: true,
+      hasMore: false,
+      entries: [
+        {
+          operation: "create",
+          path: "notes/attributed.md",
+          actor: suppliedActor,
+          content: "attributed\n",
+        },
+      ],
+    });
+    const rawHistory = await readRawFileHistory(vaultRoot);
+    expect(rawHistory).toContain("Ada Lovelace");
+
+    const historyAgain = await app.request(`${filePath("notes/attributed.md")}/history`);
+    expect(historyAgain.status).toBe(200);
+    await expect(readRawFileHistory(vaultRoot)).resolves.toBe(rawHistory);
   });
 
   it.each([
@@ -464,6 +492,12 @@ describe("daemon routing", () => {
         operation: "create",
         path: "notes/defaulted.md",
         actor: expectedActor,
+      });
+      const history = await app.request(`${filePath("notes/defaulted.md")}/history`);
+      expect(history.status).toBe(200);
+      await expect(history.json()).resolves.toMatchObject({
+        ok: true,
+        entries: [{ operation: "create", actor: expectedActor }],
       });
       await registry.close();
     },
@@ -2243,6 +2277,10 @@ async function readAuditRows(
 
 async function readRawFolderMetadata(root: string): Promise<string> {
   return readFile(join(root, ".kb2/folders.yml"), "utf8");
+}
+
+async function readRawFileHistory(root: string): Promise<string> {
+  return readFile(join(root, ".kb2/file-history.yml"), "utf8");
 }
 
 async function writeFileWithParents(

--- a/apps/daemon/src/vault-registry.ts
+++ b/apps/daemon/src/vault-registry.ts
@@ -54,6 +54,10 @@ export interface VaultRegistryChangeEvent {
 
 export type VaultRegistryChangeEventHandler = (event: VaultRegistryChangeEvent) => void;
 
+export interface VaultRegistryOptions {
+  historyCoalesceWindowMs?: number;
+}
+
 /**
  * Normalize a string into a vault slug using github-slugger (battle-tested, not
  * hand-rolled). Used to derive a slug from a folder name when minting identity,
@@ -285,10 +289,10 @@ export async function discoverVaults(vaultsHome: string): Promise<VaultRegistryE
 }
 
 /** Build a root-scoped service + document manager per discovered vault. */
-export function buildVaultInstances(entries: VaultRegistryEntry[]): Map<string, VaultInstance> {
+export function buildVaultInstances(entries: VaultRegistryEntry[], options: VaultRegistryOptions = {}): Map<string, VaultInstance> {
   const instances = new Map<string, VaultInstance>();
   for (const entry of entries) {
-    instances.set(entry.slug, buildVaultInstance(entry));
+    instances.set(entry.slug, buildVaultInstance(entry, options));
   }
   return instances;
 }
@@ -321,16 +325,17 @@ export class VaultRegistry {
   private constructor(
     private readonly vaultsHome: string,
     private readonly trashHome: string,
+    private readonly options: VaultRegistryOptions,
     instances: Map<string, VaultInstance>
   ) {
     this.instances = instances;
   }
 
   /** Scan `vaultsHome`, mint identities as needed, and build one instance per vault. */
-  static async load(vaultsHome: string, trashHome: string): Promise<VaultRegistry> {
+  static async load(vaultsHome: string, trashHome: string, options: VaultRegistryOptions = {}): Promise<VaultRegistry> {
     const entries = await discoverVaults(vaultsHome);
-    const instances = buildVaultInstances(entries);
-    return new VaultRegistry(vaultsHome, trashHome, instances);
+    const instances = buildVaultInstances(entries, options);
+    return new VaultRegistry(vaultsHome, trashHome, options, instances);
   }
 
   /** Every registered vault as `{ id, displayName }`, ordered by slug. */
@@ -405,7 +410,7 @@ export class VaultRegistry {
     await seedVaultFromStarterKit(root);
 
     const entry: VaultRegistryEntry = { slug, displayName, root };
-    const instance = buildVaultInstance(entry);
+    const instance = buildVaultInstance(entry, this.options);
     this.instances.set(slug, instance);
     this.subscribeInstance(instance);
 
@@ -610,9 +615,13 @@ function applyVaultMetadataInput(
 }
 
 /** Build a single root-scoped service + document manager for one vault entry. */
-function buildVaultInstance(entry: VaultRegistryEntry): VaultInstance {
+function buildVaultInstance(entry: VaultRegistryEntry, options: VaultRegistryOptions = {}): VaultInstance {
   const manager = new DocumentSessionManager({ root: entry.root });
-  const service = createVaultService({ vaultRoot: entry.root, documentSessions: manager });
+  const service = createVaultService({
+    vaultRoot: entry.root,
+    documentSessions: manager,
+    historyCoalesceWindowMs: options.historyCoalesceWindowMs
+  });
   return { entry, service, manager };
 }
 

--- a/packages/doc-session/src/protocol.ts
+++ b/packages/doc-session/src/protocol.ts
@@ -25,6 +25,7 @@ export interface DocumentSessionEvent {
   ts: number;
   fromPath?: string;
   toPath?: string;
+  attribution?: DocumentUpdateAttribution;
 }
 
 export interface AckedSyncUpdate {

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -11,6 +11,7 @@ import {
   LOCAL_AGENT_DOCUMENT_UPDATE_ATTRIBUTION,
   LOCAL_USER_DOCUMENT_UPDATE_ATTRIBUTION,
   createDocumentUpdateAttributionOrigin,
+  documentUpdateAttributionFromOrigin,
   type DocumentSessionEvent,
   type DocumentUpdateAttribution
 } from './protocol.js';
@@ -128,6 +129,7 @@ export class OneFileDocumentSession {
   private nonEmptyMaterializedContent = false;
   // Set only around this session's own atomic write so file-watch echoes can be distinguished from external edits.
   private pendingWriteHash: string | undefined;
+  private pendingPersistAttribution: DocumentUpdateAttribution | undefined;
   private persistRequested = false;
   private persistPromise: Promise<void> | undefined;
   private persistFailed = false;
@@ -422,6 +424,7 @@ export class OneFileDocumentSession {
       return;
     }
 
+    this.pendingPersistAttribution = documentUpdateAttributionFromOrigin(origin);
     this.requestPersist().catch((error: unknown) => {
       console.warn(`KB-2 failed to persist document update for ${this.filePath}; keeping active Yjs session open.`, error);
     });
@@ -464,6 +467,8 @@ export class OneFileDocumentSession {
     }
 
     const content = this.currentContent();
+    const attribution = this.pendingPersistAttribution;
+    this.pendingPersistAttribution = undefined;
     const diskContent = await readOptionalFile(this.filePath);
     const diskHash = diskContent === undefined ? undefined : hashContent(diskContent);
 
@@ -488,7 +493,10 @@ export class OneFileDocumentSession {
       this.lastWrittenContent = content;
       this.nonEmptyMaterializedContent = content.length > 0;
       this.markPersistRecovered();
-      this.emitEvent('content-persisted');
+      this.emitEvent({
+        ...this.createEvent('content-persisted'),
+        ...(attribution !== undefined ? { attribution } : {})
+      });
     } finally {
       if (this.pendingWriteHash === contentHash) {
         this.pendingWriteHash = undefined;

--- a/packages/vault-core/src/file-history.ts
+++ b/packages/vault-core/src/file-history.ts
@@ -1,0 +1,477 @@
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+import type { VaultActor, AuditOperation } from "./audit.js";
+import { isNodeError } from "./fs.js";
+import { resolveVaultPath, validateVaultPath } from "./path.js";
+import type { VaultResult } from "./vault-ops.js";
+
+export type FileHistoryOperation = "create" | "update" | "move" | "rename";
+
+export interface FileHistoryEntry {
+  id: string;
+  path: string;
+  operation: FileHistoryOperation;
+  actor: VaultActor;
+  integrationId?: string;
+  createdAt: string;
+  updatedAt: string;
+  content: string;
+  size: number;
+  contentHash: string;
+}
+
+export interface RecordFileHistoryInput {
+  path: string;
+  operation: FileHistoryOperation;
+  actor?: VaultActor;
+  content: string;
+  now?: Date;
+  coalesceWindowMs?: number;
+}
+
+export interface ListFileHistoryInput {
+  path: string;
+  before?: string;
+  beforeId?: string;
+  limit?: number;
+}
+
+export interface FileHistoryPage {
+  entries: FileHistoryEntry[];
+  hasMore: boolean;
+}
+
+type FileHistoryMap = Record<string, FileHistoryEntry[]>;
+
+const FILE_HISTORY_RELATIVE_PATH = path.posix.join(".kb2", "file-history.yml");
+const DEFAULT_HISTORY_COALESCE_WINDOW_MS = 5 * 60 * 1000;
+const DEFAULT_HISTORY_PAGE_LIMIT = 50;
+const MAX_HISTORY_PAGE_LIMIT = 200;
+const fileHistoryMutationQueues = new Map<string, Promise<void>>();
+
+function ignoreMutationQueueResult(): void {
+  return undefined;
+}
+
+function fail(error: "invalid_path" | "invalid_metadata" | "metadata_parse_failed", message: string): VaultResult<never> {
+  return { ok: false, error, message };
+}
+
+function metadataFileFailure(
+  message = "file history metadata file is malformed",
+): VaultResult<never> {
+  return fail("metadata_parse_failed", message);
+}
+
+function fileHistoryPath(root: string): string {
+  return resolveVaultPath(root, FILE_HISTORY_RELATIVE_PATH);
+}
+
+async function withFileHistoryMutation<T>(
+  root: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const key = path.resolve(root);
+  const previous = fileHistoryMutationQueues.get(key) ?? Promise.resolve();
+  const run = previous.then(operation, operation);
+  const next = run.then(ignoreMutationQueueResult, ignoreMutationQueueResult);
+  fileHistoryMutationQueues.set(key, next);
+
+  try {
+    return await run;
+  } finally {
+    if (fileHistoryMutationQueues.get(key) === next) {
+      fileHistoryMutationQueues.delete(key);
+    }
+  }
+}
+
+export async function recordFileHistory(
+  root: string,
+  input: RecordFileHistoryInput,
+): Promise<VaultResult<FileHistoryEntry>> {
+  let rel: string;
+  try {
+    rel = validateVaultPath(input.path, "file");
+  } catch (error) {
+    if (error instanceof Error) {
+      return fail("invalid_path", error.message);
+    }
+    /* v8 ignore next -- validateVaultPath throws Error instances; non-Error throws are defensive rethrows. */
+    throw error;
+  }
+
+  return await withFileHistoryMutation(root, async () => {
+    const map = await readFileHistoryMap(root);
+    if (!map.ok) return map;
+
+    const now = input.now ?? new Date();
+    const nowIso = now.toISOString();
+    const existingEntries = map.value[rel] ?? [];
+    const actor = cloneActor(input.actor ?? { kind: "unknown" });
+    const integrationId = integrationIdForActor(actor);
+    const contentHash = await hashContent(input.content);
+    const size = new TextEncoder().encode(input.content).byteLength;
+    const coalesceWindowMs = normalizeCoalesceWindowMs(input.coalesceWindowMs);
+    const previous = existingEntries.at(-1);
+
+    let entry: FileHistoryEntry;
+    if (
+      previous &&
+      sameActorAndIntegration(previous, actor, integrationId) &&
+      now.getTime() - new Date(previous.updatedAt).getTime() <= coalesceWindowMs
+    ) {
+      entry = {
+        ...previous,
+        path: rel,
+        content: input.content,
+        size,
+        contentHash,
+        updatedAt: nowIso,
+      };
+      existingEntries[existingEntries.length - 1] = entry;
+    } else {
+      entry = {
+        id: randomUUID(),
+        path: rel,
+        operation: input.operation,
+        actor,
+        ...(integrationId !== undefined ? { integrationId } : {}),
+        createdAt: nowIso,
+        updatedAt: nowIso,
+        content: input.content,
+        size,
+        contentHash,
+      };
+      existingEntries.push(entry);
+    }
+
+    await writeFileHistoryMap(root, { ...map.value, [rel]: existingEntries });
+    return { ok: true, value: cloneFileHistoryEntry(entry) };
+  });
+}
+
+export async function listFileHistory(
+  root: string,
+  input: ListFileHistoryInput,
+): Promise<VaultResult<FileHistoryPage>> {
+  let rel: string;
+  try {
+    rel = validateVaultPath(input.path, "file");
+  } catch (error) {
+    if (error instanceof Error) {
+      return fail("invalid_path", error.message);
+    }
+    /* v8 ignore next -- validateVaultPath throws Error instances; non-Error throws are defensive rethrows. */
+    throw error;
+  }
+
+  const map = await readFileHistoryMap(root);
+  if (!map.ok) return map;
+
+  const newestFirst = [...(map.value[rel] ?? [])].sort(compareHistoryEntriesDesc);
+  const limited = applyHistoryCursor(newestFirst, input.before, input.beforeId);
+  const limit = normalizePageLimit(input.limit);
+  const entries = limited.slice(0, limit);
+  return {
+    ok: true,
+    value: {
+      entries: entries.map(cloneFileHistoryEntry),
+      hasMore: limited.length > entries.length,
+    },
+  };
+}
+
+export function historyOperationFromAudit(operation: AuditOperation): FileHistoryOperation | undefined {
+  switch (operation) {
+    case "create":
+      return "create";
+    case "write":
+    case "splice":
+    case "append":
+    case "prepend":
+      return "update";
+    case "move":
+      return "move";
+    case "mkdir":
+    case "delete":
+      return undefined;
+  }
+}
+
+async function readFileHistoryMap(
+  root: string,
+): Promise<VaultResult<FileHistoryMap>> {
+  let content: string;
+  try {
+    content = await readFile(fileHistoryPath(root), "utf8");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return { ok: true, value: {} };
+    }
+    throw error;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(content);
+  } catch {
+    return metadataFileFailure();
+  }
+
+  if (!isRecord(parsed) || !isRecord(parsed.files)) {
+    return metadataFileFailure();
+  }
+
+  const map: FileHistoryMap = {};
+  for (const [filePath, rawEntries] of Object.entries(parsed.files)) {
+    try {
+      validateVaultPath(filePath, "file");
+    } catch {
+      return metadataFileFailure();
+    }
+
+    if (!Array.isArray(rawEntries)) return metadataFileFailure();
+    const entries: FileHistoryEntry[] = [];
+    for (const rawEntry of rawEntries) {
+      const normalized = normalizeFileHistoryEntry(filePath, rawEntry);
+      if (!normalized.ok) return normalized;
+      entries.push(normalized.value);
+    }
+    if (entries.length > 0) {
+      map[filePath] = entries;
+    }
+  }
+
+  return { ok: true, value: map };
+}
+
+async function writeFileHistoryMap(
+  root: string,
+  history: FileHistoryMap,
+): Promise<void> {
+  const filePath = fileHistoryPath(root);
+  const directory = path.dirname(filePath);
+  await mkdir(directory, { recursive: true });
+
+  const sortedFiles = Object.fromEntries(
+    Object.entries(history)
+      .filter(([, entries]) => entries.length > 0)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([filePath, entries]) => [filePath, entries.map(serializedEntry)]),
+  );
+  const content = stringifyYaml({ files: sortedFiles });
+  const temporaryPath = path.join(
+    directory,
+    `.${process.pid}.${randomUUID()}.tmp`,
+  );
+
+  try {
+    await writeFile(temporaryPath, content, "utf8");
+    await rename(temporaryPath, filePath);
+  } catch (error) {
+    /* v8 ignore start -- Cleanup runs only after an atomic-write filesystem failure; success-path durability is covered by raw file-history.yml assertions. */
+    await rm(temporaryPath, { force: true });
+    throw error;
+    /* v8 ignore stop */
+  }
+}
+
+function normalizeFileHistoryEntry(
+  filePath: string,
+  value: unknown,
+): VaultResult<FileHistoryEntry> {
+  if (!isRecord(value)) return metadataFileFailure();
+  if (
+    typeof value.id !== "string" ||
+    typeof value.operation !== "string" ||
+    typeof value.createdAt !== "string" ||
+    typeof value.updatedAt !== "string" ||
+    typeof value.content !== "string" ||
+    typeof value.size !== "number" ||
+    typeof value.contentHash !== "string" ||
+    !isFileHistoryOperation(value.operation) ||
+    !isIsoDate(value.createdAt) ||
+    !isIsoDate(value.updatedAt) ||
+    !isRecord(value.actor)
+  ) {
+    return metadataFileFailure();
+  }
+
+  const actor = normalizeActor(value.actor);
+  if (!actor.ok) return actor;
+  if (value.integrationId !== undefined && typeof value.integrationId !== "string") {
+    return metadataFileFailure();
+  }
+
+  return {
+    ok: true,
+    value: {
+      id: value.id,
+      path: filePath,
+      operation: value.operation,
+      actor: actor.value,
+      ...(typeof value.integrationId === "string" ? { integrationId: value.integrationId } : {}),
+      createdAt: value.createdAt,
+      updatedAt: value.updatedAt,
+      content: value.content,
+      size: value.size,
+      contentHash: value.contentHash,
+    },
+  };
+}
+
+function normalizeActor(value: Record<string, unknown>): VaultResult<VaultActor> {
+  if (
+    value.kind !== "user" &&
+    value.kind !== "mcp_client" &&
+    value.kind !== "integration" &&
+    value.kind !== "system" &&
+    value.kind !== "unknown"
+  ) {
+    return metadataFileFailure();
+  }
+
+  const id = optionalString(value, "id");
+  if (!id.ok) return id;
+  const name = optionalString(value, "name");
+  if (!name.ok) return name;
+  const client = optionalString(value, "client");
+  if (!client.ok) return client;
+
+  return {
+    ok: true,
+    value: {
+      kind: value.kind,
+      ...(id.value !== undefined ? { id: id.value } : {}),
+      ...(name.value !== undefined ? { name: name.value } : {}),
+      ...(client.value !== undefined ? { client: client.value } : {}),
+    },
+  };
+}
+
+function optionalString(
+  value: Record<string, unknown>,
+  key: "id" | "name" | "client",
+): VaultResult<string | undefined> {
+  if (!Object.prototype.hasOwnProperty.call(value, key)) {
+    return { ok: true, value: undefined };
+  }
+  return typeof value[key] === "string"
+    ? { ok: true, value: value[key] }
+    : metadataFileFailure();
+}
+
+function serializedEntry(entry: FileHistoryEntry): Omit<FileHistoryEntry, "path"> {
+  return {
+    id: entry.id,
+    operation: entry.operation,
+    actor: cloneActor(entry.actor),
+    ...(entry.integrationId !== undefined ? { integrationId: entry.integrationId } : {}),
+    createdAt: entry.createdAt,
+    updatedAt: entry.updatedAt,
+    content: entry.content,
+    size: entry.size,
+    contentHash: entry.contentHash,
+  };
+}
+
+function cloneFileHistoryEntry(entry: FileHistoryEntry): FileHistoryEntry {
+  return {
+    id: entry.id,
+    path: entry.path,
+    operation: entry.operation,
+    actor: cloneActor(entry.actor),
+    ...(entry.integrationId !== undefined ? { integrationId: entry.integrationId } : {}),
+    createdAt: entry.createdAt,
+    updatedAt: entry.updatedAt,
+    content: entry.content,
+    size: entry.size,
+    contentHash: entry.contentHash,
+  };
+}
+
+function cloneActor(actor: VaultActor): VaultActor {
+  return {
+    kind: actor.kind,
+    ...(actor.id !== undefined ? { id: actor.id } : {}),
+    ...(actor.name !== undefined ? { name: actor.name } : {}),
+    ...(actor.client !== undefined ? { client: actor.client } : {}),
+  };
+}
+
+function sameActorAndIntegration(
+  entry: FileHistoryEntry,
+  actor: VaultActor,
+  integrationId: string | undefined,
+): boolean {
+  return actorKey(entry.actor) === actorKey(actor) && (entry.integrationId ?? "") === (integrationId ?? "");
+}
+
+function actorKey(actor: VaultActor): string {
+  return JSON.stringify([
+    actor.kind,
+    actor.id ?? "",
+    actor.name ?? "",
+  ]);
+}
+
+function integrationIdForActor(actor: VaultActor): string | undefined {
+  return actor.client;
+}
+
+function applyHistoryCursor(
+  entries: FileHistoryEntry[],
+  before: string | undefined,
+  beforeId: string | undefined,
+): FileHistoryEntry[] {
+  if (!before) return entries;
+  const beforeTime = new Date(before).getTime();
+  if (!Number.isFinite(beforeTime)) return entries;
+
+  return entries.filter((entry) => {
+    const entryTime = new Date(entry.createdAt).getTime();
+    if (entryTime < beforeTime) return true;
+    if (entryTime > beforeTime) return false;
+    return beforeId === undefined ? false : entry.id < beforeId;
+  });
+}
+
+function compareHistoryEntriesDesc(left: FileHistoryEntry, right: FileHistoryEntry): number {
+  const timeDelta = new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime();
+  return timeDelta || right.id.localeCompare(left.id);
+}
+
+function normalizeCoalesceWindowMs(value: number | undefined): number {
+  return value !== undefined && Number.isFinite(value) && value >= 0
+    ? value
+    : DEFAULT_HISTORY_COALESCE_WINDOW_MS;
+}
+
+function normalizePageLimit(value: number | undefined): number {
+  if (value === undefined || !Number.isInteger(value) || value < 1) {
+    return DEFAULT_HISTORY_PAGE_LIMIT;
+  }
+  return Math.min(value, MAX_HISTORY_PAGE_LIMIT);
+}
+
+function isFileHistoryOperation(value: string): value is FileHistoryOperation {
+  return value === "create" || value === "update" || value === "move" || value === "rename";
+}
+
+function isIsoDate(value: string): boolean {
+  return Number.isFinite(new Date(value).getTime());
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+async function hashContent(content: string): Promise<string> {
+  const bytes = new TextEncoder().encode(content);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -35,6 +35,11 @@ import {
   type VaultContext,
 } from "./vault-ops.js";
 import { onVaultAudit } from "./audit.js";
+import {
+  historyOperationFromAudit,
+  listFileHistory,
+  recordFileHistory,
+} from "./file-history.js";
 import { searchVaultFiles } from "./search.js";
 import { validateVaultPath } from "./path.js";
 import { anchoredSpliceContractCases } from "./splice-contract-cases.test-support.js";
@@ -207,6 +212,348 @@ describe("vault-core filesystem operations", () => {
     expect(auditLines[1]).toMatchObject({
       operation: "write",
       path: "notes/a.md",
+    });
+  });
+
+  it("persists per-file history with actor integration coalescing and newest-first paging", async () => {
+    const actor = {
+      kind: "user" as const,
+      id: "user-1",
+      name: "Ada Lovelace",
+      client: "cloud-web",
+    };
+    const otherClient = { ...actor, client: "agent-client" };
+    const otherActor = {
+      kind: "integration" as const,
+      id: "user-1",
+      name: "Ada Bot",
+      client: "cloud-web",
+    };
+
+    await expect(
+      recordFileHistory(root, {
+        path: "notes/history.md",
+        operation: "create",
+        actor,
+        content: "first",
+        now: new Date("2026-06-30T00:00:00.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: { operation: "create", actor, content: "first" },
+    });
+    await recordFileHistory(root, {
+      path: "notes/history.md",
+      operation: "update",
+      actor,
+      content: "second",
+      now: new Date("2026-06-30T00:01:00.000Z"),
+    });
+    await recordFileHistory(root, {
+      path: "notes/history.md",
+      operation: "update",
+      actor: otherClient,
+      content: "third",
+      now: new Date("2026-06-30T00:02:00.000Z"),
+    });
+    await recordFileHistory(root, {
+      path: "notes/history.md",
+      operation: "update",
+      actor: otherActor,
+      content: "fourth",
+      now: new Date("2026-06-30T00:03:00.000Z"),
+    });
+    await recordFileHistory(root, {
+      path: "notes/history.md",
+      operation: "update",
+      actor: otherActor,
+      content: "fifth",
+      now: new Date("2026-06-30T00:10:00.000Z"),
+    });
+
+    const firstPage = await listFileHistory(root, {
+      path: "notes/history.md",
+      limit: 2,
+    });
+    expect(firstPage).toMatchObject({
+      ok: true,
+      value: {
+        hasMore: true,
+        entries: [
+          { content: "fifth", actor: otherActor },
+          { content: "fourth", actor: otherActor },
+        ],
+      },
+    });
+    if (!firstPage.ok) throw new Error("expected history page");
+    const cursor = firstPage.value.entries.at(-1);
+    if (!cursor) throw new Error("expected cursor entry");
+    await expect(
+      listFileHistory(root, {
+        path: "notes/history.md",
+        before: cursor.createdAt,
+        beforeId: cursor.id,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: {
+        hasMore: false,
+        entries: [
+          { content: "third", actor: otherClient },
+          { operation: "create", content: "second", actor },
+        ],
+      },
+    });
+
+    await expect(readRawFileHistory(root)).resolves.toMatchObject({
+      parsed: {
+        files: {
+          "notes/history.md": [
+            expect.objectContaining({
+              operation: "create",
+              actor,
+              content: "second",
+            }),
+            expect.objectContaining({
+              operation: "update",
+              actor: otherClient,
+              content: "third",
+            }),
+            expect.objectContaining({
+              operation: "update",
+              actor: otherActor,
+              content: "fourth",
+            }),
+            expect.objectContaining({
+              operation: "update",
+              actor: otherActor,
+              content: "fifth",
+            }),
+          ],
+        },
+      },
+    });
+
+    await recordFileHistory(root, {
+      path: "alpha/sorted.md",
+      operation: "create",
+      actor,
+      content: "sorted",
+      now: new Date("2026-06-30T00:20:00.000Z"),
+    });
+    const sortedRaw = await readRawFileHistory(root);
+    expect(Object.keys((sortedRaw.parsed as { files: Record<string, unknown> }).files)).toEqual([
+      "alpha/sorted.md",
+      "notes/history.md",
+    ]);
+  });
+
+  it("rejects invalid history inputs and malformed durable metadata", async () => {
+    await expect(
+      listFileHistory(root, { path: "notes/missing.md" }),
+    ).resolves.toEqual({
+      ok: true,
+      value: { entries: [], hasMore: false },
+    });
+    await expect(
+      recordFileHistory(root, {
+        path: "../escape.md",
+        operation: "create",
+        content: "bad",
+      }),
+    ).resolves.toMatchObject({ ok: false, error: "invalid_path" });
+    await expect(
+      listFileHistory(root, { path: "../escape.md" }),
+    ).resolves.toMatchObject({ ok: false, error: "invalid_path" });
+
+    await recordFileHistory(root, {
+      path: "notes/unknown.md",
+      operation: "create",
+      content: "unknown",
+      now: new Date("2026-06-30T01:00:00.000Z"),
+      coalesceWindowMs: -1,
+    });
+    await expect(
+      listFileHistory(root, {
+        path: "notes/unknown.md",
+        before: "not-a-date",
+        limit: 999,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: {
+        entries: [{ actor: { kind: "unknown" }, content: "unknown" }],
+      },
+    });
+
+    const validEntry = {
+      id: "entry-1",
+      operation: "create",
+      actor: { kind: "user" },
+      createdAt: "2026-06-30T01:00:00.000Z",
+      updatedAt: "2026-06-30T01:00:00.000Z",
+      content: "x",
+      size: 1,
+      contentHash: "hash",
+    };
+    const malformedCases: unknown[] = [
+      "files: [",
+      { files: [] },
+      { files: { "../bad.md": [] } },
+      { files: { "notes/a.md": {} } },
+      { files: { "notes/a.md": ["bad"] } },
+      { files: { "notes/a.md": [{ ...validEntry, id: 1 }] } },
+      { files: { "notes/a.md": [{ ...validEntry, integrationId: 42 }] } },
+      { files: { "notes/a.md": [{ ...validEntry, actor: { kind: "person" } }] } },
+      { files: { "notes/a.md": [{ ...validEntry, actor: { kind: "user", id: 42 } }] } },
+      { files: { "notes/a.md": [{ ...validEntry, actor: { kind: "user", name: 42 } }] } },
+      { files: { "notes/a.md": [{ ...validEntry, actor: { kind: "user", client: 42 } }] } },
+    ];
+
+    for (const malformed of malformedCases) {
+      await writeRawFileHistory(root, malformed);
+      await expect(
+        listFileHistory(root, { path: "notes/a.md" }),
+      ).resolves.toMatchObject({
+        ok: false,
+        error: "metadata_parse_failed",
+      });
+    }
+
+    await writeRawFileHistory(root, { files: [] });
+    await expect(
+      recordFileHistory(root, {
+        path: "notes/a.md",
+        operation: "create",
+        content: "x",
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: "metadata_parse_failed",
+    });
+
+    await writeRawFileHistory(root, {
+      files: { "notes/renamed.md": [{ ...validEntry, operation: "rename" }] },
+    });
+    await expect(
+      listFileHistory(root, { path: "notes/renamed.md" }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: { entries: [{ operation: "rename" }] },
+    });
+  });
+
+  it("honors zero coalescing windows and cursor tie-breaks entries with equal timestamps", async () => {
+    const at = new Date("2026-06-30T02:00:00.000Z");
+    const actor = { kind: "user" as const, id: "same", client: "browser" };
+
+    await recordFileHistory(root, {
+      path: "notes/zero.md",
+      operation: "update",
+      actor,
+      content: "first",
+      now: at,
+      coalesceWindowMs: 0,
+    });
+    await recordFileHistory(root, {
+      path: "notes/zero.md",
+      operation: "update",
+      actor,
+      content: "second",
+      now: new Date(at.getTime() + 1),
+      coalesceWindowMs: 0,
+    });
+    await expect(
+      listFileHistory(root, { path: "notes/zero.md" }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: { entries: [{ content: "second" }, { content: "first" }] },
+    });
+
+    await recordFileHistory(root, {
+      path: "notes/anonymous.md",
+      operation: "update",
+      actor: { kind: "system" },
+      content: "first",
+      now: at,
+    });
+    await recordFileHistory(root, {
+      path: "notes/anonymous.md",
+      operation: "update",
+      actor: { kind: "system" },
+      content: "second",
+      now: new Date(at.getTime() + 1),
+    });
+    await expect(
+      listFileHistory(root, { path: "notes/anonymous.md" }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: { entries: [{ actor: { kind: "system" }, content: "second" }] },
+    });
+
+    await recordFileHistory(root, {
+      path: "notes/tie.md",
+      operation: "update",
+      actor: { kind: "user", id: "left" },
+      content: "left",
+      now: at,
+    });
+    await recordFileHistory(root, {
+      path: "notes/tie.md",
+      operation: "update",
+      actor: { kind: "user", id: "right" },
+      content: "right",
+      now: at,
+    });
+    const page = await listFileHistory(root, { path: "notes/tie.md" });
+    if (!page.ok) throw new Error("expected history page");
+    expect(page.value.entries).toHaveLength(2);
+    expect(page.value.entries[0]!.createdAt).toBe(page.value.entries[1]!.createdAt);
+    await expect(
+      listFileHistory(root, {
+        path: "notes/tie.md",
+        before: page.value.entries[0]!.createdAt,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: { entries: [] },
+    });
+    await expect(
+      listFileHistory(root, {
+        path: "notes/tie.md",
+        before: page.value.entries[0]!.createdAt,
+        beforeId: page.value.entries[0]!.id,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: { entries: [page.value.entries[1]] },
+    });
+    await expect(
+      listFileHistory(root, {
+        path: "notes/tie.md",
+        before: "2026-06-29T00:00:00.000Z",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: { entries: [] },
+    });
+  });
+
+  it("maps file audit operations into file history operations only", () => {
+    expect(historyOperationFromAudit("create")).toBe("create");
+    expect(historyOperationFromAudit("write")).toBe("update");
+    expect(historyOperationFromAudit("splice")).toBe("update");
+    expect(historyOperationFromAudit("append")).toBe("update");
+    expect(historyOperationFromAudit("prepend")).toBe("update");
+    expect(historyOperationFromAudit("move")).toBe("move");
+    expect(historyOperationFromAudit("mkdir")).toBeUndefined();
+    expect(historyOperationFromAudit("delete")).toBeUndefined();
+  });
+
+  it("rethrows unexpected file-history.yml read errors instead of converting them to defaults", async () => {
+    await mkdir(path.join(root, ".kb2", "file-history.yml"), { recursive: true });
+    await expect(listFileHistory(root, { path: "notes/a.md" })).rejects.toMatchObject({
+      code: "EISDIR",
     });
   });
 
@@ -1396,6 +1743,22 @@ async function readRawFolderMetadata(
 ): Promise<{ raw: string; parsed: unknown }> {
   const raw = await readFile(path.join(root, ".kb2/folders.yml"), "utf8");
   return { raw, parsed: parseYaml(raw) };
+}
+
+async function readRawFileHistory(
+  root: string,
+): Promise<{ raw: string; parsed: unknown }> {
+  const raw = await readFile(path.join(root, ".kb2/file-history.yml"), "utf8");
+  return { raw, parsed: parseYaml(raw) };
+}
+
+async function writeRawFileHistory(root: string, content: unknown): Promise<void> {
+  await mkdir(path.join(root, ".kb2"), { recursive: true });
+  await writeFile(
+    path.join(root, ".kb2/file-history.yml"),
+    typeof content === "string" ? content : JSON.stringify(content),
+    "utf8",
+  );
 }
 
 async function writeFileWithParents(

--- a/packages/vault-core/src/index.ts
+++ b/packages/vault-core/src/index.ts
@@ -12,6 +12,16 @@ export {
   normalizeFolderMetadataColor,
   type FolderMetadataColor,
 } from "./folder-metadata-options.js";
+export {
+  historyOperationFromAudit,
+  listFileHistory,
+  recordFileHistory,
+  type FileHistoryEntry,
+  type FileHistoryOperation,
+  type FileHistoryPage,
+  type ListFileHistoryInput,
+  type RecordFileHistoryInput,
+} from "./file-history.js";
 export { isNodeError, statOrNull } from "./fs.js";
 export {
   InvalidPathError,

--- a/packages/vault-service/src/index.test.ts
+++ b/packages/vault-service/src/index.test.ts
@@ -183,6 +183,212 @@ describe("vault service failure mapping", () => {
     ]);
   });
 
+  it("records file history for service writes while reads leave history untouched", async () => {
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const marcus = {
+      kind: "user" as const,
+      id: "marcus",
+      name: "Marcus",
+      client: "browser",
+    };
+    const olivia = {
+      kind: "user" as const,
+      id: "olivia",
+      name: "Olivia",
+      client: "browser",
+    };
+
+    await expect(
+      service.createNote({
+        path: "notes/history.md",
+        content: "one\n",
+        actor: marcus,
+      }),
+    ).resolves.toMatchObject({ ok: true, audit: { operation: "create" } });
+    await expect(
+      service.createNote({
+        path: "notes/history.md",
+        content: "two\n",
+        overwrite: true,
+        actor: marcus,
+      }),
+    ).resolves.toMatchObject({ ok: true, audit: { operation: "write" } });
+    await expect(service.readNote({ path: "notes/history.md" })).resolves.toMatchObject({
+      ok: true,
+      content: "two\n",
+    });
+
+    await expect(service.listNoteHistory({ path: "notes/history.md" })).resolves.toMatchObject({
+      ok: true,
+      entries: [
+        {
+          operation: "create",
+          actor: marcus,
+          content: "two\n",
+        },
+      ],
+      hasMore: false,
+    });
+    const rawAfterRead = await readRawFileHistory(root);
+    await expect(service.readNote({ path: "notes/history.md" })).resolves.toMatchObject({
+      ok: true,
+      content: "two\n",
+    });
+    await expect(readRawFileHistory(root)).resolves.toBe(rawAfterRead);
+
+    await expect(
+      service.appendNote({
+        path: "notes/history.md",
+        content: "three\n",
+        actor: olivia,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      content: "two\nthree\n",
+      audit: { operation: "append" },
+    });
+    await expect(service.listNoteHistory({ path: "notes/history.md" })).resolves.toMatchObject({
+      ok: true,
+      entries: [
+        {
+          operation: "update",
+          actor: olivia,
+          content: "two\nthree\n",
+        },
+        {
+          operation: "create",
+          actor: marcus,
+          content: "two\n",
+        },
+      ],
+    });
+  });
+
+  it("keeps service writes best-effort when file history metadata is malformed", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const actor = {
+      kind: "user" as const,
+      id: "marcus",
+      name: "Marcus",
+      client: "browser",
+    };
+
+    try {
+      await writeFileWithParents(join(root, ".kb2", "file-history.yml"), "paths: [");
+
+      await expect(
+        service.createNote({
+          path: "notes/corrupt-history.md",
+          content: "one\n",
+          actor,
+        }),
+      ).resolves.toMatchObject({ ok: true, audit: { operation: "create" } });
+      await expect(readFile(join(root, "notes", "corrupt-history.md"), "utf8")).resolves.toBe("one\n");
+
+      const read = await service.readNote({ path: "notes/corrupt-history.md" });
+      expect(read).toMatchObject({ ok: true, content: "one\n" });
+      if (!read.ok) throw new Error("expected corrupt-history note read to succeed");
+
+      await expect(
+        service.createNote({
+          path: "notes/corrupt-history.md",
+          content: "two\n",
+          overwrite: true,
+          actor,
+        }),
+      ).resolves.toMatchObject({ ok: true, audit: { operation: "write" } });
+      const overwritten = await service.readNote({ path: "notes/corrupt-history.md" });
+      expect(overwritten).toMatchObject({ ok: true, content: "two\n" });
+      const overwrittenBaseline = requireBaseline(overwritten);
+      await expect(
+        service.editNote({
+          path: "notes/corrupt-history.md",
+          baseline: overwrittenBaseline,
+          oldText: "two",
+          newText: "three",
+          actor,
+        }),
+      ).resolves.toMatchObject({ ok: true, content: "three\n" });
+      await expect(
+        service.appendNote({
+          path: "notes/corrupt-history.md",
+          content: "four\n",
+          actor,
+        }),
+      ).resolves.toMatchObject({ ok: true, content: "three\nfour\n" });
+      await expect(
+        service.prependNote({
+          path: "notes/corrupt-history.md",
+          content: "zero\n",
+          actor,
+        }),
+      ).resolves.toMatchObject({ ok: true, content: "zero\nthree\nfour\n" });
+      await expect(service.listNoteHistory({ path: "notes/corrupt-history.md" })).resolves.toMatchObject({
+        ok: false,
+        error: "metadata_parse_failed",
+      });
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("records document-session persisted history with Yjs attribution", async () => {
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const marcus = {
+      kind: "user" as const,
+      id: "marcus",
+      name: "Marcus",
+      client: "browser",
+    };
+    const olivia = {
+      kind: "user" as const,
+      id: "olivia",
+      name: "Olivia",
+      client: "cloud-relay",
+    };
+
+    await service.createNote({
+      path: "notes/socket.md",
+      content: "base\n",
+      actor: marcus,
+    });
+    const session = sessions.getSession("notes/socket.md");
+    await session.applyContent("socket\n", {
+      attribution: { actor: olivia },
+    });
+
+    await waitUntil(async () => {
+      const history = await service.listNoteHistory({ path: "notes/socket.md" });
+      return history.ok && history.entries.length === 2 && history.entries[0]?.actor.id === "olivia";
+    }, () => "expected Yjs-attributed history entry to be recorded");
+    await expect(service.listNoteHistory({ path: "notes/socket.md" })).resolves.toMatchObject({
+      ok: true,
+      entries: [
+        {
+          operation: "update",
+          actor: olivia,
+          content: "socket\n",
+        },
+        {
+          operation: "create",
+          actor: marcus,
+          content: "base\n",
+        },
+      ],
+    });
+  });
+
   it("routes live session writes and path transitions through the same audit-bearing response shape", async () => {
     await writeFileWithParents(join(root, "notes", "live.md"), "alpha\n");
     await writeFileWithParents(join(root, "tree", "child.md"), "child\n");
@@ -825,6 +1031,10 @@ async function readAuditRows(
     .trim()
     .split("\n")
     .map((line) => JSON.parse(line) as { operation: string });
+}
+
+async function readRawFileHistory(root: string): Promise<string> {
+  return readFile(join(root, ".kb2", "file-history.yml"), "utf8");
 }
 
 function requireBaseline(result: ServiceResult): string {

--- a/packages/vault-service/src/index.ts
+++ b/packages/vault-service/src/index.ts
@@ -12,8 +12,10 @@ import {
   deleteVaultFile,
   deleteVaultFolder,
   emitVaultAudit,
+  historyOperationFromAudit,
   getFolderMetadata as getVaultFolderMetadata,
   getVaultInfo,
+  listFileHistory,
   listFolderMetadata as listVaultFolderMetadata,
   listVaultTree,
   makeVaultFolder,
@@ -21,6 +23,7 @@ import {
   onVaultAudit,
   prependContent,
   readVaultFile,
+  recordFileHistory,
   searchVaultFiles,
   setFolderMetadata as setVaultFolderMetadata,
   validateVaultPath,
@@ -28,6 +31,7 @@ import {
   type AnchoredSpliceRequest,
   type AuditChangeEventOptions,
   type AuditEntry,
+  type FileHistoryEntry,
   type FolderMetadataInput,
   type VaultEntry,
   type VaultActor,
@@ -36,6 +40,7 @@ import {
 } from '@kb-2/vault-core';
 
 export type { AuditEntry, VaultActor };
+export type { FileHistoryEntry };
 
 export type ServiceErrorCode =
   | VaultErrorCode
@@ -118,6 +123,7 @@ export interface LocalMcpVaultService {
 }
 
 export interface VaultService extends LocalMcpVaultService {
+  listNoteHistory(input: { path: string; before?: string; beforeId?: string; limit?: number }): Promise<ServiceResult<{ entries: FileHistoryEntry[]; hasMore: boolean }>>;
   flushDirtySessions(): Promise<ServiceResult<{ flushed: number; durableAsOf: string }>>;
   onEvent(handler: VaultChangeEventHandler): () => void;
 }
@@ -125,6 +131,7 @@ export interface VaultService extends LocalMcpVaultService {
 export interface VaultServiceOptions {
   vaultRoot: string;
   documentSessions: DocumentSessionManager;
+  historyCoalesceWindowMs?: number;
 }
 
 export function createVaultService(options: VaultServiceOptions): VaultService {
@@ -216,7 +223,51 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
   options.documentSessions.onEvent((event) => {
     const change = changeEventFromDocumentSessionEvent(event);
     if (change) emitChange(change);
+    if (
+      event.kind === 'content-persisted' &&
+      event.attribution !== undefined &&
+      !isServiceWriteAttribution(event.attribution)
+    ) {
+      void recordPersistedSessionHistory(event).catch((error: unknown) => {
+        console.warn('KB-2 failed to record file history for persisted document session.', error);
+      });
+    }
   });
+  const recordHistory = async (
+    path: string,
+    operation: 'create' | 'update',
+    actor: VaultActor,
+    content: string
+  ): Promise<void> => {
+    const result = await recordFileHistory(options.vaultRoot, {
+      path,
+      operation,
+      actor,
+      content,
+      coalesceWindowMs: options.historyCoalesceWindowMs
+    });
+    if (!result.ok) {
+      throw new Error(`Failed to record file history for ${path}: ${result.message}`);
+    }
+  };
+  const recordHistoryFromAudit = async (audit: AuditEntry, content: string): Promise<void> => {
+    const operation = historyOperationFromAudit(audit.operation);
+    if (operation !== 'create' && operation !== 'update') return;
+    await recordHistory(audit.path, operation, audit.actor, content);
+  };
+  const recordServiceHistoryFromAudit = async (audit: AuditEntry, content: string): Promise<void> => {
+    try {
+      await recordHistoryFromAudit(audit, content);
+    } catch (error: unknown) {
+      console.warn('KB-2 failed to record file history for service write.', error);
+    }
+  };
+  const recordPersistedSessionHistory = async (event: DocumentSessionEvent): Promise<void> => {
+    const actor = vaultActorFromDocumentAttribution(event.attribution);
+    const read = await readVaultFile(ctx(), event.path);
+    if (!read.ok) return;
+    await recordHistory(event.path, 'update', actor, read.value.content);
+  };
 
   return {
     onEvent(handler) {
@@ -276,6 +327,10 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       };
     },
 
+    async listNoteHistory(input) {
+      return serviceResult(await listFileHistory(options.vaultRoot, input));
+    },
+
     async createNote(input) {
       const liveSession = options.documentSessions.getOpenSession(input.path);
       if (liveSession) {
@@ -296,6 +351,7 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
           summary: `Wrote ${input.path}`,
           changeEvent: { skipContentPersisted: true }
         });
+        await recordServiceHistoryFromAudit(audit, applied.value);
         return {
           ok: true,
           path: input.path,
@@ -310,6 +366,9 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
         content: input.content,
         overwrite: input.overwrite
       }));
+      if (result.ok) {
+        await recordServiceHistoryFromAudit(result.audit, input.content);
+      }
       return result;
     },
 
@@ -342,6 +401,7 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
         summary: `Spliced ${input.path}`,
         changeEvent: { skipContentPersisted: true }
       });
+      await recordServiceHistoryFromAudit(audit, result.value.content);
       return {
         ok: true,
         path: input.path,
@@ -372,6 +432,7 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
         summary: `Appended to ${input.path}`,
         changeEvent: { skipContentPersisted: true }
       });
+      await recordServiceHistoryFromAudit(audit, result.value.content);
       return {
         ok: true,
         path: input.path,
@@ -400,6 +461,7 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
         summary: `Prepended to ${input.path}`,
         changeEvent: { skipContentPersisted: true }
       });
+      await recordServiceHistoryFromAudit(audit, result.value.content);
       return {
         ok: true,
         path: input.path,
@@ -564,6 +626,33 @@ function actorAttribution(actor: VaultActor): DocumentUpdateAttribution {
     ...(actor.name !== undefined ? { name: actor.name } : {}),
     ...(actor.client !== undefined ? { client: actor.client } : {})
   };
+}
+
+function vaultActorFromDocumentAttribution(attribution: DocumentUpdateAttribution | undefined): VaultActor {
+  const actor = attribution?.actor;
+  if (!actor || typeof actor !== 'object' || Array.isArray(actor)) {
+    return { kind: 'unknown' };
+  }
+  const candidate = actor as Record<string, unknown>;
+  if (
+    candidate.kind !== 'user' &&
+    candidate.kind !== 'mcp_client' &&
+    candidate.kind !== 'integration' &&
+    candidate.kind !== 'system' &&
+    candidate.kind !== 'unknown'
+  ) {
+    return { kind: 'unknown' };
+  }
+  return {
+    kind: candidate.kind,
+    ...(typeof candidate.id === 'string' ? { id: candidate.id } : {}),
+    ...(typeof candidate.name === 'string' ? { name: candidate.name } : {}),
+    ...(typeof candidate.client === 'string' ? { client: candidate.client } : {})
+  };
+}
+
+function isServiceWriteAttribution(attribution: DocumentUpdateAttribution): boolean {
+  return typeof attribution.operation === 'string';
 }
 
 function emitAuditChange(


### PR DESCRIPTION
Part 1 of FC-7496 note history.

Changes:
- Add daemon-owned `.kb2/file-history.yml` metadata store for per-file create/update history snapshots.
- Record attribution from existing daemon actor/update attribution paths, with local fallback behavior preserved.
- Coalesce same actor + integration/client within configurable `KB2_HISTORY_COALESCE_WINDOW_MS` (default 5 minutes).
- Expose `GET /api/vaults/:id/files/:path/history` with newest-first `before`/`beforeId` paging.
- Keep reads/folders/vault/search/presence out of history writes.
- Keep service writes best-effort if existing history metadata is malformed: the write succeeds, history recording warns, and the read API still reports the metadata parse failure.

Verification:
- `pnpm --filter @kb-2/vault-core test`
- `pnpm --filter @kb-2/vault-service test`
- `pnpm --filter @kb-2/daemon test`
- `pnpm --filter @kb-2/vault-service typecheck`
- `pnpm check`
- parent cloud PR #111: `pnpm check` and `pnpm test:e2e` passed 14/14 after the best-effort fix

Review focus:
- Durable metadata shape and coalescing semantics.
- Yjs/session attribution propagation.
- Best-effort service-write behavior when `.kb2/file-history.yml` is corrupt.
- Route shape before cloud no-cache/proxy wiring in the parent stack.
