### PR TITLE
Render note history in daemon UI

### DIFF
--- a/apps/web/src/lib/kb-service.ts
+++ b/apps/web/src/lib/kb-service.ts
@@ -44,6 +44,40 @@ export interface SearchHit {
   };
 }
 
+export type FileHistoryOperation = "create" | "update" | "move" | "rename";
+
+export type FileHistoryActor = {
+  kind: string;
+  id?: string;
+  name?: string;
+  client?: string;
+  avatarUrl?: string | null;
+};
+
+export interface FileHistoryEntry {
+  id: string;
+  path: string;
+  operation: FileHistoryOperation;
+  actor: FileHistoryActor;
+  integrationId?: string;
+  createdAt: string;
+  updatedAt: string;
+  content: string;
+  size: number;
+  contentHash: string;
+}
+
+export interface FileHistoryPage {
+  entries: FileHistoryEntry[];
+  hasMore: boolean;
+}
+
+export interface ListNoteHistoryOptions {
+  before?: string;
+  beforeId?: string;
+  limit?: number;
+}
+
 /**
  * Maps a daemon service error code to a friendly message. Unknown codes
  * fall back to the raw message the daemon supplied. The optional
@@ -129,6 +163,15 @@ async function request<T extends { ok: true } = { ok: true }>(
 /** Build the scoped data-route prefix for a vault. */
 function vaultBase(vaultId: string): string {
   return `/api/vaults/${encodeURIComponent(vaultId)}`;
+}
+
+function noteHistoryQuery(options: ListNoteHistoryOptions): string {
+  const qs = new URLSearchParams();
+  if (options.before) qs.set("before", options.before);
+  if (options.beforeId) qs.set("beforeId", options.beforeId);
+  if (options.limit !== undefined) qs.set("limit", String(options.limit));
+  const query = qs.toString();
+  return query.length > 0 ? `?${query}` : "";
 }
 
 export const kbService = {
@@ -217,6 +260,17 @@ export const kbService = {
       `${vaultBase(vaultId)}/tree`,
     );
     return result.entries;
+  },
+
+  async listNoteHistory(
+    vaultId: string,
+    path: string,
+    options: ListNoteHistoryOptions = {},
+  ): Promise<FileHistoryPage> {
+    const result = await request<{ ok: true } & FileHistoryPage>(
+      `${vaultBase(vaultId)}/files/${encodeVaultPath(path)}/history${noteHistoryQuery(options)}`,
+    );
+    return { entries: result.entries, hasMore: result.hasMore };
   },
 
   async search(

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -22,6 +22,7 @@
   import {
     ConfirmDialog,
     DocumentByline,
+    DocumentHistoryPanel,
     DocumentNotFoundState,
     EditorSaveNotifications,
     EmptyVaultsState,
@@ -47,7 +48,7 @@
     ROOT_DEFAULT_COLOR,
     resolveFolderColor,
   } from '@kb-2/ui';
-  import { kbService, type VaultSummary } from '$lib/kb-service';
+  import { kbService, type FileHistoryEntry, type VaultSummary } from '$lib/kb-service';
   import type { DocumentSessionEvent } from '@kb-2/doc-session/protocol';
   import {
     useAppState,
@@ -58,7 +59,7 @@
   } from '$lib/app-state';
   import { buildStarredViewData } from '$lib/favorites-data';
   import { createViewportStore } from '$lib/viewport.svelte';
-  import { onMount, untrack } from 'svelte';
+  import { onDestroy, onMount, untrack } from 'svelte';
   import { createQueries, createQuery, useQueryClient } from '@tanstack/svelte-query';
   import { queryKeys } from '$lib/realtime';
 
@@ -171,6 +172,16 @@
   let persistRecoveredVisible = $state(false);
   let docDeleted = $state(false);
   let notFoundPath = $state<string | null>(null);
+  let historyPanelOpen = $state(false);
+  let historyEntries = $state<FileHistoryEntry[]>([]);
+  let historyHasMore = $state(false);
+  let historyLoading = $state(false);
+  let historyLoadingMore = $state(false);
+  let historyError = $state<string | null>(null);
+  let historyLoadedPath = $state<string | null>(null);
+  let historyLoadedVaultId = $state<string | null>(null);
+  let historyRequestId = 0;
+  let historyRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   // The vaults the daemon serves (id = stable slug, displayName = label).
   // The active id keys every data call and the collaborative socket.
   let knownVaults = $state<VaultSummary[]>([]);
@@ -522,6 +533,122 @@
       ? 'error'
       : 'normal',
   );
