### PR TITLE
Report daemon runtime metadata to relay

### DIFF
--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -128,6 +128,13 @@ export function createApp(options: CreateAppOptions): Hono {
       return context.json({ ok: true, vaults: registry.list() });
     });
 
+    api.get('/storage', async (context) => {
+      return context.json({
+        ok: true,
+        usedBytes: await registry.storageUsageBytes()
+      });
+    });
+
     api.post('/vaults', async (context) => {
       const body = await readJsonObject(context.req.raw);
       if (!body.ok) return mapServiceResult(context, body);

--- a/apps/daemon/src/config.test.ts
+++ b/apps/daemon/src/config.test.ts
@@ -101,10 +101,14 @@ describe('daemon config', () => {
   it('normalizes relay URL when supplied', () => {
     expect(resolveRelayConfig({
       KB2_RELAY_URL: ' http://127.0.0.1:9920/t/dev1 ',
-      KB2_RELAY_TOKEN: ' test-token '
+      KB2_RELAY_TOKEN: ' test-token ',
+      KB2_DAEMON_VERSION: ' 0.1.0 ',
+      KB2_DAEMON_BUILD: ' registry.fly.io/kb1@sha256:abc123 '
     })).toEqual({
       relayUrl: 'http://127.0.0.1:9920/t/dev1',
-      token: 'test-token'
+      token: 'test-token',
+      daemonVersion: '0.1.0',
+      daemonBuild: 'registry.fly.io/kb1@sha256:abc123'
     });
   });
 

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -39,6 +39,8 @@ export interface DaemonConfig {
 export interface DaemonRelayConfig {
   relayUrl: string;
   token: string;
+  daemonVersion?: string;
+  daemonBuild?: string;
 }
 
 export interface ResolveConfigOptions {
@@ -99,8 +101,15 @@ export function resolveRelayConfig(env: NodeJS.ProcessEnv = process.env): Daemon
 
   return {
     relayUrl: new URL(relayUrl).href,
-    token
+    token,
+    ...(optionalEnv(env.KB2_DAEMON_VERSION) ? { daemonVersion: optionalEnv(env.KB2_DAEMON_VERSION) } : {}),
+    ...(optionalEnv(env.KB2_DAEMON_BUILD) ? { daemonBuild: optionalEnv(env.KB2_DAEMON_BUILD) } : {})
   };
+}
+
+function optionalEnv(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
 }
 
 export function resolveActorDefault(env: NodeJS.ProcessEnv = process.env): ActorDefault {

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -203,6 +203,8 @@ function createRelayLifecycleController(
     relayUrl: new URL(config.relay.relayUrl),
     daemonUrl,
     token: config.relay.token,
+    daemonVersion: config.relay.daemonVersion,
+    daemonBuild: config.relay.daemonBuild,
     logger: daemonRelayLogger,
   });
   let unsubscribeVaultEvents: (() => void) | undefined;

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -378,6 +378,21 @@ describe("daemon routing", () => {
     });
   });
 
+  it("reports storage bytes used by active and soft-deleted vault data", async () => {
+    const { app, vaultRoot } = await setupScopedVault();
+    await writeFile(join(vaultRoot, "active.md"), "active-bytes");
+    const trashed = join(kb2Home, VAULT_TRASH_DIRNAME, "old-vault");
+    await mkdir(trashed, { recursive: true });
+    await writeFile(join(trashed, "old.md"), "trash-bytes");
+
+    const response = await app.request("/api/storage");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { ok?: unknown; usedBytes?: unknown };
+    expect(body.ok).toBe(true);
+    expect(typeof body.usedBytes).toBe("number");
+    expect(body.usedBytes).toBeGreaterThanOrEqual("active-bytes".length + "trash-bytes".length);
+  });
+
   it("attributes REST writes from the x-kb1-actor header in responses and audit JSONL", async () => {
     const { app, vaultRoot } = await setupScopedVault();
     const suppliedActor = {

--- a/apps/daemon/src/vault-registry.ts
+++ b/apps/daemon/src/vault-registry.ts
@@ -345,6 +345,13 @@ export class VaultRegistry {
       .sort((a, b) => a.id.localeCompare(b.id));
   }
 
+  async storageUsageBytes(): Promise<number> {
+    return (
+      await directorySizeBytes(this.vaultsHome) +
+      await directorySizeBytes(this.trashHome)
+    );
+  }
+
   /** Resolve a vault's live instance by slug, or `undefined` when unknown. */
   get(id: string): VaultInstance | undefined {
     return this.instances.get(id);
@@ -663,6 +670,31 @@ async function isDirectory(target: string): Promise<boolean> {
     if (isNodeErrorCode(error, 'ENOENT')) {
       return false;
     }
+    throw error;
+  }
+}
+
+async function directorySizeBytes(path: string): Promise<number> {
+  const entries = await readDirectoryEntries(path);
+  let total = 0;
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    const child = join(path, entry.name);
+    if (entry.isDirectory()) {
+      total += await directorySizeBytes(child);
+      continue;
+    }
+    const info = await stat(child);
+    if (info.isFile()) total += info.size;
+  }
+  return total;
+}
+
+async function readDirectoryEntries(path: string) {
+  try {
+    return await readdir(path, { withFileTypes: true });
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) return [];
     throw error;
   }
 }

--- a/packages/tunnel-client/src/heartbeat.test.ts
+++ b/packages/tunnel-client/src/heartbeat.test.ts
@@ -97,6 +97,31 @@ describe('TunnelClient control heartbeat', () => {
     expect(MockWebSocket.instances).toHaveLength(2);
   });
 
+  it('advertises optional daemon version metadata on control hello', async () => {
+    const { TunnelClient } = await import('./index.js');
+    const client = new TunnelClient({
+      relayUrl: new URL('http://relay.example/t/dev1'),
+      daemonUrl: new URL('http://127.0.0.1:9891'),
+      token: 'token-1',
+      daemonVersion: '0.1.0',
+      daemonBuild: 'registry.fly.io/kb1@sha256:abc123',
+      logger: { log: vi.fn() },
+    });
+
+    client.start();
+    const firstControl = MockWebSocket.instances[0];
+    firstControl.open();
+
+    expect(sentText(firstControl, 0)).toBe(encodeTunnelMessage({
+      type: 'control.hello',
+      version: 2,
+      token: 'token-1',
+      daemonVersion: '0.1.0',
+      daemonBuild: 'registry.fly.io/kb1@sha256:abc123',
+      features: [TUNNEL_FEATURES.RELAY_FRAMES_V1],
+    }));
+  });
+
   it('keeps connect and disconnect idempotent for lifecycle callers', async () => {
     const { TunnelClient } = await import('./index.js');
     const client = new TunnelClient({

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -41,6 +41,8 @@ export type TunnelClientConfig = {
   relayUrl: URL;
   daemonUrl: URL;
   token: string;
+  daemonVersion?: string;
+  daemonBuild?: string;
   logger?: TunnelClientLogger;
   fetch?: typeof fetch;
   random?: () => number;
@@ -184,6 +186,8 @@ export class TunnelClient {
         type: 'control.hello',
         version: TUNNEL_PROTOCOL_VERSION,
         token: this.config.token,
+        ...(this.config.daemonVersion ? { daemonVersion: this.config.daemonVersion } : {}),
+        ...(this.config.daemonBuild ? { daemonBuild: this.config.daemonBuild } : {}),
         features: [TUNNEL_FEATURES.RELAY_FRAMES_V1],
       }));
       this.startControlHeartbeat(control);

--- a/packages/tunnel-protocol/src/index.test.ts
+++ b/packages/tunnel-protocol/src/index.test.ts
@@ -46,6 +46,8 @@ it("round-trips control hello feature advertisement", () => {
     type: "control.hello",
     version: TUNNEL_PROTOCOL_VERSION,
     token: "test-token",
+    daemonVersion: "0.1.0",
+    daemonBuild: "registry.example/kb2d@sha256:abc123",
     features: [TUNNEL_FEATURES.RELAY_FRAMES_V1]
   } as const;
 

--- a/packages/tunnel-protocol/src/index.ts
+++ b/packages/tunnel-protocol/src/index.ts
@@ -351,6 +351,8 @@ export type TunnelControlClientHello = {
   type: "control.hello";
   version: TunnelProtocolVersion;
   token: string;
+  daemonVersion?: string;
+  daemonBuild?: string;
   features?: readonly TunnelFeature[];
 };
 


### PR DESCRIPTION
## Summary
- add optional daemonVersion/daemonBuild fields to tunnel control hello
- pass KB2_DAEMON_VERSION and KB2_DAEMON_BUILD from daemon config into the tunnel client
- expose GET /api/storage so the cloud control plane can query byte usage reactively

## Verification
- pnpm --dir local --filter @kb-2/tunnel-protocol build
- pnpm --dir local --filter @kb-2/tunnel-protocol typecheck
- pnpm --dir local --filter @kb-2/tunnel-client typecheck
- pnpm --dir local --filter @kb-2/daemon typecheck
- pnpm --dir local --filter @kb-2/tunnel-protocol test -- --runInBand
- pnpm --dir local --filter @kb-2/tunnel-client exec vitest run src/heartbeat.test.ts
- pnpm --dir local --filter @kb-2/daemon exec vitest run src/config.test.ts
- pnpm --dir local --filter @kb-2/daemon exec vitest run src/routing.test.ts -t "reports storage bytes"

Cloud dependency: FC-5115 Fly-managed daemon control plane records runtime version/build on relay connect and queries /api/storage through the relay.