### PR TITLE
Carry note history across file moves

### DIFF
--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -442,6 +442,51 @@ describe("daemon routing", () => {
     const historyAgain = await app.request(`${filePath("notes/attributed.md")}/history`);
     expect(historyAgain.status).toBe(200);
     await expect(readRawFileHistory(vaultRoot)).resolves.toBe(rawHistory);
+
+    const moved = await app.request(`${filePath("notes/attributed.md")}/move`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-kb1-actor": JSON.stringify(suppliedActor),
+      },
+      body: JSON.stringify({ to: "archive/attributed.md" }),
+    });
+    expect(moved.status).toBe(200);
+    await expect(moved.json()).resolves.toMatchObject({
+      ok: true,
+      fromPath: "notes/attributed.md",
+      toPath: "archive/attributed.md",
+      audit: { actor: suppliedActor },
+    });
+
+    const oldHistory = await app.request(`${filePath("notes/attributed.md")}/history`);
+    expect(oldHistory.status).toBe(200);
+    await expect(oldHistory.json()).resolves.toMatchObject({
+      ok: true,
+      hasMore: false,
+      entries: [],
+    });
+
+    const movedHistory = await app.request(`${filePath("archive/attributed.md")}/history`);
+    expect(movedHistory.status).toBe(200);
+    await expect(movedHistory.json()).resolves.toMatchObject({
+      ok: true,
+      hasMore: false,
+      entries: [
+        {
+          operation: "move",
+          path: "archive/attributed.md",
+          actor: suppliedActor,
+          content: "attributed\n",
+        },
+        {
+          operation: "create",
+          path: "archive/attributed.md",
+          actor: suppliedActor,
+          content: "attributed\n",
+        },
+      ],
+    });
   });
 
   it.each([

--- a/packages/vault-core/src/file-history.ts
+++ b/packages/vault-core/src/file-history.ts
@@ -39,6 +39,14 @@ export interface ListFileHistoryInput {
   limit?: number;
 }
 
+export interface MoveFileHistoryInput {
+  fromPath: string;
+  toPath: string;
+  actor?: VaultActor;
+  content: string;
+  now?: Date;
+}
+
 export interface FileHistoryPage {
   entries: FileHistoryEntry[];
   hasMore: boolean;
@@ -183,6 +191,57 @@ export async function listFileHistory(
       hasMore: limited.length > entries.length,
     },
   };
+}
+
+export async function moveFileHistory(
+  root: string,
+  input: MoveFileHistoryInput,
+): Promise<VaultResult<FileHistoryEntry>> {
+  let from: string;
+  let to: string;
+  try {
+    from = validateVaultPath(input.fromPath, "file");
+    to = validateVaultPath(input.toPath, "file");
+  } catch (error) {
+    if (error instanceof Error) {
+      return fail("invalid_path", error.message);
+    }
+    /* v8 ignore next -- validateVaultPath throws Error instances; non-Error throws are defensive rethrows. */
+    throw error;
+  }
+
+  return await withFileHistoryMutation(root, async () => {
+    const map = await readFileHistoryMap(root);
+    if (!map.ok) return map;
+
+    const movedEntries = (map.value[from] ?? []).map((entry) => ({
+      ...entry,
+      path: to,
+    }));
+    const actor = cloneActor(input.actor ?? { kind: "unknown" });
+    const integrationId = integrationIdForActor(actor);
+    const nowIso = (input.now ?? new Date()).toISOString();
+    const contentHash = await hashContent(input.content);
+    const size = new TextEncoder().encode(input.content).byteLength;
+    const entry: FileHistoryEntry = {
+      id: randomUUID(),
+      path: to,
+      operation: moveOperationForPaths(from, to),
+      actor,
+      ...(integrationId !== undefined ? { integrationId } : {}),
+      createdAt: nowIso,
+      updatedAt: nowIso,
+      content: input.content,
+      size,
+      contentHash,
+    };
+
+    const nextMap = { ...map.value };
+    delete nextMap[from];
+    nextMap[to] = [...movedEntries, entry];
+    await writeFileHistoryMap(root, nextMap);
+    return { ok: true, value: cloneFileHistoryEntry(entry) };
+  });
 }
 
 export function historyOperationFromAudit(operation: AuditOperation): FileHistoryOperation | undefined {
@@ -421,6 +480,15 @@ function actorKey(actor: VaultActor): string {
 
 function integrationIdForActor(actor: VaultActor): string | undefined {
   return actor.client;
+}
+
+function moveOperationForPaths(
+  fromPath: string,
+  toPath: string,
+): "move" | "rename" {
+  return path.posix.dirname(fromPath) === path.posix.dirname(toPath)
+    ? "rename"
+    : "move";
 }
 
 function applyHistoryCursor(

--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -38,6 +38,7 @@ import { onVaultAudit } from "./audit.js";
 import {
   historyOperationFromAudit,
   listFileHistory,
+  moveFileHistory,
   recordFileHistory,
 } from "./file-history.js";
 import { searchVaultFiles } from "./search.js";
@@ -346,6 +347,114 @@ describe("vault-core filesystem operations", () => {
       "alpha/sorted.md",
       "notes/history.md",
     ]);
+  });
+
+  it("carries path-keyed file history across file moves and renames", async () => {
+    const actor = {
+      kind: "user" as const,
+      id: "marcus",
+      name: "Marcus",
+      client: "browser",
+    };
+
+    await recordFileHistory(root, {
+      path: "notes/original.md",
+      operation: "create",
+      actor,
+      content: "one\n",
+      now: new Date("2026-06-30T00:00:00.000Z"),
+    });
+    await expect(
+      moveFileHistory(root, {
+        fromPath: "notes/original.md",
+        toPath: "notes/renamed.md",
+        actor,
+        content: "one\n",
+        now: new Date("2026-06-30T00:01:00.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: {
+        path: "notes/renamed.md",
+        operation: "rename",
+        actor,
+        content: "one\n",
+      },
+    });
+    await expect(listFileHistory(root, { path: "notes/original.md" })).resolves.toMatchObject({
+      ok: true,
+      value: { entries: [], hasMore: false },
+    });
+    await expect(listFileHistory(root, { path: "notes/renamed.md" })).resolves.toMatchObject({
+      ok: true,
+      value: {
+        entries: [
+          { path: "notes/renamed.md", operation: "rename", content: "one\n" },
+          { path: "notes/renamed.md", operation: "create", content: "one\n" },
+        ],
+      },
+    });
+
+    await recordFileHistory(root, {
+      path: "move/source.md",
+      operation: "create",
+      actor,
+      content: "move me\n",
+      now: new Date("2026-06-30T00:01:30.000Z"),
+    });
+    await recordFileHistory(root, {
+      path: "archive/source.md",
+      operation: "create",
+      actor: { kind: "system" },
+      content: "unrelated target\n",
+      now: new Date("2026-06-30T00:01:40.000Z"),
+    });
+    await expect(
+      moveFileHistory(root, {
+        fromPath: "move/source.md",
+        toPath: "archive/source.md",
+        actor,
+        content: "move me\n",
+        now: new Date("2026-06-30T00:01:45.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: { operation: "move", path: "archive/source.md" },
+    });
+    await expect(listFileHistory(root, { path: "archive/source.md" })).resolves.toMatchObject({
+      ok: true,
+      value: {
+        entries: [
+          { operation: "move", actor, content: "move me\n" },
+          { operation: "create", actor, content: "move me\n" },
+        ],
+      },
+    });
+
+    await expect(
+      moveFileHistory(root, {
+        fromPath: "../outside.md",
+        toPath: "notes/nope.md",
+        actor,
+        content: "",
+      }),
+    ).resolves.toMatchObject({ ok: false, error: "invalid_path" });
+
+    await writeRawFileHistory(root, { files: { "empty.md": [] } });
+    await expect(listFileHistory(root, { path: "empty.md" })).resolves.toMatchObject({
+      ok: true,
+      value: { entries: [], hasMore: false },
+    });
+
+    await writeRawFileHistory(root, "files: [");
+    await expect(
+      moveFileHistory(root, {
+        fromPath: "notes/a.md",
+        toPath: "notes/b.md",
+        actor,
+        content: "",
+      }),
+    ).resolves.toMatchObject({ ok: false, error: "metadata_parse_failed" });
   });
 
   it("rejects invalid history inputs and malformed durable metadata", async () => {

--- a/packages/vault-core/src/index.ts
+++ b/packages/vault-core/src/index.ts
@@ -15,11 +15,13 @@ export {
 export {
   historyOperationFromAudit,
   listFileHistory,
+  moveFileHistory,
   recordFileHistory,
   type FileHistoryEntry,
   type FileHistoryOperation,
   type FileHistoryPage,
   type ListFileHistoryInput,
+  type MoveFileHistoryInput,
   type RecordFileHistoryInput,
 } from "./file-history.js";
 export { isNodeError, statOrNull } from "./fs.js";

--- a/packages/vault-service/src/index.test.ts
+++ b/packages/vault-service/src/index.test.ts
@@ -267,6 +267,126 @@ describe("vault service failure mapping", () => {
     });
   });
 
+  it("carries note history across cold and live note moves", async () => {
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const marcus = {
+      kind: "user" as const,
+      id: "marcus",
+      name: "Marcus",
+      client: "browser",
+    };
+    const olivia = {
+      kind: "user" as const,
+      id: "olivia",
+      name: "Olivia",
+      client: "browser",
+    };
+
+    await expect(
+      service.createNote({
+        path: "notes/history.md",
+        content: "one\n",
+        actor: marcus,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    await expect(
+      service.appendNote({
+        path: "notes/history.md",
+        content: "two\n",
+        actor: olivia,
+      }),
+    ).resolves.toMatchObject({ ok: true, content: "one\ntwo\n" });
+    await expect(
+      service.moveNote({
+        fromPath: "notes/history.md",
+        toPath: "archive/history.md",
+        actor: marcus,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      fromPath: "notes/history.md",
+      toPath: "archive/history.md",
+      audit: { operation: "move", actor: marcus },
+    });
+    await expect(service.listNoteHistory({ path: "notes/history.md" })).resolves.toMatchObject({
+      ok: true,
+      entries: [],
+      hasMore: false,
+    });
+    await expect(service.listNoteHistory({ path: "archive/history.md" })).resolves.toMatchObject({
+      ok: true,
+      entries: [
+        {
+          path: "archive/history.md",
+          operation: "move",
+          actor: marcus,
+          content: "one\ntwo\n",
+        },
+        {
+          path: "archive/history.md",
+          operation: "update",
+          actor: olivia,
+          content: "one\ntwo\n",
+        },
+        {
+          path: "archive/history.md",
+          operation: "create",
+          actor: marcus,
+          content: "one\n",
+        },
+      ],
+      hasMore: false,
+    });
+
+    await expect(
+      service.createNote({
+        path: "live/rename.md",
+        content: "live\n",
+        actor: olivia,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    await sessions.getSession("live/rename.md").open();
+    await expect(
+      service.moveNote({
+        fromPath: "live/rename.md",
+        toPath: "live/renamed.md",
+        actor: marcus,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      fromPath: "live/rename.md",
+      toPath: "live/renamed.md",
+      live: true,
+      audit: { operation: "move", actor: marcus },
+    });
+    await expect(service.listNoteHistory({ path: "live/rename.md" })).resolves.toMatchObject({
+      ok: true,
+      entries: [],
+      hasMore: false,
+    });
+    await expect(service.listNoteHistory({ path: "live/renamed.md" })).resolves.toMatchObject({
+      ok: true,
+      entries: [
+        {
+          path: "live/renamed.md",
+          operation: "rename",
+          actor: marcus,
+          content: "live\n",
+        },
+        {
+          path: "live/renamed.md",
+          operation: "create",
+          actor: olivia,
+          content: "live\n",
+        },
+      ],
+      hasMore: false,
+    });
+  });
+
   it("keeps service writes best-effort when file history metadata is malformed", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const service = createVaultService({

--- a/packages/vault-service/src/index.ts
+++ b/packages/vault-service/src/index.ts
@@ -19,6 +19,7 @@ import {
   listFolderMetadata as listVaultFolderMetadata,
   listVaultTree,
   makeVaultFolder,
+  moveFileHistory,
   moveVaultPath,
   onVaultAudit,
   prependContent,
@@ -268,6 +269,27 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
     if (!read.ok) return;
     await recordHistory(event.path, 'update', actor, read.value.content);
   };
+  const carryHistoryAfterFileMove = async (moved: {
+    fromPath: string;
+    toPath: string;
+    audit: AuditEntry;
+  }): Promise<void> => {
+    try {
+      const read = await readVaultFile(ctx(), moved.toPath);
+      if (!read.ok) return;
+      const result = await moveFileHistory(options.vaultRoot, {
+        fromPath: moved.fromPath,
+        toPath: moved.toPath,
+        actor: moved.audit.actor,
+        content: read.value.content,
+      });
+      if (!result.ok) {
+        throw new Error(`Failed to move file history from ${moved.fromPath} to ${moved.toPath}: ${result.message}`);
+      }
+    } catch (error: unknown) {
+      console.warn('KB-2 failed to carry file history after note move.', error);
+    }
+  };
 
   return {
     onEvent(handler) {
@@ -503,6 +525,7 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       const movedLive = await mapVaultFailure(() => options.documentSessions.moveSession(input.fromPath, input.toPath, moveOnDisk));
       if (!movedLive.ok) return movedLive;
       if (movedLive.value) {
+        await carryHistoryAfterFileMove(moved!);
         return { ok: true, ...moved!, live: true };
       }
       const result = serviceResult(await moveVaultPath(ctx(input.actor), {
@@ -510,6 +533,9 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
         fromPath: input.fromPath,
         toPath: input.toPath
       }));
+      if (result.ok) {
+        await carryHistoryAfterFileMove(result);
+      }
       return result;
     },
 


### PR DESCRIPTION
## Summary
- rekey daemon-owned file history from old note path to new note path after successful note moves/renames
- append a non-coalesced move/rename snapshot attributed from the move audit actor
- replace any stale target-path history rather than merging unrelated file histories (documented kill-history fallback)

## Verification
- pnpm --dir local --filter @kb-2/vault-core exec vitest run src/index.test.ts
- pnpm --dir local --filter @kb-2/vault-service exec vitest run src/index.test.ts
- pnpm --dir local --filter @kb-2/daemon exec vitest run src/routing.test.ts
- pnpm --dir local --filter @kb-2/vault-core build && pnpm --dir local --filter @kb-2/vault-core typecheck
- pnpm --dir local --filter @kb-2/vault-service build && pnpm --dir local --filter @kb-2/vault-service typecheck
- pnpm --dir local --filter @kb-2/daemon build && pnpm --dir local --filter @kb-2/daemon typecheck