+
+  const HISTORY_PAGE_SIZE = 25;
+
+  function resetHistoryState(): void {
+    historyEntries = [];
+    historyHasMore = false;
+    historyLoading = false;
+    historyLoadingMore = false;
+    historyError = null;
+    historyLoadedPath = null;
+    historyLoadedVaultId = null;
+  }
+
+  function openHistoryPanel(): void {
+    if (viewingFolder) return;
+    if (!historyPanelOpen) resetHistoryState();
+    historyPanelOpen = true;
+  }
+
+  function closeHistoryPanel(): void {
+    historyPanelOpen = false;
+  }
+
+  async function loadHistoryHead(path: string): Promise<void> {
+    if (!activeVaultId || path.length === 0) return;
+    const vaultIdForRequest = activeVaultId;
+    const requestId = ++historyRequestId;
+    historyLoading = true;
+    historyError = null;
+    try {
+      const page = await kbService.listNoteHistory(vaultIdForRequest, path, {
+        limit: HISTORY_PAGE_SIZE,
+      });
+      if (requestId !== historyRequestId) return;
+      historyEntries = page.entries;
+      historyHasMore = page.hasMore;
+      historyLoadedPath = path;
+      historyLoadedVaultId = vaultIdForRequest;
+    } catch (cause) {
+      if (requestId !== historyRequestId) return;
+      historyError =
+        cause instanceof Error ? cause.message : 'Failed to load history.';
+    } finally {
+      if (requestId === historyRequestId) historyLoading = false;
+    }
+  }
+
+  async function loadOlderHistory(): Promise<void> {
+    const vaultIdForRequest = historyLoadedVaultId ?? activeVaultId;
+    if (!vaultIdForRequest || historyLoadingMore || historyEntries.length === 0) {
+      return;
+    }
+    const path = historyLoadedPath ?? documentPath;
+    const oldest = historyEntries[historyEntries.length - 1];
+    historyLoadingMore = true;
+    historyError = null;
+    try {
+      const page = await kbService.listNoteHistory(vaultIdForRequest, path, {
+        before: oldest.createdAt,
+        beforeId: oldest.id,
+        limit: HISTORY_PAGE_SIZE,
+      });
+      const seen = new Set(historyEntries.map((entry) => entry.id));
+      const merged = [...historyEntries];
+      for (const entry of page.entries) {
+        if (!seen.has(entry.id)) merged.push(entry);
+      }
+      historyEntries = merged;
+      historyHasMore = page.hasMore;
+    } catch (cause) {
+      historyError =
+        cause instanceof Error ? cause.message : 'Failed to load older history.';
+    } finally {
+      historyLoadingMore = false;
+    }
+  }
+
+  function scheduleHistoryRefresh(): void {
+    if (!historyPanelOpen || viewingFolder || documentPath.length === 0) return;
+    if (historyRefreshTimer !== null) clearTimeout(historyRefreshTimer);
+    const path = documentPath;
+    historyRefreshTimer = setTimeout(() => {
+      historyRefreshTimer = null;
+      void loadHistoryHead(path);
+    }, 1_000);
+  }
+
+  onDestroy(() => {
+    historyRequestId += 1;
+    if (historyRefreshTimer !== null) clearTimeout(historyRefreshTimer);
+  });
+
+  $effect(() => {
+    if (!historyPanelOpen) return;
+    if (viewingFolder) {
+      historyPanelOpen = false;
+      resetHistoryState();
+      return;
+    }
+    const path = documentPath;
+    const activeVaultKey = activeVaultId;
+    if (path.length === 0) return;
+    untrack(() => {
+      if (historyLoadedPath !== path || historyLoadedVaultId !== activeVaultKey) {
+        void loadHistoryHead(path);
+      }
+    });
+  });
+
+  $effect(() => {
+    const saveStatus = saveState.status;
+    if (saveStatus !== 'saved') return;
+    untrack(() => {
+      scheduleHistoryRefresh();
+    });
+  });
 
   // The document header breadcrumb trail. Built in the app from the
   // active path so the package stays free of path-parsing policy
@@ -1657,23 +1784,41 @@
         {#if notFoundPath === documentPath}
           <DocumentNotFoundState path={documentPath} />
         {:else if provider && providerSynced}
-          <div class="doc-column">
-            <DocumentByline
-              statusLabel={bylineStatusLabel}
-              statusTone={bylineStatusTone}
-            />
-            {#key provider}
-              <PlaintextEditor
-                ydoc={provider.doc}
-                ytext={provider.text}
-                livePaths={livePaths}
-                orgPeople={orgPeople}
-                readOnly={docDeleted}
-                scroll="external"
-                class="vault-editor"
-                onWikilinkClick={handleWikilinkClick}
+          <div class:history-open={historyPanelOpen} class="document-workspace">
+            <div class="doc-column">
+              <DocumentByline
+                statusLabel={bylineStatusLabel}
+                statusTone={bylineStatusTone}
+                onHistory={openHistoryPanel}
               />
-            {/key}
+              {#key provider}
+                <PlaintextEditor
+                  ydoc={provider.doc}
+                  ytext={provider.text}
+                  livePaths={livePaths}
+                  orgPeople={orgPeople}
+                  readOnly={docDeleted}
+                  scroll="external"
+                  class="vault-editor"
+                  onWikilinkClick={handleWikilinkClick}
+                />
+              {/key}
+            </div>
+            {#if historyPanelOpen}
+              <DocumentHistoryPanel
+                class="note-history-panel"
+                path={documentPath}
+                entries={historyEntries}
+                loading={historyLoading}
+                loadingMore={historyLoadingMore}
+                error={historyError}
+                hasMore={historyHasMore}
+                onClose={closeHistoryPanel}
+                onLoadMore={() => {
+                  void loadOlderHistory();
+                }}
+              />
+            {/if}
           </div>
         {:else if mounted}
           <div class="loading">Opening document…</div>
@@ -1884,6 +2029,20 @@
     }
   }
 
+  .document-workspace {
+    max-width: 760px;
+    margin: 0 auto;
+    width: 100%;
+  }
+
+  .document-workspace.history-open {
+    max-width: 1160px;
+    display: grid;
+    grid-template-columns: minmax(0, 760px) minmax(280px, 340px);
+    gap: 48px;
+    align-items: start;
+  }
+
   /* Single owning element for the document column geometry — the editor
      is a width:100% child, centered at a fixed prose measure. */
   .doc-column {
@@ -1892,11 +2051,22 @@
     width: 100%;
   }
 
+  .document-workspace.history-open .doc-column {
+    margin: 0;
+  }
+
   /* Editor surface only — transparent so the doc-body's panel color
      shows through. Top breathing room sits on the column, not a header
      band. */
   .doc-body :global(.vault-editor) {
     background: transparent;
+  }
+
+  @media (max-width: 1180px) {
+    .document-workspace.history-open {
+      max-width: 760px;
+      display: block;
+    }
   }
 
   .loading {

--- a/apps/web/src/test/local-editor-route.test.ts
+++ b/apps/web/src/test/local-editor-route.test.ts
@@ -136,6 +136,59 @@ describe("local editor route", () => {
             ],
           });
         }
+        if (url === "/api/vaults/demo-vault/files/hello-world.md/history?limit=25") {
+          return json({
+            ok: true,
+            entries: [
+              {
+                id: "hist-2",
+                path: "hello-world.md",
+                operation: "update",
+                actor: { kind: "user", id: "marcus", name: "Marcus" },
+                integrationId: "agent-codex",
+                createdAt: "2026-06-30T05:01:00.000Z",
+                updatedAt: "2026-06-30T05:03:00.000Z",
+                content: "second version",
+                size: 14,
+                contentHash: "hash-2",
+              },
+              {
+                id: "hist-1",
+                path: "hello-world.md",
+                operation: "create",
+                actor: { kind: "user", id: "olivia", name: "Olivia" },
+                createdAt: "2026-06-30T05:00:00.000Z",
+                updatedAt: "2026-06-30T05:00:00.000Z",
+                content: "first version",
+                size: 13,
+                contentHash: "hash-1",
+              },
+            ],
+            hasMore: true,
+          });
+        }
+        if (
+          url ===
+          "/api/vaults/demo-vault/files/hello-world.md/history?before=2026-06-30T05%3A00%3A00.000Z&beforeId=hist-1&limit=25"
+        ) {
+          return json({
+            ok: true,
+            entries: [
+              {
+                id: "hist-0",
+                path: "hello-world.md",
+                operation: "update",
+                actor: { kind: "agent", id: "local-agent", name: "local agent" },
+                createdAt: "2026-06-30T04:55:00.000Z",
+                updatedAt: "2026-06-30T04:55:00.000Z",
+                content: "older version",
+                size: 13,
+                contentHash: "hash-0",
+              },
+            ],
+            hasMore: false,
+          });
+        }
         return json(
           { ok: false, error: "not_found", message: `Unhandled ${url}` },
           404,
@@ -250,6 +303,41 @@ describe("local editor route", () => {
       "content:projects/active/editor-shell.md",
     );
     expect(editor.value).toBe("content:projects/active/editor-shell.md");
+  });
+
+  it("opens note history from the byline and pages older entries", async () => {
+    render(AppStateHarness);
+
+    expect(await screen.findByLabelText("Markdown editor")).toBeTruthy();
+    await fireEvent.click(screen.getByRole("button", { name: "History" }));
+
+    const panel = within(await screen.findByTestId("document-history-panel"));
+    expect(await panel.findByText("Marcus")).toBeTruthy();
+    expect(panel.getByText("Olivia")).toBeTruthy();
+    expect(panel.getByText("second version")).toBeTruthy();
+    expect(panel.getByText("first version")).toBeTruthy();
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.some(
+          ([url]) => url === "/api/vaults/demo-vault/files/hello-world.md/history?limit=25",
+        ),
+    ).toBe(true);
+
+    await fireEvent.click(panel.getByRole("button", { name: "Load older" }));
+
+    await waitFor(() => {
+      expect(panel.getByText("older version")).toBeTruthy();
+    });
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.some(
+          ([url]) =>
+            url ===
+            "/api/vaults/demo-vault/files/hello-world.md/history?before=2026-06-30T05%3A00%3A00.000Z&beforeId=hist-1&limit=25",
+        ),
+    ).toBe(true);
   });
 
   it("rebinds the editor on history navigation and can land on a deleted document path", async () => {

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -46,6 +46,7 @@ export type {
 } from "./layout/LocalStatusShell.svelte";
 export { default as DocumentSaveBanner } from "./notifications/DocumentSaveBanner.svelte";
 export { default as DocumentByline } from "./local-editor/DocumentByline.svelte";
+export { default as DocumentHistoryPanel } from "./local-editor/DocumentHistoryPanel.svelte";
 export { default as DocumentHeader } from "./local-editor/DocumentHeader.svelte";
 export { default as DocumentHeaderMenu } from "./local-editor/DocumentHeaderMenu.svelte";
 export { default as FolderCanvas } from "./local-editor/FolderCanvas.svelte";

--- a/packages/ui/src/lib/local-editor/DocumentByline.svelte
+++ b/packages/ui/src/lib/local-editor/DocumentByline.svelte
@@ -3,19 +3,21 @@
    * Ported from KB-1:
    * apps/@kb-1/web/src/lib/components/app/canvas/document/DocumentByline.svelte
    *
-   * Local daemon delta: metadata/history links are intentionally omitted until
-   * those surfaces exist here. The right-side snippet lets cloud pass presence
-   * avatars while the daemon uses the same byline minus presence.
+   * Local daemon delta: metadata is still omitted until that surface exists.
+   * History now mirrors KB-1's byline affordance and opens the note-scoped
+   * history panel from the route shell.
    */
   interface Props {
     statusLabel?: string;
     statusTone?: "normal" | "error";
+    onHistory?: () => void;
     right?: import("svelte").Snippet;
   }
 
   let {
     statusLabel,
     statusTone = "normal",
+    onHistory,
     right,
   }: Props = $props();
 </script>
@@ -24,6 +26,12 @@
   <div class="left">
     {#if statusLabel}
       <span class="status" class:error={statusTone === "error"}>{statusLabel}</span>
+    {/if}
+    {#if statusLabel && onHistory}
+      <span class="sep" aria-hidden="true">·</span>
+    {/if}
+    {#if onHistory}
+      <button type="button" class="link" onclick={onHistory}>History</button>
     {/if}
   </div>
 
@@ -86,6 +94,25 @@
 
   .status.error {
     color: rgb(220 38 38);
+  }
+
+  .link {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    color: var(--rd-ink-3);
+    font: inherit;
+    letter-spacing: inherit;
+    cursor: pointer;
+  }
+
+  .link:hover {
+    color: var(--rd-ink-1);
+  }
+
+  .sep {
+    color: var(--rd-ink-5);
   }
 
   @media (max-width: 880px) {

--- a/packages/ui/src/lib/local-editor/DocumentHistoryPanel.svelte
+++ b/packages/ui/src/lib/local-editor/DocumentHistoryPanel.svelte
@@ -1,0 +1,427 @@
+<script lang="ts">
+  import Icon from "../primitives/Icon.svelte";
+
+  // Borrowed from KB-1's components/history/HistoryList.svelte and
+  // components/history/HistoryRow.svelte. This port renders content-version
+  // snapshots instead of KB-1's change-feed because FC-7496 Part 1 stores a
+  // daemon-owned per-file content-version log.
+  export type DocumentHistoryOperation = "create" | "update" | "move" | "rename";
+
+  export type DocumentHistoryActor = {
+    kind: string;
+    id?: string;
+    name?: string;
+    client?: string;
+    avatarUrl?: string | null;
+  };
+
+  export interface DocumentHistoryEntry {
+    id: string;
+    path: string;
+    operation: DocumentHistoryOperation;
+    actor: DocumentHistoryActor;
+    integrationId?: string;
+    createdAt: string;
+    updatedAt: string;
+    content: string;
+    size: number;
+    contentHash: string;
+  }
+
+  interface Props {
+    path: string;
+    entries: readonly DocumentHistoryEntry[];
+    loading?: boolean;
+    loadingMore?: boolean;
+    error?: string | null;
+    hasMore?: boolean;
+    onClose?: () => void;
+    onLoadMore?: () => void;
+    now?: number;
+    class?: string;
+  }
+
+  let {
+    path,
+    entries,
+    loading = false,
+    loadingMore = false,
+    error = null,
+    hasMore = false,
+    onClose,
+    onLoadMore,
+    now = Date.now(),
+    class: className,
+  }: Props = $props();
+
+  const absoluteFormatter = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+  function fileLabel(filePath: string): string {
+    const leaf = filePath.split("/").filter(Boolean).at(-1);
+    return leaf && leaf.length > 0 ? leaf : "Untitled";
+  }
+
+  function operationLabel(operation: DocumentHistoryOperation): string {
+    switch (operation) {
+      case "create":
+        return "Created";
+      case "move":
+        return "Moved";
+      case "rename":
+        return "Renamed";
+      default:
+        return "Updated";
+    }
+  }
+
+  function operationClass(operation: DocumentHistoryOperation): string {
+    switch (operation) {
+      case "create":
+        return "is-create";
+      case "move":
+      case "rename":
+        return "is-move";
+      default:
+        return "is-update";
+    }
+  }
+
+  function actorName(actor: DocumentHistoryActor): string {
+    if (actor.name && actor.name.length > 0) return actor.name;
+    if (actor.id && actor.id.length > 0) return actor.id;
+    if (actor.kind === "agent" || actor.client) return "local agent";
+    return "local user";
+  }
+
+  function actorDetail(entry: DocumentHistoryEntry): string | null {
+    if (entry.actor.client && entry.actor.client.length > 0) {
+      return entry.actor.client;
+    }
+    if (entry.integrationId && entry.integrationId.length > 0) {
+      return entry.integrationId;
+    }
+    return null;
+  }
+
+  function formatWhen(value: string): string {
+    const time = new Date(value).getTime();
+    if (!Number.isFinite(time)) return "Unknown time";
+    const diff = Math.max(0, now - time);
+    const minutes = Math.floor(diff / 60_000);
+    if (minutes < 5) return "<5m";
+    if (minutes < 60) return "<1h";
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h`;
+    const days = Math.floor(hours / 24);
+    if (days < 7) return `${days}d`;
+    return absoluteFormatter.format(new Date(time));
+  }
+
+  function previewContent(content: string): string {
+    const normalized = content.replace(/\r\n/g, "\n").trim();
+    if (normalized.length === 0) return "(empty note)";
+    const lines = normalized.split("\n");
+    const clipped = lines.slice(0, 8).join("\n");
+    const withLineClip = lines.length > 8 ? `${clipped}\n...` : clipped;
+    return withLineClip.length > 520
+      ? `${withLineClip.slice(0, 520).trimEnd()}...`
+      : withLineClip;
+  }
+</script>
+
+<aside
+  class={["history-panel", className].filter(Boolean).join(" ")}
+  aria-label="Note history"
+  data-testid="document-history-panel"
+>
+  <header class="panel-head">
+    <div class="heading">
+      <div class="eyebrow">History</div>
+      <h2>{fileLabel(path)}</h2>
+      <div class="path" title={path}>{path}</div>
+    </div>
+    {#if onClose}
+      <button
+        type="button"
+        class="close"
+        aria-label="Close history"
+        onclick={onClose}
+      >
+        <Icon name="x" size={15} weight="regular" />
+      </button>
+    {/if}
+  </header>
+
+  <div class="panel-body">
+    {#if error !== null && entries.length === 0}
+      <div class="state error">{error}</div>
+    {:else if loading && entries.length === 0}
+      <div class="state">Loading history...</div>
+    {:else if entries.length === 0}
+      <div class="state">No history yet.</div>
+    {:else}
+      <ol class="entries">
+        {#each entries as entry (entry.id)}
+          <li class="entry" data-testid="document-history-entry">
+            <div class="marker" aria-hidden="true">
+              <Icon name="history" size={14} weight="regular" />
+            </div>
+            <div class="entry-main">
+              <div class="entry-meta">
+                <span class="actor">{actorName(entry.actor)}</span>
+                {#if actorDetail(entry)}
+                  <span class="detail">· {actorDetail(entry)}</span>
+                {/if}
+                <span class={`operation ${operationClass(entry.operation)}`}>
+                  {operationLabel(entry.operation).toLowerCase()}
+                </span>
+                <time datetime={entry.updatedAt}>
+                  {formatWhen(entry.updatedAt)}
+                </time>
+              </div>
+              <pre class="snapshot">{previewContent(entry.content)}</pre>
+            </div>
+          </li>
+        {/each}
+      </ol>
+
+      {#if hasMore}
+        <button
+          type="button"
+          class="load-more"
+          disabled={loadingMore}
+          onclick={() => onLoadMore?.()}
+        >
+          {loadingMore ? "Loading..." : "Load older"}
+        </button>
+      {/if}
+
+      {#if error !== null}
+        <div class="state error inline">{error}</div>
+      {/if}
+    {/if}
+  </div>
+</aside>
+
+<style>
+  .history-panel {
+    width: min(340px, 100%);
+    max-height: calc(100vh - 148px);
+    display: flex;
+    flex-direction: column;
+    border-left: 1px solid color-mix(in srgb, var(--rd-ink-5) 36%, transparent);
+    padding: 30px 0 0 24px;
+    color: var(--rd-ink-2);
+    font-family: var(--rd-ui);
+  }
+
+  .panel-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding-bottom: 14px;
+    border-bottom: 1px solid color-mix(in srgb, var(--rd-ink-5) 28%, transparent);
+  }
+
+  .heading {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .eyebrow {
+    color: var(--rd-ink-4);
+    font-family: var(--rd-mono);
+    font-size: 10px;
+    text-transform: uppercase;
+  }
+
+  h2 {
+    margin: 4px 0 2px;
+    color: var(--rd-ink-1);
+    font-size: 15px;
+    line-height: 1.25;
+    font-weight: 600;
+    overflow-wrap: anywhere;
+  }
+
+  .path {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--rd-ink-4);
+    font-family: var(--rd-mono);
+    font-size: 11px;
+  }
+
+  .close {
+    width: 26px;
+    height: 26px;
+    display: inline-grid;
+    place-items: center;
+    border: 1px solid transparent;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--rd-ink-3);
+    cursor: pointer;
+  }
+
+  .close:hover {
+    border-color: color-mix(in srgb, var(--rd-ink-5) 42%, transparent);
+    background: color-mix(in srgb, var(--rd-ink-5) 10%, transparent);
+    color: var(--rd-ink-1);
+  }
+
+  .panel-body {
+    min-height: 0;
+    overflow: auto;
+    padding: 14px 2px 32px 0;
+  }
+
+  .state {
+    padding: 12px 0;
+    color: var(--rd-ink-4);
+    font-size: 12px;
+    line-height: 1.45;
+  }
+
+  .state.error {
+    color: rgb(185 28 28);
+  }
+
+  .state.inline {
+    padding-top: 8px;
+  }
+
+  .entries {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .entry {
+    display: grid;
+    grid-template-columns: 18px minmax(0, 1fr);
+    gap: 10px;
+    padding: 0 0 18px;
+  }
+
+  .marker {
+    margin-top: 2px;
+    width: 18px;
+    height: 18px;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    color: var(--rd-ink-4);
+    background: color-mix(in srgb, var(--rd-panel) 90%, var(--rd-ink-5));
+  }
+
+  .entry-main {
+    min-width: 0;
+    border-bottom: 1px solid color-mix(in srgb, var(--rd-ink-5) 22%, transparent);
+    padding-bottom: 16px;
+  }
+
+  .entry-meta {
+    display: flex;
+    align-items: baseline;
+    gap: 5px;
+    min-width: 0;
+    color: var(--rd-ink-3);
+    font-size: 12px;
+    line-height: 1.35;
+  }
+
+  .actor {
+    min-width: 0;
+    max-width: 130px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--rd-ink-1);
+    font-weight: 600;
+  }
+
+  .detail {
+    min-width: 0;
+    max-width: 96px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--rd-ink-4);
+  }
+
+  .operation {
+    margin-left: 2px;
+    font-weight: 600;
+  }
+
+  .operation.is-create {
+    color: rgb(4 120 87);
+  }
+
+  .operation.is-update {
+    color: rgb(3 105 161);
+  }
+
+  .operation.is-move {
+    color: rgb(180 83 9);
+  }
+
+  time {
+    margin-left: auto;
+    flex-shrink: 0;
+    color: var(--rd-ink-4);
+    font-family: var(--rd-mono);
+    font-size: 11px;
+  }
+
+  .snapshot {
+    margin: 8px 0 0;
+    max-height: 154px;
+    overflow: hidden;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    color: var(--rd-ink-2);
+    font: 12px/1.45 var(--rd-mono);
+  }
+
+  .load-more {
+    width: 100%;
+    height: 30px;
+    border: 1px solid color-mix(in srgb, var(--rd-ink-5) 42%, transparent);
+    border-radius: 5px;
+    background: transparent;
+    color: var(--rd-ink-3);
+    font: 12px var(--rd-ui);
+    cursor: pointer;
+  }
+
+  .load-more:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--rd-ink-5) 10%, transparent);
+    color: var(--rd-ink-1);
+  }
+
+  .load-more:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+
+  @media (max-width: 1180px) {
+    .history-panel {
+      width: 100%;
+      max-height: none;
+      border-left: 0;
+      border-top: 1px solid color-mix(in srgb, var(--rd-ink-5) 36%, transparent);
+      margin-top: 28px;
+      padding: 22px 0 0;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- add the shared note history side panel and byline History affordance to the daemon UI
- wire the daemon web service to the daemon-owned file history API with cursor paging
- cover opening the panel and loading older history entries in the local editor route test

## Verification
- pnpm --filter @kb-2/web exec vitest run src/test/local-editor-route.test.ts
- pnpm --filter @kb-2/ui typecheck
- pnpm --filter @kb-2/web typecheck
- pnpm check (daemon repo)
- manual browser check on daemon UI: History panel rendered attributed Marcus/Codex file history rows
- cloud full gate using this daemon pointer: pnpm test:e2e passed 14/14 on rerun after clearing orphaned e2e containers

## Notes
- stacked on daemon PR #47 / branch fc7496-history-part-1-daemon-store
- the first full e2e attempt hit a setup timeout before UI execution, left orphaned e2e containers, and passed 14/14 after those containers were cleared