### PR TITLE
Add filesystem artifact support

### DIFF
--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -11,7 +11,9 @@ import {
   type VaultChangeEvent,
   type VaultService
 } from '@kb-2/vault-service';
+import { createReadStream } from 'node:fs';
 import { resolve } from 'node:path';
+import { Readable } from 'node:stream';
 
 import { SERVICE_NAME, type ActorDefault } from './config.js';
 import {
@@ -66,6 +68,8 @@ interface VaultRouteScope {
   resolve(context: Context): ServiceResult<{ service: VaultService }>;
   /** Prefix to strip when extracting a `/files/...` path from this scope. */
   filesPrefix(context: Context): string;
+  /** Prefix to strip when extracting a `/raw/...` path from this scope. */
+  rawPrefix(context: Context): string;
   /** Prefix to strip when extracting a `/folders/...` path from this scope. */
   foldersPrefix(context: Context): string;
 }
@@ -196,6 +200,7 @@ export function createApp(options: CreateAppOptions): Hono {
         return { ok: true, service: instance.service };
       },
       filesPrefix: (context) => `/api/vaults/${vaultIdParam(context)}/files/`,
+      rawPrefix: (context) => `/api/vaults/${vaultIdParam(context)}/raw/`,
       foldersPrefix: (context) => `/api/vaults/${vaultIdParam(context)}/folders/`
     };
     api.get('/vaults/:id/events', (context) => {
@@ -296,6 +301,31 @@ function registerVaultDataRoutes(
       limit: queryNumber(context, 'limit'),
       offset: queryNumber(context, 'offset')
     }));
+  });
+
+  router.get(`${basePath}/raw/*`, async (context) => {
+    const resolved = scope.resolve(context);
+    if (!resolved.ok) return mapServiceResult(context, resolved);
+    const rawPath = filePathParam(context.req.path, scope.rawPrefix(context));
+    const result = await resolved.service.readRawFile({ path: rawPath });
+    if (!result.ok) return mapServiceResult(context, result);
+    return rawFileResponse(context, result);
+  });
+
+  router.put(`${basePath}/raw/*`, async (context) => {
+    const resolved = scope.resolve(context);
+    if (!resolved.ok) return mapServiceResult(context, resolved);
+    const rawPath = filePathParam(context.req.path, scope.rawPrefix(context));
+    const actor = actorFromRequest(context, actorDefault);
+    if (!actor.ok) return mapServiceResult(context, actor);
+    const bytes = new Uint8Array(await context.req.raw.arrayBuffer());
+    const overwrite = context.req.query('overwrite') === 'true';
+    return mapServiceResult(context, await resolved.service.writeRawFile({
+      path: rawPath,
+      bytes,
+      overwrite,
+      actor: actor.actor
+    }), overwrite ? 200 : 201);
   });
 
   router.get(`${basePath}/files/*`, async (context) => {
@@ -555,6 +585,32 @@ function formatServerSentEvent(event: VaultChangeEvent): string {
   return `event: change\ndata: ${JSON.stringify(event)}\n\n`;
 }
 
+type RawFileReadResult = Awaited<ReturnType<VaultService['readRawFile']>>;
+type RawFileReadSuccess = Extract<RawFileReadResult, { ok: true }>;
+
+function rawFileResponse(context: Context, result: RawFileReadSuccess): Response {
+  const etag = rawFileEtag(result.size, result.mtimeMs);
+  const headers = new Headers({
+    'content-type': result.artifact.contentType,
+    'content-length': String(result.size),
+    etag,
+    'cache-control': 'private, max-age=3600',
+    'content-security-policy': 'sandbox',
+    'x-content-type-options': 'nosniff'
+  });
+
+  if (context.req.header('if-none-match') === etag) {
+    return new Response(null, { status: 304, headers });
+  }
+
+  const stream = Readable.toWeb(createReadStream(result.filePath)) as ReadableStream<Uint8Array>;
+  return new Response(stream, { status: 200, headers });
+}
+
+function rawFileEtag(size: number, mtimeMs: number): string {
+  return `W/"${size}-${Math.trunc(mtimeMs)}"`;
+}
+
 function mapServiceResult(
   context: Context,
   result: ServiceResult,
@@ -613,13 +669,15 @@ function statusForRegistryError(error: VaultRegistryErrorCode): 400 | 404 | 409 
   }
 }
 
-function statusForServiceError(error: ServiceErrorCode): 400 | 404 | 409 | 413 | 500 {
+function statusForServiceError(error: ServiceErrorCode): 400 | 404 | 409 | 413 | 415 | 500 {
   switch (error) {
     case 'invalid_actor':
     case 'invalid_path':
     case 'invalid_metadata':
     case 'invalid_request':
       return 400;
+    case 'not_editable':
+      return 415;
     case 'metadata_parse_failed':
       return 500;
     case 'not_found':

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -7,7 +7,7 @@ import type { VaultChangeEventKind } from '@kb-2/vault-service';
 import type { IncomingMessage } from 'node:http';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { validateVaultPath, type VaultActor } from '@kb-2/vault-core';
+import { classifyArtifactPath, validateVaultPath, type VaultActor } from '@kb-2/vault-core';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { WebSocketServer } from 'ws';
 
@@ -341,7 +341,8 @@ function parseScopedFilesPath(pathWithoutYjs: string): { id: string; rawPath: st
 
 function safeValidateFilePath(rawPath: string): string | undefined {
   try {
-    return validateVaultPath(decodeURIComponent(rawPath), 'file');
+    const filePath = validateVaultPath(decodeURIComponent(rawPath), 'file');
+    return classifyArtifactPath(filePath).editable ? filePath : undefined;
   } catch {
     return undefined;
   }

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -89,6 +89,9 @@ describe("daemon routing", () => {
   /** Path to a scoped file route for the lone test vault. */
   const filePath = (vaultPath: string): string =>
     `/api/vaults/${VAULT}/files/${vaultPath}`;
+  /** Path to a scoped raw-file route for the lone test vault. */
+  const rawPath = (vaultPath: string): string =>
+    `/api/vaults/${VAULT}/raw/${vaultPath}`;
   /** Path to a scoped folder route for the lone test vault. */
   const folderPath = (vaultPath?: string): string =>
     vaultPath === undefined
@@ -366,6 +369,180 @@ describe("daemon routing", () => {
       actor: { kind: "user" },
     });
     expect(audit[1]).toMatchObject({ operation: "write", path: "notes/a.md" });
+  });
+
+  it("classifies copied-in text and attachment artifacts in the scoped tree route", async () => {
+    const { app, vaultRoot } = await setupScopedVault();
+    await writeFileWithParents(join(vaultRoot, "notes/a.md"), "# A\n");
+    await writeFileWithParents(join(vaultRoot, "scripts/app.ts"), "export {};\n");
+    await mkdir(join(vaultRoot, "attachments"), { recursive: true });
+    await writeFile(join(vaultRoot, "attachments/photo.png"), new Uint8Array([0x89, 0x50, 0x4e, 0x47]));
+    await writeFile(join(vaultRoot, "attachments/icon.svg"), "<svg />");
+    await writeFile(join(vaultRoot, "attachments/blob"), new Uint8Array([1, 2, 3]));
+
+    const response = await app.request(`/api/vaults/${VAULT}/tree`);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      entries: expect.arrayContaining([
+        {
+          path: "notes/a.md",
+          kind: "file",
+          size: 4,
+          mtimeMs: expect.any(Number),
+          artifact: {
+            kind: "text",
+            contentType: "text/markdown; charset=utf-8",
+            editable: true,
+            preview: "markdown",
+          },
+        },
+        {
+          path: "scripts/app.ts",
+          kind: "file",
+          size: 11,
+          mtimeMs: expect.any(Number),
+          artifact: {
+            kind: "text",
+            contentType: "text/typescript; charset=utf-8",
+            editable: true,
+            preview: "text",
+          },
+        },
+        {
+          path: "attachments/photo.png",
+          kind: "file",
+          size: 4,
+          mtimeMs: expect.any(Number),
+          artifact: {
+            kind: "attachment",
+            contentType: "image/png",
+            editable: false,
+            preview: "image",
+          },
+        },
+        {
+          path: "attachments/icon.svg",
+          kind: "file",
+          size: 7,
+          mtimeMs: expect.any(Number),
+          artifact: {
+            kind: "attachment",
+            contentType: "application/octet-stream",
+            editable: false,
+            preview: "download",
+          },
+        },
+        {
+          path: "attachments/blob",
+          kind: "file",
+          size: 3,
+          mtimeMs: expect.any(Number),
+          artifact: {
+            kind: "attachment",
+            contentType: "application/octet-stream",
+            editable: false,
+            preview: "download",
+          },
+        },
+      ]),
+    });
+  });
+
+  it("round-trips raw bytes with content headers, ETag caching, and audit rows", async () => {
+    const { app, vaultRoot } = await setupScopedVault();
+    const bytes = new Uint8Array([0, 1, 2, 255]);
+
+    const created = await app.request(rawPath("attachments/photo.png"), {
+      method: "PUT",
+      body: new Blob([bytes]),
+    });
+    expect(created.status).toBe(201);
+    await expect(created.json()).resolves.toMatchObject({
+      ok: true,
+      path: "attachments/photo.png",
+      size: 4,
+      artifact: {
+        kind: "attachment",
+        contentType: "image/png",
+        editable: false,
+        preview: "image",
+      },
+    });
+    await expect(readFile(join(vaultRoot, "attachments/photo.png"))).resolves.toEqual(Buffer.from(bytes));
+
+    const duplicate = await app.request(rawPath("attachments/photo.png"), {
+      method: "PUT",
+      body: new Blob([new Uint8Array([9])]),
+    });
+    expect(duplicate.status).toBe(409);
+    await expect(duplicate.json()).resolves.toMatchObject({
+      ok: false,
+      error: "already_exists",
+    });
+
+    const read = await app.request(rawPath("attachments/photo.png"));
+    expect(read.status).toBe(200);
+    expect(read.headers.get("content-type")).toBe("image/png");
+    expect(read.headers.get("content-length")).toBe("4");
+    expect(read.headers.get("content-security-policy")).toBe("sandbox");
+    expect(read.headers.get("x-content-type-options")).toBe("nosniff");
+    const etag = read.headers.get("etag");
+    expect(etag).toMatch(/^W\/"\d+-\d+"$/);
+    expect([...new Uint8Array(await read.arrayBuffer())]).toEqual([...bytes]);
+
+    const notModified = await app.request(rawPath("attachments/photo.png"), {
+      headers: { "if-none-match": etag ?? "" },
+    });
+    expect(notModified.status).toBe(304);
+
+    const overwritten = await app.request(`${rawPath("attachments/photo.png")}?overwrite=true`, {
+      method: "PUT",
+      body: new Blob([new Uint8Array([5, 6])]),
+    });
+    expect(overwritten.status).toBe(200);
+    await expect(overwritten.json()).resolves.toMatchObject({
+      ok: true,
+      path: "attachments/photo.png",
+      size: 2,
+    });
+    await expect(readFile(join(vaultRoot, "attachments/photo.png"))).resolves.toEqual(Buffer.from([5, 6]));
+
+    const audit = await readAuditRows(vaultRoot);
+    expect(audit.map((row) => row.operation)).toEqual(["create", "write"]);
+    expect(audit.map((row) => row.path)).toEqual([
+      "attachments/photo.png",
+      "attachments/photo.png",
+    ]);
+  });
+
+  it("keeps binary attachments out of the text document route", async () => {
+    const { app } = await setupScopedVault();
+    const bytes = new Uint8Array([0, 1, 2, 255]);
+
+    const created = await app.request(rawPath("attachments/photo.png"), {
+      method: "PUT",
+      body: new Blob([bytes]),
+    });
+    expect(created.status).toBe(201);
+
+    const readAsText = await app.request(filePath("attachments/photo.png"));
+    expect(readAsText.status).toBe(415);
+    await expect(readAsText.json()).resolves.toMatchObject({
+      ok: false,
+      error: "not_editable",
+    });
+
+    const writeAsText = await app.request(`${filePath("attachments/photo.png")}?overwrite=true`, {
+      method: "PUT",
+      headers: { "content-type": "text/plain" },
+      body: "not png",
+    });
+    expect(writeAsText.status).toBe(415);
+    await expect(writeAsText.json()).resolves.toMatchObject({
+      ok: false,
+      error: "not_editable",
+    });
   });
 
   it("returns a clean 404 for a scoped data route addressing an unknown vault", async () => {

--- a/apps/web/src/lib/kb-service.ts
+++ b/apps/web/src/lib/kb-service.ts
@@ -22,10 +22,29 @@ export interface VaultSummary {
   metadata?: { color?: string };
 }
 
+export type ArtifactKind = "text" | "attachment";
+
+export type ArtifactPreview =
+  | "markdown"
+  | "text"
+  | "image"
+  | "audio"
+  | "video"
+  | "pdf"
+  | "download";
+
+export interface ArtifactInfo {
+  kind: ArtifactKind;
+  contentType: string;
+  editable: boolean;
+  preview: ArtifactPreview;
+}
+
 export interface TreeEntry {
   path: string;
   kind: "file" | "folder";
   metadata?: { color?: string };
+  artifact?: ArtifactInfo;
 }
 
 export interface VaultInfo {
@@ -119,6 +138,8 @@ function messageForError(
       return "That item no longer exists.";
     case "invalid_path":
       return "That name contains characters that are not allowed.";
+    case "not_editable":
+      return "That file is not editable as a text document.";
     case "invalid_metadata":
       return "That folder customization is not valid.";
     case "stale_doc":
@@ -172,6 +193,81 @@ function noteHistoryQuery(options: ListNoteHistoryOptions): string {
   if (options.limit !== undefined) qs.set("limit", String(options.limit));
   const query = qs.toString();
   return query.length > 0 ? `?${query}` : "";
+}
+
+function rawOverwriteQuery(overwrite: boolean): string {
+  return overwrite ? "?overwrite=true" : "";
+}
+
+type RawFileBody = Blob | ArrayBuffer | Uint8Array;
+
+const IMAGE_TYPE_EXTENSIONS: Record<string, string> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+};
+
+function isBlob(body: RawFileBody): body is Blob {
+  return typeof Blob !== "undefined" && body instanceof Blob;
+}
+
+function rawRequestBody(body: RawFileBody): BodyInit {
+  if (isBlob(body)) return body;
+  if (body instanceof ArrayBuffer) return body;
+  const copy = new Uint8Array(body.byteLength);
+  copy.set(body);
+  return copy.buffer;
+}
+
+function parentOf(path: string): string {
+  const index = path.lastIndexOf("/");
+  return index === -1 ? "" : path.slice(0, index);
+}
+
+function joinPath(parent: string, child: string): string {
+  return parent ? `${parent}/${child}` : child;
+}
+
+function extensionForFile(file: File): string {
+  const normalizedType = file.type.split(";")[0]?.trim().toLowerCase() ?? "";
+  return IMAGE_TYPE_EXTENSIONS[normalizedType] ?? "";
+}
+
+function uploadFilename(file: File): string {
+  const fallbackExtension = extensionForFile(file) || ".bin";
+  const rawName = file.name.trim() || `image${fallbackExtension}`;
+  const basename = rawName.split(/[\\/]/).filter(Boolean).at(-1) ?? rawName;
+  const lastDot = basename.lastIndexOf(".");
+  const stem = sanitizeFilenamePart(lastDot > 0 ? basename.slice(0, lastDot) : basename);
+  const rawExtension = lastDot > 0 ? basename.slice(lastDot).toLowerCase() : "";
+  const extension = rawExtension || fallbackExtension;
+  return `${stem}${extension}`;
+}
+
+function sanitizeFilenamePart(input: string): string {
+  const cleaned = input
+    .toLowerCase()
+    .replace(/[\u0000-\u001f\u007f/\\]/g, "-")
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .replace(/^\.+$/, "")
+    .trim();
+  if (cleaned.length === 0 || cleaned === ".kb2") return "image";
+  return cleaned;
+}
+
+function collisionSafeName(filename: string, index: number): string {
+  if (index === 1) return filename;
+  const dot = filename.lastIndexOf(".");
+  if (dot <= 0) return `${filename}-${index}`;
+  return `${filename.slice(0, dot)}-${index}${filename.slice(dot)}`;
+}
+
+function markdownPathForUpload(documentPath: string, filename: string): string {
+  void documentPath;
+  return filename;
 }
 
 export const kbService = {
@@ -260,6 +356,48 @@ export const kbService = {
       `${vaultBase(vaultId)}/tree`,
     );
     return result.entries;
+  },
+
+  rawSrc(vaultId: string, path: string): string {
+    return `${vaultBase(vaultId)}/raw/${encodeVaultPath(path)}`;
+  },
+
+  async writeRawFile(
+    vaultId: string,
+    path: string,
+    body: RawFileBody,
+    overwrite = false,
+  ): Promise<void> {
+    await request(
+      `${vaultBase(vaultId)}/raw/${encodeVaultPath(path)}${rawOverwriteQuery(overwrite)}`,
+      {
+        method: "PUT",
+        body: rawRequestBody(body),
+      },
+    );
+  },
+
+  async uploadAttachment(
+    vaultId: string,
+    documentPath: string,
+    file: File,
+  ): Promise<{ path: string; vaultPath: string }> {
+    const folder = parentOf(documentPath);
+    const filename = uploadFilename(file);
+    const existing = new Set((await kbService.tree(vaultId)).map((entry) => entry.path));
+
+    for (let index = 1; index <= 100; index += 1) {
+      const candidateName = collisionSafeName(filename, index);
+      const candidatePath = joinPath(folder, candidateName);
+      if (existing.has(candidatePath)) continue;
+      await kbService.writeRawFile(vaultId, candidatePath, file, false);
+      return {
+        path: markdownPathForUpload(documentPath, candidateName),
+        vaultPath: candidatePath,
+      };
+    }
+
+    throw new Error("Could not find an available attachment filename.");
   },
 
   async listNoteHistory(

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -48,7 +48,7 @@
     ROOT_DEFAULT_COLOR,
     resolveFolderColor,
   } from '@kb-2/ui';
-  import { kbService, type FileHistoryEntry, type VaultSummary } from '$lib/kb-service';
+  import { kbService, type ArtifactInfo, type FileHistoryEntry, type VaultSummary } from '$lib/kb-service';
   import type { DocumentSessionEvent } from '@kb-2/doc-session/protocol';
   import {
     useAppState,
@@ -67,6 +67,7 @@
     path: string;
     kind: 'file' | 'folder';
     metadata?: { color?: string };
+    artifact?: ArtifactInfo;
   }
 
   type TreeDirtyEventKind =
@@ -349,7 +350,7 @@
       for (const node of list) {
         if (node.kind === 'folder') {
           walk(node.children);
-        } else {
+        } else if (node.artifact?.editable !== false) {
           out.push({ path: node.path, noteId: node.path });
         }
       }
@@ -396,6 +397,11 @@
   const activeNode = $derived(findNode(tree, documentPath));
   const viewingFolder = $derived(
     documentPath === '' || activeNode?.kind === 'folder',
+  );
+  const activeAttachmentNode = $derived(
+    activeNode?.kind === 'file' && activeNode.artifact?.editable === false
+      ? activeNode
+      : undefined,
   );
   // The folder node backing the canvas — its `children` is the full
   // subtree (direct children plus descendants) the canvas renders. At
@@ -842,6 +848,28 @@
     await goto(vaultRoute(activeVaultId, path), { noScroll: true, keepFocus: true });
   }
 
+  function openRawFile(vaultId: string, path: string): void {
+    const url = kbService.rawSrc(vaultId, path);
+    const opened = window.open(url, '_blank', 'noopener,noreferrer');
+    if (!opened) {
+      window.location.assign(url);
+    }
+  }
+
+  function openFilePath(vaultId: string, path: string): void {
+    const node = findNode(vaultTrees[vaultId] ?? [], path);
+    if (node?.kind === 'file' && node.artifact?.editable === false) {
+      openRawFile(vaultId, path);
+      return;
+    }
+
+    if (vaultId !== activeVaultId) {
+      void goto(vaultRoute(vaultId, path), { noScroll: true, keepFocus: true });
+      return;
+    }
+    void openDocument(path);
+  }
+
   // Switch the active vault: navigate to its root. The derived active id
   // follows the new URL; the active-vault effect remembers it as the
   // last-opened and loads its tree if uncached.
@@ -857,11 +885,7 @@
   // Mirrors openFolder.
   function openFileFromRow(key: string): void {
     const { vaultId: keyVaultId, path } = noteKeyParts(key);
-    if (keyVaultId !== activeVaultId) {
-      void goto(vaultRoute(keyVaultId, path), { noScroll: true, keepFocus: true });
-      return;
-    }
-    void openDocument(path);
+    openFilePath(keyVaultId, path);
   }
 
   // Wikilink navigation. The editor fires with the URL-encoded target;
@@ -1454,6 +1478,7 @@
             kind: 'file',
             path: entry.path,
             name: nameFromPath(entry.path),
+            artifact: entry.artifact,
           };
       byPath.set(entry.path, node);
     }
@@ -1490,6 +1515,35 @@
   function parentOf(path: string): string {
     const index = path.lastIndexOf('/');
     return index === -1 ? '' : path.slice(0, index);
+  }
+
+  function rawAttachmentSrc(path: string): string {
+    return kbService.rawSrc(vaultId, resolveAttachmentPath(documentPath, path));
+  }
+
+  async function uploadImageAttachment(file: File): Promise<{ path: string }> {
+    const uploaded = await kbService.uploadAttachment(vaultId, documentPath, file);
+    void refreshTree();
+    return { path: uploaded.path };
+  }
+
+  function resolveAttachmentPath(fromDocumentPath: string, targetPath: string): string {
+    const documentFolder = parentOf(fromDocumentPath);
+    const joined = documentFolder ? `${documentFolder}/${targetPath}` : targetPath;
+    return normalizeVaultRelativePath(joined);
+  }
+
+  function normalizeVaultRelativePath(input: string): string {
+    const segments: string[] = [];
+    for (const segment of input.split('/')) {
+      if (segment.length === 0 || segment === '.') continue;
+      if (segment === '..') {
+        segments.pop();
+        continue;
+      }
+      segments.push(segment);
+    }
+    return segments.join('/');
   }
 
   function nameFromPath(path: string): string {
@@ -1634,7 +1688,12 @@
     const path = documentPath;
     if (!id) return;
     untrack(() => {
-      if (path === '' || findNode(tree, path)?.kind === 'folder') {
+      const node = findNode(tree, path);
+      if (
+        path === '' ||
+        node?.kind === 'folder' ||
+        (node?.kind === 'file' && node.artifact?.editable === false)
+      ) {
         teardownProvider();
         return;
       }
@@ -1642,12 +1701,11 @@
     });
   });
 
-  // A folder deep-link on cold load opens a provider before the tree has
-  // loaded (the folder/file split can't be made yet). Once the tree
-  // arrives and the path resolves to a folder, tear that stray provider
-  // down — the folder canvas renders instead of the editor.
+  // A folder or attachment deep-link on cold load may open a provider before
+  // the tree has loaded. Once the tree resolves the path to non-document
+  // content, tear that stray provider down.
   $effect(() => {
-    if (!viewingFolder || !provider) return;
+    if (!(viewingFolder || activeAttachmentNode) || !provider) return;
     untrack(() => {
       provider?.destroy();
       provider = null;
@@ -1764,13 +1822,28 @@
       children={activeFolderNode?.children ?? tree}
       onOpenFile={(path) => {
         navOpen = false;
-        void openDocument(path);
+        openFilePath(vaultId, path);
       }}
       onOpenFolder={(path) => {
         navOpen = false;
         void openDocument(path);
       }}
     />
+  {:else if activeAttachmentNode}
+    <div class="doc-body-wrap">
+      <div class="doc-body">
+        <div class="attachment-open">
+          <a
+            class="attachment-open-link"
+            href={kbService.rawSrc(vaultId, activeAttachmentNode.path)}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Open {activeAttachmentNode.name}
+          </a>
+        </div>
+      </div>
+    </div>
   {:else}
     <!-- Document scroll structure ported from the reference DocumentCanvas:
          `.doc-body` is the full-width scroll container so the whole pane
@@ -1800,6 +1873,8 @@
                   readOnly={docDeleted}
                   scroll="external"
                   class="vault-editor"
+                  attachmentSrc={rawAttachmentSrc}
+                  uploadImage={uploadImageAttachment}
                   onWikilinkClick={handleWikilinkClick}
                 />
               {/key}
@@ -2076,6 +2151,25 @@
     padding: 24px 0;
     color: var(--rd-ink-4);
     font-size: 13px;
+  }
+
+  .attachment-open {
+    max-width: 760px;
+    margin: 0 auto;
+    width: 100%;
+    padding: 24px 0;
+  }
+
+  .attachment-open-link {
+    color: var(--rd-accent);
+    font-family: var(--rd-ui);
+    font-size: 13px;
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .attachment-open-link:hover {
+    text-decoration: underline;
   }
 
   .error {

--- a/apps/web/src/test/FakePlaintextEditor.svelte
+++ b/apps/web/src/test/FakePlaintextEditor.svelte
@@ -2,7 +2,12 @@
   import { onMount } from 'svelte';
   import type * as Y from 'yjs';
 
-  let { readOnly = false, ydoc, ytext } = $props<{ readOnly?: boolean; ydoc?: Y.Doc; ytext?: Y.Text }>();
+  let { readOnly = false, ydoc, ytext } = $props<{
+    readOnly?: boolean;
+    ydoc?: Y.Doc;
+    ytext?: Y.Text;
+    attachmentSrc?: (path: string) => string;
+  }>();
   let binding = $state({ docGuid: '', content: '' });
 
   onMount(() => {

--- a/apps/web/src/test/local-editor-route.test.ts
+++ b/apps/web/src/test/local-editor-route.test.ts
@@ -127,12 +127,47 @@ describe("local editor route", () => {
                 metadata: { color: "#fda4af" },
               },
               {
+                kind: "folder",
+                path: "attachments",
+                size: 0,
+                mtimeMs: 1,
+              },
+              {
                 kind: "file",
                 path: "projects/active/editor-shell.md",
                 size: 12,
                 mtimeMs: 1,
+                artifact: {
+                  kind: "text",
+                  contentType: "text/markdown; charset=utf-8",
+                  editable: true,
+                  preview: "markdown",
+                },
               },
-              { kind: "file", path: "hello-world.md", size: 12, mtimeMs: 1 },
+              {
+                kind: "file",
+                path: "attachments/live.png",
+                size: 4,
+                mtimeMs: 1,
+                artifact: {
+                  kind: "attachment",
+                  contentType: "image/png",
+                  editable: false,
+                  preview: "image",
+                },
+              },
+              {
+                kind: "file",
+                path: "hello-world.md",
+                size: 12,
+                mtimeMs: 1,
+                artifact: {
+                  kind: "text",
+                  contentType: "text/markdown; charset=utf-8",
+                  editable: true,
+                  preview: "markdown",
+                },
+              },
             ],
           });
         }
@@ -240,6 +275,49 @@ describe("local editor route", () => {
     expect(treeProvider?.path).toBe("projects/active/editor-shell.md");
     expect(treeProvider?.text.toString()).toBe("typed into tree-opened file");
     expect(mocks.providers[0]?.text.toString()).toBe("content:hello-world.md");
+  });
+
+  it("opens attachment rows through the raw route instead of the document provider", async () => {
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockImplementation(() => ({ closed: false }) as Window);
+
+    render(AppStateHarness);
+
+    await screen.findByLabelText("Markdown editor");
+    const initialProviderCount = mocks.providers.length;
+    mocks.goto.mockClear();
+    const filesPanel = within(
+      screen.getByRole("complementary", { name: "Vault files" }),
+    );
+
+    await fireEvent.click(await filesPanel.findByText("attachments"));
+    await fireEvent.click(filesPanel.getByText("live.png"));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      "/api/vaults/demo-vault/raw/attachments/live.png",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(mocks.goto).not.toHaveBeenCalled();
+    expect(mocks.providers).toHaveLength(initialProviderCount);
+
+    openSpy.mockRestore();
+  });
+
+  it("renders direct attachment routes as raw-file links, not editable documents", async () => {
+    setPageUrl("/demo-vault/attachments/live.png");
+    window.history.pushState(null, "", "/demo-vault/attachments/live.png");
+
+    render(AppStateHarness);
+
+    const link = await screen.findByRole("link", { name: "Open live.png" });
+    expect((link as HTMLAnchorElement).getAttribute("href")).toBe(
+      "/api/vaults/demo-vault/raw/attachments/live.png",
+    );
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Markdown editor")).toBeNull();
+    });
   });
 
   it("hides the vault tree when the vault is toggled off in the filter", async () => {

--- a/packages/editor/src/lib/PlaintextEditor.svelte
+++ b/packages/editor/src/lib/PlaintextEditor.svelte
@@ -32,6 +32,7 @@
   import { plaintextMentionKeymap } from './plaintext-mention-keymap';
   import { plaintextListKeymap } from './plaintext-list-keymap';
   import { plaintextLinkPaste } from './plaintext-link-paste';
+  import { plaintextImageUpload } from './plaintext-image-upload';
   // Remote-cursor layer (cloud-014 part-6). Mounted only when the host supplies
   // both `awareness` and `noteId` — the daemon UI, which has no presence,
   // passes neither and the producer/consumer are skipped entirely.
@@ -98,6 +99,12 @@
      *  and routing stay unified. Omit when there's no navigation context
      *  (Storybook, no-vault tests) — clicks on wikilinks no-op then. */
     onWikilinkClick?: (encodedTarget: string, event: MouseEvent) => void;
+    /** Paste/drop image upload hook. Hosts decide where bytes are written;
+     *  the editor stores only the returned markdown path. */
+    uploadImage?: (file: File) => Promise<{ path: string }>;
+    onUploadStart?: () => void;
+    onUploadEnd?: () => void;
+    onError?: (err: unknown, file: File) => void;
     /** Vault-scoped awareness handle (cloud-014 part-6). When supplied
      *  (together with `noteId`), the editor publishes the local caret /
      *  selection to `awareness.cursor` and renders remote peers' carets +
@@ -122,6 +129,10 @@
     livePaths = [],
     orgPeople = [],
     onWikilinkClick,
+    uploadImage,
+    onUploadStart,
+    onUploadEnd,
+    onError,
     awareness,
     noteId,
   }: Props = $props();
@@ -447,6 +458,18 @@
       // inserts `[note name](url)`. Non-URL pastes (and URL pastes
       // that match neither rule) fall through to default CM6 paste.
       // See `plaintext-link-paste.ts` for the decision rules.
+      ...(uploadImage && !readOnly
+        ? [
+            plaintextImageUpload({
+              uploadFile: uploadImage,
+              ytext: stableText,
+              ydoc: stableDoc,
+              onUploadStart,
+              onUploadEnd,
+              onError,
+            }),
+          ]
+        : []),
       ...(!readOnly ? [plaintextLinkPaste()] : []),
       keymap.of([
         { key: 'Mod-z', run: undoCmd, preventDefault: true },

--- a/packages/editor/src/lib/plaintext-image-upload.test.ts
+++ b/packages/editor/src/lib/plaintext-image-upload.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as Y from 'yjs';
+import {
+  PENDING_UPLOAD_SCHEME,
+  PLAINTEXT_IMAGE_SWAP_ORIGIN,
+  UPLOAD_FAILED_SCHEME,
+  plaintextImageUpload,
+  swapSentinelInYText,
+} from './plaintext-image-upload';
+import { PLAINTEXT_USER_ORIGIN } from './content-format';
+
+function setupDoc(initial = ''): { doc: Y.Doc; ytext: Y.Text } {
+  const doc = new Y.Doc();
+  const ytext = doc.getText('markdown');
+  if (initial.length > 0) {
+    doc.transact(() => {
+      ytext.insert(0, initial);
+    }, null);
+  }
+  return { doc, ytext };
+}
+
+describe('swapSentinelInYText', () => {
+  it('replaces a pending-upload sentinel with the uploaded path', () => {
+    const { doc, ytext } = setupDoc('before ![cat](pending-upload://abc) after');
+    expect(
+      swapSentinelInYText(ytext, doc, 'pending-upload://abc', 'cat.png'),
+    ).toBe(true);
+    expect(ytext.toJSON()).toBe('before ![cat](cat.png) after');
+  });
+
+  it('returns false when the sentinel is gone', () => {
+    const { doc, ytext } = setupDoc('plain text');
+    expect(
+      swapSentinelInYText(ytext, doc, 'pending-upload://missing', 'x.png'),
+    ).toBe(false);
+    expect(ytext.toJSON()).toBe('plain text');
+  });
+
+  it('uses a non-user origin so upload completion is not undoable', () => {
+    const { doc, ytext } = setupDoc(`![](${PENDING_UPLOAD_SCHEME}uuid)`);
+    const undoManager = new Y.UndoManager(ytext, {
+      trackedOrigins: new Set([PLAINTEXT_USER_ORIGIN]),
+    });
+    const origins: unknown[] = [];
+    doc.on('afterTransaction', (tr) => origins.push(tr.origin));
+
+    swapSentinelInYText(ytext, doc, `${PENDING_UPLOAD_SCHEME}uuid`, 'final.png');
+
+    expect(origins).toContain(PLAINTEXT_IMAGE_SWAP_ORIGIN);
+    undoManager.undo();
+    expect(ytext.toJSON()).toBe('![](final.png)');
+  });
+});
+
+describe('plaintextImageUpload', () => {
+  it('constructs a CodeMirror extension', () => {
+    const { doc, ytext } = setupDoc();
+    expect(
+      plaintextImageUpload({
+        uploadFile: () => Promise.resolve({ path: 'noop.png' }),
+        ydoc: doc,
+        ytext,
+      }),
+    ).toBeDefined();
+  });
+
+  it('documents the failure sentinel contract used by the image widget', () => {
+    const { doc, ytext } = setupDoc();
+    const uuid = 'failed-upload';
+    doc.transact(() => {
+      ytext.insert(0, `![x](${PENDING_UPLOAD_SCHEME}${uuid})`);
+    }, PLAINTEXT_USER_ORIGIN);
+    const onError = vi.fn();
+    const error = new Error('upload failed');
+
+    swapSentinelInYText(
+      ytext,
+      doc,
+      `${PENDING_UPLOAD_SCHEME}${uuid}`,
+      `${UPLOAD_FAILED_SCHEME}${uuid}`,
+    );
+    onError(error);
+
+    expect(ytext.toJSON()).toBe(`![x](${UPLOAD_FAILED_SCHEME}${uuid})`);
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+});

--- a/packages/editor/src/lib/plaintext-image-upload.ts
+++ b/packages/editor/src/lib/plaintext-image-upload.ts
@@ -1,0 +1,147 @@
+import type { Extension } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import type * as Y from 'yjs';
+
+const ALLOWED_IMAGE_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
+
+export const PENDING_UPLOAD_SCHEME = 'pending-upload://';
+export const UPLOAD_FAILED_SCHEME = 'upload-failed://';
+export const PLAINTEXT_IMAGE_SWAP_ORIGIN = 'plaintext-image-swap';
+
+export interface PlaintextImageUploadOptions {
+  uploadFile: (file: File) => Promise<{ path: string }>;
+  ytext: Y.Text;
+  ydoc: Y.Doc;
+  onUploadStart?: () => void;
+  onUploadEnd?: () => void;
+  onError?: (err: unknown, file: File) => void;
+}
+
+function extractImageFiles(data: DataTransfer | null): File[] {
+  if (!data) return [];
+  const seen = new Set<File>();
+  const files: File[] = [];
+
+  for (const file of Array.from(data.files)) {
+    if (ALLOWED_IMAGE_TYPES.has(file.type) && !seen.has(file)) {
+      seen.add(file);
+      files.push(file);
+    }
+  }
+
+  for (const item of Array.from(data.items)) {
+    if (item.kind !== 'file') continue;
+    if (!ALLOWED_IMAGE_TYPES.has(item.type)) continue;
+    const file = item.getAsFile();
+    if (file && !seen.has(file)) {
+      seen.add(file);
+      files.push(file);
+    }
+  }
+
+  return files;
+}
+
+function defaultAltFromFilename(name: string): string {
+  const base = name.split('/').pop() ?? '';
+  return base.replace(/\.[^.]+$/, '');
+}
+
+function mintUploadId(): string {
+  return crypto.randomUUID();
+}
+
+function insertSentinelAtCursor(
+  view: EditorView,
+  alt: string,
+  uuid: string,
+): void {
+  const markdown = `![${alt}](${PENDING_UPLOAD_SCHEME}${uuid})`;
+  const { from, to } = view.state.selection.main;
+  view.dispatch({
+    changes: { from, to, insert: markdown },
+    selection: { anchor: from + markdown.length },
+    scrollIntoView: true,
+  });
+}
+
+export function swapSentinelInYText(
+  ytext: Y.Text,
+  ydoc: Y.Doc,
+  needle: string,
+  replacement: string,
+): boolean {
+  const haystack = ytext.toJSON();
+  const index = haystack.indexOf(needle);
+  if (index < 0) return false;
+  ydoc.transact(() => {
+    ytext.delete(index, needle.length);
+    ytext.insert(index, replacement);
+  }, PLAINTEXT_IMAGE_SWAP_ORIGIN);
+  return true;
+}
+
+async function handleOneUpload(
+  file: File,
+  uuid: string,
+  options: PlaintextImageUploadOptions,
+): Promise<void> {
+  const sentinelUrl = `${PENDING_UPLOAD_SCHEME}${uuid}`;
+  options.onUploadStart?.();
+  try {
+    const { path } = await options.uploadFile(file);
+    swapSentinelInYText(options.ytext, options.ydoc, sentinelUrl, path);
+  } catch (err) {
+    swapSentinelInYText(
+      options.ytext,
+      options.ydoc,
+      sentinelUrl,
+      `${UPLOAD_FAILED_SCHEME}${uuid}`,
+    );
+    options.onError?.(err, file);
+  } finally {
+    options.onUploadEnd?.();
+  }
+}
+
+export function plaintextImageUpload(
+  options: PlaintextImageUploadOptions,
+): Extension {
+  return EditorView.domEventHandlers({
+    paste(event, view) {
+      if (!view.state.facet(EditorView.editable)) return false;
+      const files = extractImageFiles(event.clipboardData);
+      if (files.length === 0) return false;
+
+      event.preventDefault();
+      for (const file of files) {
+        const uuid = mintUploadId();
+        insertSentinelAtCursor(view, defaultAltFromFilename(file.name), uuid);
+        void handleOneUpload(file, uuid, options);
+      }
+      return true;
+    },
+    drop(event, view) {
+      if (!view.state.facet(EditorView.editable)) return false;
+      const files = extractImageFiles(event.dataTransfer);
+      if (files.length === 0) return false;
+
+      const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+      event.preventDefault();
+      if (pos !== null) {
+        view.dispatch({ selection: { anchor: pos } });
+      }
+      for (const file of files) {
+        const uuid = mintUploadId();
+        insertSentinelAtCursor(view, defaultAltFromFilename(file.name), uuid);
+        void handleOneUpload(file, uuid, options);
+      }
+      return true;
+    },
+  });
+}

--- a/packages/local-mcp/src/server.test.ts
+++ b/packages/local-mcp/src/server.test.ts
@@ -1,5 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { fileURLToPath } from "node:url";
 
 import { createLocalMcpEndpoint } from "./server.js";
 import type {
@@ -10,6 +11,8 @@ import type {
 
 const CORAL = "#fda4af";
 const MINT = "#a7f3d0";
+type ServiceInput<Name extends keyof LocalMcpVaultService> =
+  Parameters<LocalMcpVaultService[Name]>[0];
 
 describe("local MCP server", () => {
   it("rejects requests that do not carry or initialize a valid MCP session", async () => {
@@ -42,6 +45,7 @@ describe("local MCP server", () => {
 
   it("registers every tier-1 tool and forwards calls to the injected service with initialize attribution", async () => {
     const mutationActors: VaultActor[] = [];
+    const fixturePath = fileURLToPath(new URL("./server.test.ts", import.meta.url));
     const service: LocalMcpVaultService = {
       vaultInfo: async () => ({
         ok: true,
@@ -49,7 +53,7 @@ describe("local MCP server", () => {
         fileCount: 1,
         folderCount: 1,
       }),
-      listFiles: async (input) => ({
+      listFiles: async (input: ServiceInput<"listFiles">) => ({
         ok: true,
         entries: [
           {
@@ -57,20 +61,44 @@ describe("local MCP server", () => {
             kind: input.under ? "folder" : "file",
             size: 4,
             mtimeMs: 1,
+            artifact: input.under
+              ? undefined
+              : {
+                  kind: "text",
+                  contentType: "text/markdown; charset=utf-8",
+                  editable: true,
+                  preview: "markdown",
+                },
             metadata: input.under ? { color: CORAL } : undefined,
           },
+          ...(input.under
+            ? []
+            : [
+                {
+                  path: "assets/pixel.png",
+                  kind: "file" as const,
+                  size: 8,
+                  mtimeMs: 2,
+                  artifact: {
+                    kind: "attachment" as const,
+                    contentType: "image/png",
+                    editable: false,
+                    preview: "image",
+                  },
+                },
+              ]),
         ],
       }),
       listFolderMetadata: async () => ({
         ok: true,
         folders: { notes: { color: CORAL } },
       }),
-      getFolderMetadata: async (input) => ({
+      getFolderMetadata: async (input: ServiceInput<"getFolderMetadata">) => ({
         ok: true,
         path: input.path,
         metadata: { color: CORAL },
       }),
-      setFolderMetadata: async (input) =>
+      setFolderMetadata: async (input: ServiceInput<"setFolderMetadata">) =>
         recordActor(mutationActors, input.actor, {
           ok: true,
           path: input.path,
@@ -87,13 +115,40 @@ describe("local MCP server", () => {
         size: 10,
         mtimeMs: 1,
       }),
-      createNote: async (input) =>
+      readRawFile: async (input: ServiceInput<"readRawFile">) => ({
+        ok: true,
+        path: input.path,
+        filePath: fixturePath,
+        size: 8,
+        mtimeMs: 2,
+        artifact: {
+          kind: "attachment",
+          contentType: "image/png",
+          editable: false,
+          preview: "image",
+        },
+      }),
+      writeRawFile: async (input: ServiceInput<"writeRawFile">) =>
+        recordActor(mutationActors, input.actor, {
+          ok: true,
+          path: input.path,
+          size: input.bytes.byteLength,
+          mtimeMs: 3,
+          artifact: {
+            kind: "attachment" as const,
+            contentType: "image/png",
+            editable: false,
+            preview: "image" as const,
+          },
+          audit: audit(input.actor, "create"),
+        }),
+      createNote: async (input: ServiceInput<"createNote">) =>
         recordActor(mutationActors, input.actor, {
           ok: true,
           path: input.path,
           audit: audit(input.actor, "create"),
         }),
-      editNote: async (input) =>
+      editNote: async (input: ServiceInput<"editNote">) =>
         recordActor(
           mutationActors,
           input.actor,
@@ -113,7 +168,7 @@ describe("local MCP server", () => {
                 audit: audit(input.actor, "splice"),
               },
         ),
-      appendNote: async (input) =>
+      appendNote: async (input: ServiceInput<"appendNote">) =>
         recordActor(mutationActors, input.actor, {
           ok: true,
           path: input.path,
@@ -121,7 +176,7 @@ describe("local MCP server", () => {
           baseline: "b3",
           audit: audit(input.actor, "append"),
         }),
-      prependNote: async (input) =>
+      prependNote: async (input: ServiceInput<"prependNote">) =>
         recordActor(mutationActors, input.actor, {
           ok: true,
           path: input.path,
@@ -129,14 +184,14 @@ describe("local MCP server", () => {
           baseline: "b4",
           audit: audit(input.actor, "prepend"),
         }),
-      deleteNote: async (input) =>
+      deleteNote: async (input: ServiceInput<"deleteNote">) =>
         recordActor(mutationActors, input.actor, {
           ok: true,
           path: input.path,
           permanent: input.permanent,
           audit: audit(input.actor, "delete"),
         }),
-      moveNote: async (input) =>
+      moveNote: async (input: ServiceInput<"moveNote">) =>
         recordActor(mutationActors, input.actor, {
           ok: true,
           fromPath: input.fromPath,
@@ -144,13 +199,13 @@ describe("local MCP server", () => {
           kind: "file",
           audit: audit(input.actor, "move"),
         }),
-      createFolder: async (input) =>
+      createFolder: async (input: ServiceInput<"createFolder">) =>
         recordActor(mutationActors, input.actor, {
           ok: true,
           path: input.path,
           audit: audit(input.actor, "mkdir"),
         }),
-      deleteFolder: async (input) =>
+      deleteFolder: async (input: ServiceInput<"deleteFolder">) =>
         recordActor(mutationActors, input.actor, {
           ok: true,
           path: input.path,
@@ -158,7 +213,7 @@ describe("local MCP server", () => {
           liveDeleted: [],
           audit: audit(input.actor, "delete"),
         }),
-      moveFolder: async (input) =>
+      moveFolder: async (input: ServiceInput<"moveFolder">) =>
         recordActor(mutationActors, input.actor, {
           ok: true,
           fromPath: input.fromPath,
@@ -202,14 +257,17 @@ describe("local MCP server", () => {
       "delete_note",
       "edit_note",
       "get_folder_metadata",
+      "list_attachments",
       "list_files",
       "list_vaults",
       "move_folder",
       "move_note",
       "prepend_note",
+      "read_attachment",
       "read_note",
       "search",
       "set_folder_metadata",
+      "upload_attachment",
       "vault_info",
     ]);
 
@@ -244,6 +302,12 @@ describe("local MCP server", () => {
       entries: [{ path: "notes", metadata: { color: CORAL } }],
     });
     expect(
+      await toolJson(client, "list_attachments", { vaultId: V }),
+    ).toMatchObject({
+      ok: true,
+      attachments: [{ path: "assets/pixel.png", preview: "image" }],
+    });
+    expect(
       await toolJson(client, "get_folder_metadata", {
         vaultId: V,
         path: "notes",
@@ -259,6 +323,19 @@ describe("local MCP server", () => {
     expect(
       await toolJson(client, "read_note", { vaultId: V, path: "note.md" }),
     ).toMatchObject({ ok: true, baseline: "b1" });
+    expect(
+      await toolJson(client, "read_attachment", {
+        vaultId: V,
+        path: "assets/pixel.png",
+      }),
+    ).toMatchObject({ ok: true, path: "assets/pixel.png", preview: "image" });
+    expect(
+      await toolJson(client, "upload_attachment", {
+        vaultId: V,
+        path: "assets/agent.png",
+        content_base64: Buffer.from("tiny").toString("base64"),
+      }),
+    ).toMatchObject({ ok: true, path: "assets/agent.png", size: 4 });
     expect(
       await toolJson(client, "create_note", {
         vaultId: V,
@@ -358,7 +435,7 @@ describe("local MCP server", () => {
       'edit_note rejected: {"ok":false,"error":"stale_doc","message":"document changed since the provided baseline","current_content":"alpha beta","baseline":"fresh"}',
     );
 
-    expect(mutationActors).toHaveLength(11);
+    expect(mutationActors).toHaveLength(12);
     expect(
       mutationActors.every(
         (actor) =>
@@ -457,7 +534,17 @@ function recordActor<T extends ServiceResult>(
   return result;
 }
 
-function audit(actor: VaultActor, operation: string) {
+type AuditOperation =
+  | "create"
+  | "write"
+  | "mkdir"
+  | "delete"
+  | "move"
+  | "splice"
+  | "append"
+  | "prepend";
+
+function audit(actor: VaultActor, operation: AuditOperation) {
   return {
     id: `${operation}-1`,
     ts: "2026-06-11T00:00:00.000Z",
@@ -471,9 +558,36 @@ function audit(actor: VaultActor, operation: string) {
 
 function emptyService(): LocalMcpVaultService {
   const ok = async (): Promise<ServiceResult> => ({ ok: true });
+  const actor: VaultActor = { kind: "system" };
   return {
     vaultInfo: ok,
     listFiles: ok,
+    readRawFile: async (input) => ({
+      ok: true,
+      path: input.path,
+      filePath: fileURLToPath(new URL("./server.test.ts", import.meta.url)),
+      size: 1,
+      mtimeMs: 1,
+      artifact: {
+        kind: "attachment",
+        contentType: "application/octet-stream",
+        editable: false,
+        preview: "download",
+      },
+    }),
+    writeRawFile: async (input) => ({
+      ok: true,
+      path: input.path,
+      size: input.bytes.byteLength,
+      mtimeMs: 1,
+      artifact: {
+        kind: "attachment",
+        contentType: "application/octet-stream",
+        editable: false,
+        preview: "download",
+      },
+      audit: audit(actor, "write"),
+    }),
     readNote: ok,
     createNote: ok,
     listFolderMetadata: ok,

--- a/packages/local-mcp/src/server.ts
+++ b/packages/local-mcp/src/server.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
@@ -21,6 +22,7 @@ const unknownActor: LocalMcpActor = localAgentActor("unknown local caller");
 
 /** The single synthetic vault id used when the endpoint is built from a bare service. */
 const SINGLE_VAULT_ID = "default";
+const MAX_INLINE_ATTACHMENT_BYTES = 4 * 1024;
 
 export interface LocalMcpEndpoint {
   handleRequest(request: Request): Promise<Response>;
@@ -201,6 +203,136 @@ export function createLocalMcpServer(
     },
     (service, input) => service.listFiles(input),
   );
+
+  registerVaultTool<{ folder?: string; kind?: "image" | "attachment" }>(
+    server,
+    resolve,
+    "list_attachments",
+    {
+      description:
+        "List binary attachments in a vault, optionally scoped to a folder and/or images only. Markdown/text documents are excluded; use list_files for editable notes.",
+      inputSchema: {
+        folder: z
+          .string()
+          .optional()
+          .describe("Optional folder path. Omit for the vault root."),
+        kind: z
+          .enum(["image", "attachment"])
+          .optional()
+          .describe("Use image for image files, attachment for non-image binaries."),
+      },
+    },
+    async (service, input) => {
+      const listed = await service.listFiles({
+        under: input.folder,
+        depth: Number.MAX_SAFE_INTEGER,
+      });
+      if (!listed.ok) return listed;
+      return {
+        ok: true,
+        attachments: attachmentRows(listed as { entries?: unknown }, input.kind),
+      };
+    },
+  );
+
+  registerVaultTool<{ path: string }>(
+    server,
+    resolve,
+    "read_attachment",
+    {
+      description:
+        "Read a binary attachment by vault-relative path. Images are returned as a native MCP image block plus metadata; non-image attachments return base64 text.",
+      inputSchema: {
+        path: z.string().describe("Vault-relative attachment path."),
+      },
+    },
+    async (service, input) => {
+      const result = await service.readRawFile({ path: input.path });
+      if (!result.ok) return result;
+      if (result.artifact.kind !== "attachment") {
+        return {
+          ok: false,
+          error: "invalid_request",
+          message: `"${input.path}" is an editable text document, not an attachment. Use read_note instead.`,
+        };
+      }
+
+      const contentBase64 = (await readFile(result.filePath)).toString("base64");
+      const metadata = {
+        path: result.path,
+        contentType: result.artifact.contentType,
+        preview: result.artifact.preview,
+        size: result.size,
+        mtimeMs: result.mtimeMs,
+      };
+      if (result.artifact.preview === "image") {
+        return {
+          content: [
+            { type: "text", text: JSON.stringify({ ok: true, ...metadata }, null, 2) },
+            {
+              type: "image",
+              data: contentBase64,
+              mimeType: result.artifact.contentType,
+            },
+          ],
+        };
+      }
+
+      return {
+        ok: true,
+        ...metadata,
+        contentBase64,
+      };
+    },
+  );
+
+  registerVaultTool<{
+    path: string;
+    content_base64: string;
+    overwrite?: boolean;
+  }>(server, resolve, "upload_attachment", {
+    description:
+      "Upload a tiny binary attachment inline as base64. The destination path is vault-relative and explicit. Inline uploads are capped at 4 KiB; larger attachment side-channel upload is a follow-up.",
+    inputSchema: {
+      path: z
+        .string()
+        .min(1)
+        .describe("Vault-relative destination path, e.g. assets/screenshot.png."),
+      content_base64: z
+        .string()
+        .refine((value) => base64ByteUpperBound(value) <= MAX_INLINE_ATTACHMENT_BYTES, {
+          message:
+            "content_base64 decodes to more than 4 KiB. Inline attachment uploads are capped at 4 KiB.",
+        })
+        .describe("Raw file bytes encoded as base64, without a data URL prefix."),
+      overwrite: z
+        .boolean()
+        .optional()
+        .describe("Replace an existing file at path when true."),
+    },
+  }, async (service, input) => {
+    if (!isAttachmentPath(input.path)) {
+      return {
+        ok: false,
+        error: "invalid_request",
+        message: "upload_attachment only writes binary attachment paths, not editable text documents.",
+      };
+    }
+    const bytes = decodeBase64(input.content_base64);
+    if (!bytes) {
+      return {
+        ok: false,
+        error: "invalid_request",
+        message: "content_base64 is not valid base64.",
+      };
+    }
+    return service.writeRawFile({
+      path: input.path,
+      bytes,
+      overwrite: input.overwrite,
+      actor: actor(),
+    });
+  });
 
   registerVaultTool<{ path: string }>(
     server,
@@ -597,6 +729,9 @@ function registerTool<TInput extends object>(
 ): void {
   server.registerTool(name, config, async (input) => {
     const result = await handler(input as TInput);
+    if (isDirectToolResult(result)) {
+      return result;
+    }
     if (isServiceFailure(result)) {
       return {
         isError: true,
@@ -612,6 +747,23 @@ function registerTool<TInput extends object>(
   });
 }
 
+type DirectToolResult = {
+  isError?: boolean;
+  content: Array<
+    | { type: "text"; text: string }
+    | { type: "image"; data: string; mimeType: string }
+  >;
+};
+
+function isDirectToolResult(value: unknown): value is DirectToolResult {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      "content" in value &&
+      Array.isArray((value as { content?: unknown }).content),
+  );
+}
+
 function isServiceFailure(value: unknown): value is ServiceFailure {
   return Boolean(
     value &&
@@ -619,6 +771,112 @@ function isServiceFailure(value: unknown): value is ServiceFailure {
     "ok" in value &&
     (value as { ok?: unknown }).ok === false,
   );
+}
+
+interface ListedVaultEntry {
+  path: string;
+  kind: "file" | "folder";
+  size?: number;
+  mtimeMs?: number;
+  artifact?: {
+    kind: "text" | "attachment";
+    contentType: string;
+    editable: boolean;
+    preview: string;
+  };
+}
+
+function attachmentRows(
+  result: { entries?: unknown },
+  kind: "image" | "attachment" | undefined,
+): Array<{
+  path: string;
+  contentType: string;
+  preview: string;
+  size: number;
+  mtimeMs: number;
+}> {
+  const entries = Array.isArray(result.entries) ? result.entries : [];
+  return entries.flatMap((entry): Array<{
+    path: string;
+    contentType: string;
+    preview: string;
+    size: number;
+    mtimeMs: number;
+  }> => {
+    if (!isListedVaultEntry(entry)) return [];
+    if (entry.kind !== "file" || entry.artifact?.kind !== "attachment") return [];
+    if (kind === "image" && entry.artifact.preview !== "image") return [];
+    if (kind === "attachment" && entry.artifact.preview === "image") return [];
+    return [{
+      path: entry.path,
+      contentType: entry.artifact.contentType,
+      preview: entry.artifact.preview,
+      size: entry.size ?? 0,
+      mtimeMs: entry.mtimeMs ?? 0,
+    }];
+  });
+}
+
+function isListedVaultEntry(value: unknown): value is ListedVaultEntry {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      typeof (value as { path?: unknown }).path === "string" &&
+      ((value as { kind?: unknown }).kind === "file" ||
+        (value as { kind?: unknown }).kind === "folder"),
+  );
+}
+
+function base64ByteUpperBound(value: string): number {
+  return Math.ceil((value.length * 3) / 4);
+}
+
+function decodeBase64(value: string): Uint8Array | null {
+  if (value.length % 4 !== 0) return null;
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(value)) return null;
+  return Buffer.from(value, "base64");
+}
+
+const TEXT_ATTACHMENT_EXTENSIONS = new Set([
+  ".md",
+  ".markdown",
+  ".mdown",
+  ".mkdn",
+  ".txt",
+  ".log",
+  ".csv",
+  ".tsv",
+  ".html",
+  ".htm",
+  ".css",
+  ".js",
+  ".jsx",
+  ".ts",
+  ".tsx",
+  ".json",
+  ".yml",
+  ".yaml",
+  ".xml",
+  ".toml",
+  ".ini",
+  ".sh",
+  ".py",
+  ".rb",
+  ".go",
+  ".rs",
+  ".java",
+  ".c",
+  ".cpp",
+  ".h",
+  ".hpp",
+]);
+
+function isAttachmentPath(path: string): boolean {
+  const name = path.split("/").at(-1) ?? path;
+  const dot = name.lastIndexOf(".");
+  const extension = dot >= 0 ? name.slice(dot).toLowerCase() : "";
+  return !TEXT_ATTACHMENT_EXTENSIONS.has(extension);
 }
 
 function jsonRpcError(message: string, status: number): Response {

--- a/packages/ui/src/lib/local-editor/types.ts
+++ b/packages/ui/src/lib/local-editor/types.ts
@@ -1,9 +1,28 @@
 import type { AccentName } from "../primitives/accent";
 
+export type LocalArtifactKind = "text" | "attachment";
+
+export type LocalArtifactPreview =
+  | "markdown"
+  | "text"
+  | "image"
+  | "audio"
+  | "video"
+  | "pdf"
+  | "download";
+
+export interface LocalArtifactInfo {
+  kind: LocalArtifactKind;
+  contentType: string;
+  editable: boolean;
+  preview: LocalArtifactPreview;
+}
+
 export interface LocalFileNode {
   kind: "file";
   path: string;
   name: string;
+  artifact?: LocalArtifactInfo;
 }
 
 export interface LocalFolderMetadata {

--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -21,6 +21,7 @@ import {
   prependContent,
 } from "./splice.js";
 import {
+  classifyArtifactPath,
   deleteVaultFile,
   deleteVaultFolder,
   getFolderMetadata,
@@ -29,8 +30,10 @@ import {
   listVaultTree,
   makeVaultFolder,
   moveVaultPath,
+  readVaultRawFile,
   readVaultFile,
   setFolderMetadata,
+  writeVaultRawFile,
   writeVaultFile,
   type VaultContext,
 } from "./vault-ops.js";
@@ -80,6 +83,7 @@ describe("vault path validation", () => {
     ["/absolute.md", "file"],
     ["nested//file.md", "file"],
     ["nested/", "folder"],
+    ["nested/../asset", "artifact"],
     [".", "folder"],
     ["..", "folder"],
     ["nested/../file.md", "file"],
@@ -88,6 +92,7 @@ describe("vault path validation", () => {
     ["folder/.hidden", "file"],
     ["folder/trailing.", "file"],
     [".kb2/audit.md", "file"],
+    [".kb2/audit.bin", "artifact"],
     [`${"a".repeat(256)}.md`, "file"],
     [`${"a".repeat(1025)}.md`, "file"],
   ] as const)("rejects invalid %s as %s", (input, kind) => {
@@ -98,6 +103,8 @@ describe("vault path validation", () => {
     ["note.md", "file"],
     ["nested/note.md", "file"],
     ["nested/deep", "folder"],
+    ["attachments/photo.png", "artifact"],
+    ["attachments/extensionless", "artifact"],
   ] as const)("accepts %s as %s", (input, kind) => {
     expect(validateVaultPath(input, kind)).toBe(input);
   });
@@ -213,6 +220,151 @@ describe("vault-core filesystem operations", () => {
     expect(auditLines[1]).toMatchObject({
       operation: "write",
       path: "notes/a.md",
+    });
+  });
+
+  it("classifies copied-in filesystem artifacts without required metadata", async () => {
+    await writeFileWithParents(path.join(root, "notes/a.md"), "# A\n", "utf8");
+    await writeFileWithParents(
+      path.join(root, "scripts/app.ts"),
+      "export {};\n",
+      "utf8",
+    );
+    await mkdir(path.join(root, "attachments"), { recursive: true });
+    await writeFile(path.join(root, "attachments/photo.png"), new Uint8Array([0x89, 0x50, 0x4e, 0x47]));
+    await writeFile(path.join(root, "attachments/blob"), new Uint8Array([1, 2, 3]));
+
+    const tree = await listVaultTree(ctx, { depth: Number.MAX_SAFE_INTEGER });
+    expect(tree).toMatchObject({ ok: true });
+    if (!tree.ok) throw new Error("expected tree");
+    expect(tree.value.entries).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        path: "notes/a.md",
+        kind: "file",
+        artifact: {
+          kind: "text",
+          contentType: "text/markdown; charset=utf-8",
+          editable: true,
+          preview: "markdown",
+        },
+      }),
+      expect.objectContaining({
+        path: "scripts/app.ts",
+        kind: "file",
+        artifact: {
+          kind: "text",
+          contentType: "text/typescript; charset=utf-8",
+          editable: true,
+          preview: "text",
+        },
+      }),
+      expect.objectContaining({
+        path: "attachments/photo.png",
+        kind: "file",
+        artifact: {
+          kind: "attachment",
+          contentType: "image/png",
+          editable: false,
+          preview: "image",
+        },
+      }),
+      expect.objectContaining({
+        path: "attachments/blob",
+        kind: "file",
+        artifact: {
+          kind: "attachment",
+          contentType: "application/octet-stream",
+          editable: false,
+          preview: "download",
+        },
+      }),
+    ]));
+  });
+
+  it("round-trips raw bytes without the editable text path", async () => {
+    const bytes = new Uint8Array([0, 1, 2, 255]);
+    const created = await writeVaultRawFile(ctx, {
+      path: "attachments/photo.png",
+      bytes,
+    });
+    expect(created).toMatchObject({
+      ok: true,
+      value: {
+        path: "attachments/photo.png",
+        size: 4,
+        artifact: {
+          kind: "attachment",
+          contentType: "image/png",
+          editable: false,
+          preview: "image",
+        },
+      },
+    });
+    await expect(readFile(path.join(root, "attachments/photo.png"))).resolves.toEqual(Buffer.from(bytes));
+
+    const duplicate = await writeVaultRawFile(ctx, {
+      path: "attachments/photo.png",
+      bytes: new Uint8Array([9]),
+    });
+    expect(duplicate).toMatchObject({ ok: false, error: "already_exists" });
+
+    const raw = await readVaultRawFile(ctx, "attachments/photo.png");
+    expect(raw).toMatchObject({
+      ok: true,
+      value: {
+        path: "attachments/photo.png",
+        filePath: path.join(root, "attachments/photo.png"),
+        size: 4,
+      },
+    });
+
+    await expect(readVaultFile(ctx, "attachments/photo.png")).resolves.toMatchObject({
+      ok: false,
+      error: "not_editable",
+    });
+    await expect(writeVaultFile(ctx, {
+      path: "attachments/photo.png",
+      content: "not png",
+      overwrite: true,
+    })).resolves.toMatchObject({
+      ok: false,
+      error: "not_editable",
+    });
+
+    const extensionless = await writeVaultRawFile(ctx, {
+      path: "attachments/blob",
+      bytes,
+    });
+    expect(extensionless).toMatchObject({
+      ok: true,
+      value: {
+        artifact: {
+          kind: "attachment",
+          contentType: "application/octet-stream",
+          preview: "download",
+        },
+      },
+    });
+  });
+
+  it("exposes deterministic artifact classification for callers", () => {
+    expect(classifyArtifactPath("notes/a.md")).toEqual({
+      kind: "text",
+      contentType: "text/markdown; charset=utf-8",
+      editable: true,
+      preview: "markdown",
+    });
+    expect(classifyArtifactPath("assets/clip.mp3")).toEqual({
+      kind: "attachment",
+      contentType: "audio/mpeg",
+      editable: false,
+      preview: "audio",
+    });
+    expect(classifyArtifactPath("assets/unknown")).toEqual({
+      kind: "attachment",
+      contentType: "application/octet-stream",
+      editable: false,
+      preview: "download",
     });
   });
 

--- a/packages/vault-core/src/index.ts
+++ b/packages/vault-core/src/index.ts
@@ -48,6 +48,7 @@ export {
   type SearchResult,
 } from "./search.js";
 export {
+  classifyArtifactPath,
   deleteVaultFile,
   deleteVaultFolder,
   getFolderMetadata,
@@ -56,9 +57,14 @@ export {
   listVaultTree,
   makeVaultFolder,
   moveVaultPath,
+  readVaultRawFile,
   readVaultFile,
   setFolderMetadata,
+  writeVaultRawFile,
   writeVaultFile,
+  type ArtifactInfo,
+  type ArtifactKind,
+  type ArtifactPreview,
   type DeleteValue,
   type FolderMetadata,
   type FolderMetadataInput,
@@ -66,11 +72,13 @@ export {
   type FolderMetadataValue,
   type MoveValue,
   type ReadFileValue,
+  type ReadRawFileValue,
   type VaultContext,
   type VaultEntry,
   type VaultErrorCode,
   type VaultInfo,
   type VaultResult,
   type WriteFileValue,
+  type WriteRawFileValue,
 } from "./vault-ops.js";
 export { anchoredSpliceContractCases } from "./splice-contract-cases.test-support.js";

--- a/packages/vault-core/src/path.ts
+++ b/packages/vault-core/src/path.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 const MAX_PATH_LENGTH = 1024;
 const MAX_SEGMENT_LENGTH = 255;
 
-export type VaultPathKind = 'file' | 'folder';
+export type VaultPathKind = 'file' | 'folder' | 'artifact';
 
 export class InvalidPathError extends Error {
   constructor(public readonly input: string, public readonly reason: string) {

--- a/packages/vault-core/src/vault-ops.ts
+++ b/packages/vault-core/src/vault-ops.ts
@@ -32,6 +32,7 @@ export type { AuditEntry, VaultActor };
 export type VaultErrorCode =
   | "invalid_path"
   | "invalid_metadata"
+  | "not_editable"
   | "not_found"
   | "already_exists"
   | "path_collision"
@@ -53,6 +54,7 @@ export interface VaultEntry {
   kind: "file" | "folder";
   size: number;
   mtimeMs: number;
+  artifact?: ArtifactInfo;
   metadata?: FolderMetadata;
 }
 
@@ -73,6 +75,40 @@ export interface WriteFileValue {
   path: string;
   size: number;
   mtimeMs: number;
+  audit: AuditEntry;
+}
+
+export type ArtifactKind = "text" | "attachment";
+
+export type ArtifactPreview =
+  | "markdown"
+  | "text"
+  | "image"
+  | "audio"
+  | "video"
+  | "pdf"
+  | "download";
+
+export interface ArtifactInfo {
+  kind: ArtifactKind;
+  contentType: string;
+  editable: boolean;
+  preview: ArtifactPreview;
+}
+
+export interface ReadRawFileValue {
+  path: string;
+  filePath: string;
+  size: number;
+  mtimeMs: number;
+  artifact: ArtifactInfo;
+}
+
+export interface WriteRawFileValue {
+  path: string;
+  size: number;
+  mtimeMs: number;
+  artifact: ArtifactInfo;
   audit: AuditEntry;
 }
 
@@ -177,6 +213,104 @@ function isHiddenMetadataPath(relPath: string): boolean {
   return relPath === ".kb2" || relPath.startsWith(".kb2/");
 }
 
+const TEXT_ARTIFACT_EXTENSIONS: Record<string, { contentType: string; preview: ArtifactPreview }> = {
+  ".md": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
+  ".markdown": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
+  ".mdown": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
+  ".mkdn": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
+  ".txt": { contentType: "text/plain; charset=utf-8", preview: "text" },
+  ".log": { contentType: "text/plain; charset=utf-8", preview: "text" },
+  ".csv": { contentType: "text/csv; charset=utf-8", preview: "text" },
+  ".tsv": { contentType: "text/tab-separated-values; charset=utf-8", preview: "text" },
+  ".html": { contentType: "text/html; charset=utf-8", preview: "text" },
+  ".htm": { contentType: "text/html; charset=utf-8", preview: "text" },
+  ".css": { contentType: "text/css; charset=utf-8", preview: "text" },
+  ".js": { contentType: "text/javascript; charset=utf-8", preview: "text" },
+  ".jsx": { contentType: "text/javascript; charset=utf-8", preview: "text" },
+  ".ts": { contentType: "text/typescript; charset=utf-8", preview: "text" },
+  ".tsx": { contentType: "text/typescript; charset=utf-8", preview: "text" },
+  ".json": { contentType: "application/json; charset=utf-8", preview: "text" },
+  ".yml": { contentType: "application/yaml; charset=utf-8", preview: "text" },
+  ".yaml": { contentType: "application/yaml; charset=utf-8", preview: "text" },
+  ".xml": { contentType: "application/xml; charset=utf-8", preview: "text" },
+  ".toml": { contentType: "application/toml; charset=utf-8", preview: "text" },
+  ".ini": { contentType: "text/plain; charset=utf-8", preview: "text" },
+  ".sh": { contentType: "text/x-shellscript; charset=utf-8", preview: "text" },
+  ".py": { contentType: "text/x-python; charset=utf-8", preview: "text" },
+  ".rb": { contentType: "text/x-ruby; charset=utf-8", preview: "text" },
+  ".go": { contentType: "text/x-go; charset=utf-8", preview: "text" },
+  ".rs": { contentType: "text/x-rust; charset=utf-8", preview: "text" },
+  ".java": { contentType: "text/x-java-source; charset=utf-8", preview: "text" },
+  ".c": { contentType: "text/x-c; charset=utf-8", preview: "text" },
+  ".cpp": { contentType: "text/x-c++; charset=utf-8", preview: "text" },
+  ".h": { contentType: "text/x-c; charset=utf-8", preview: "text" },
+  ".hpp": { contentType: "text/x-c++; charset=utf-8", preview: "text" },
+};
+
+const ATTACHMENT_ARTIFACT_EXTENSIONS: Record<string, { contentType: string; preview: ArtifactPreview }> = {
+  ".png": { contentType: "image/png", preview: "image" },
+  ".jpg": { contentType: "image/jpeg", preview: "image" },
+  ".jpeg": { contentType: "image/jpeg", preview: "image" },
+  ".gif": { contentType: "image/gif", preview: "image" },
+  ".webp": { contentType: "image/webp", preview: "image" },
+  ".avif": { contentType: "image/avif", preview: "image" },
+  ".apng": { contentType: "image/apng", preview: "image" },
+  ".svg": { contentType: "application/octet-stream", preview: "download" },
+  ".mp3": { contentType: "audio/mpeg", preview: "audio" },
+  ".wav": { contentType: "audio/wav", preview: "audio" },
+  ".ogg": { contentType: "audio/ogg", preview: "audio" },
+  ".flac": { contentType: "audio/flac", preview: "audio" },
+  ".m4a": { contentType: "audio/mp4", preview: "audio" },
+  ".aac": { contentType: "audio/aac", preview: "audio" },
+  ".mp4": { contentType: "video/mp4", preview: "video" },
+  ".webm": { contentType: "video/webm", preview: "video" },
+  ".mov": { contentType: "video/quicktime", preview: "video" },
+  ".m4v": { contentType: "video/x-m4v", preview: "video" },
+  ".pdf": { contentType: "application/pdf", preview: "pdf" },
+  ".zip": { contentType: "application/zip", preview: "download" },
+  ".gz": { contentType: "application/gzip", preview: "download" },
+  ".tgz": { contentType: "application/gzip", preview: "download" },
+  ".tar": { contentType: "application/x-tar", preview: "download" },
+};
+
+export function classifyArtifactPath(relPath: string): ArtifactInfo {
+  const extension = path.posix.extname(relPath).toLowerCase();
+  const text = TEXT_ARTIFACT_EXTENSIONS[extension];
+  if (text) {
+    return {
+      kind: "text",
+      contentType: text.contentType,
+      editable: true,
+      preview: text.preview,
+    };
+  }
+
+  const attachment = ATTACHMENT_ARTIFACT_EXTENSIONS[extension];
+  if (attachment) {
+    return {
+      kind: "attachment",
+      contentType: attachment.contentType,
+      editable: false,
+      preview: attachment.preview,
+    };
+  }
+
+  return {
+    kind: "attachment",
+    contentType: "application/octet-stream",
+    editable: false,
+    preview: "download",
+  };
+}
+
+function ensureEditableArtifact(relPath: string): VaultResult<ArtifactInfo> {
+  const artifact = classifyArtifactPath(relPath);
+  if (!artifact.editable) {
+    return fail("not_editable", "file is not an editable text artifact");
+  }
+  return { ok: true, value: artifact };
+}
+
 async function walkEntries(
   root: string,
   relDir: string,
@@ -205,6 +339,7 @@ async function walkEntries(
         kind: "file",
         size: s.size,
         mtimeMs: s.mtimeMs,
+        artifact: classifyArtifactPath(rel),
       });
       if (entries.length >= cap) throw new EntryCapExceededError();
     }
@@ -597,6 +732,8 @@ export async function readVaultFile(
 ): Promise<VaultResult<ReadFileValue>> {
   try {
     const rel = validateVaultPath(filePath, "file");
+    const artifact = ensureEditableArtifact(rel);
+    if (!artifact.ok) return artifact;
     const abs = vaultPath(ctx.root, rel);
     const s = await statOrNull(abs);
     if (!s || !s.isFile()) return fail("not_found", "file not found");
@@ -624,6 +761,8 @@ export async function writeVaultFile(
 ): Promise<VaultResult<WriteFileValue>> {
   try {
     const rel = validateVaultPath(input.path, "file");
+    const artifact = ensureEditableArtifact(rel);
+    if (!artifact.ok) return artifact;
     const abs = vaultPath(ctx.root, rel);
     const existsAlready = await exists(abs);
     if (existsAlready && input.overwrite !== true) {
@@ -643,6 +782,77 @@ export async function writeVaultFile(
     return {
       ok: true,
       value: { path: rel, size: s.size, mtimeMs: s.mtimeMs, audit },
+    };
+  } catch (err) {
+    const pathResult = classifyPathError(err);
+    /* v8 ignore next -- Defensive false branch rethrows unexpected mkdir errors; invalid-path classification is covered. */
+    if (pathResult) return pathResult;
+    const collisionResult = classifyFsCollision(err);
+    if (collisionResult) return collisionResult;
+    /* v8 ignore next -- Defensive rethrow for unexpected write failures outside classified path/collision errors. */
+    throw err;
+  }
+}
+
+export async function readVaultRawFile(
+  ctx: VaultContext,
+  filePath: string,
+): Promise<VaultResult<ReadRawFileValue>> {
+  try {
+    const rel = validateVaultPath(filePath, "artifact");
+    const abs = vaultPath(ctx.root, rel);
+    const s = await statOrNull(abs);
+    if (!s || !s.isFile()) return fail("not_found", "file not found");
+    return {
+      ok: true,
+      value: {
+        path: rel,
+        filePath: abs,
+        size: s.size,
+        mtimeMs: s.mtimeMs,
+        artifact: classifyArtifactPath(rel),
+      },
+    };
+  } catch (err) {
+    const pathResult = classifyPathError(err);
+    /* v8 ignore next -- Defensive false branch rethrows unexpected read errors; invalid-path classification is covered. */
+    if (pathResult) return pathResult;
+    /* v8 ignore next -- Defensive rethrow for unexpected read failures outside classified path/not-found errors. */
+    throw err;
+  }
+}
+
+export async function writeVaultRawFile(
+  ctx: VaultContext,
+  input: { path: string; bytes: Uint8Array; overwrite?: boolean },
+): Promise<VaultResult<WriteRawFileValue>> {
+  try {
+    const rel = validateVaultPath(input.path, "artifact");
+    const abs = vaultPath(ctx.root, rel);
+    const existsAlready = await exists(abs);
+    if (existsAlready && input.overwrite !== true) {
+      return fail("already_exists", "file already exists");
+    }
+    await mkdir(path.dirname(abs), { recursive: true });
+    await writeFile(abs, input.bytes);
+    const s = await stat(abs);
+    const audit = await emitVaultAudit({
+      root: ctx.root,
+      actor: ctx.actor,
+      operation: existsAlready ? "write" : "create",
+      entityKind: "file",
+      path: rel,
+      summary: existsAlready ? `Wrote ${rel}` : `Created ${rel}`,
+    });
+    return {
+      ok: true,
+      value: {
+        path: rel,
+        size: s.size,
+        mtimeMs: s.mtimeMs,
+        artifact: classifyArtifactPath(rel),
+        audit,
+      },
     };
   } catch (err) {
     const pathResult = classifyPathError(err);

--- a/packages/vault-service/src/index.ts
+++ b/packages/vault-service/src/index.ts
@@ -9,6 +9,7 @@ import {
   InvalidPathError,
   appendContent,
   applyAnchoredSplice,
+  classifyArtifactPath,
   deleteVaultFile,
   deleteVaultFolder,
   emitVaultAudit,
@@ -23,24 +24,30 @@ import {
   moveVaultPath,
   onVaultAudit,
   prependContent,
+  readVaultRawFile,
   readVaultFile,
   recordFileHistory,
   searchVaultFiles,
   setFolderMetadata as setVaultFolderMetadata,
   validateVaultPath,
+  writeVaultRawFile,
   writeVaultFile,
   type AnchoredSpliceRequest,
   type AuditChangeEventOptions,
   type AuditEntry,
+  type ArtifactInfo,
   type FileHistoryEntry,
   type FolderMetadataInput,
+  type ReadRawFileValue,
   type VaultEntry,
   type VaultActor,
   type VaultErrorCode,
-  type VaultResult
+  type VaultResult,
+  type WriteRawFileValue
 } from '@kb-2/vault-core';
 
 export type { AuditEntry, VaultActor };
+export type { ArtifactInfo };
 export type { FileHistoryEntry };
 
 export type ServiceErrorCode =
@@ -110,6 +117,8 @@ export interface LocalMcpVaultService {
   listFolderMetadata(): Promise<ServiceResult>;
   getFolderMetadata(input: { path: string }): Promise<ServiceResult>;
   setFolderMetadata(input: { path: string; metadata: FolderMetadataInput; actor: VaultActor }): Promise<ServiceResult>;
+  readRawFile(input: { path: string }): Promise<ServiceResult<ReadRawFileValue>>;
+  writeRawFile(input: { path: string; bytes: Uint8Array; overwrite?: boolean; actor: VaultActor }): Promise<ServiceResult<WriteRawFileValue>>;
   readNote(input: { path: string }): Promise<ServiceResult>;
   createNote(input: { path: string; content: string; overwrite?: boolean; actor: VaultActor }): Promise<ServiceResult>;
   editNote(input: EditNoteInput & { actor: VaultActor }): Promise<ServiceResult>;
@@ -349,11 +358,25 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       };
     },
 
+    async readRawFile(input) {
+      return serviceResult(await readVaultRawFile(ctx(), input.path));
+    },
+
+    async writeRawFile(input) {
+      return serviceResult(await writeVaultRawFile(ctx(input.actor), {
+        path: input.path,
+        bytes: input.bytes,
+        overwrite: input.overwrite
+      }));
+    },
+
     async listNoteHistory(input) {
       return serviceResult(await listFileHistory(options.vaultRoot, input));
     },
 
     async createNote(input) {
+      const validPath = validateServiceFilePath(input.path);
+      if (!validPath.ok) return validPath;
       const liveSession = options.documentSessions.getOpenSession(input.path);
       if (liveSession) {
         if (!input.overwrite) {
@@ -743,7 +766,12 @@ function assertNever(value: never): never {
 
 function validateServiceFilePath(filePath: string): ServiceResult<{ path: string }> {
   try {
-    return { ok: true, path: validateVaultPath(filePath, 'file') };
+    const path = validateVaultPath(filePath, 'file');
+    const artifact = classifyArtifactPath(path);
+    if (!artifact.editable) {
+      return failure('not_editable', 'file is not an editable text artifact');
+    }
+    return { ok: true, path };
   } catch (error) {
     if (error instanceof InvalidPathError) {
       return failure('invalid_path', error.message);


### PR DESCRIPTION
## Summary
- classify vault files as editable text or non-editable attachments in the tree
- add binary-safe raw file read/write routes and route Markdown images through them
- add paste/drop image upload support plus local MCP attachment tools

## Verification
- pnpm --filter @kb-2/vault-core exec vitest run src/index.test.ts
- pnpm --filter @kb-2/daemon exec vitest run src/routing.test.ts
- pnpm --filter @kb-2/editor exec vitest run src/lib/plaintext-image-upload.test.ts
- pnpm --filter @kb-2/local-mcp exec vitest run src/server.test.ts
- pnpm --filter @kb-2/daemon typecheck
- pnpm --filter @kb-2/editor typecheck
- pnpm --filter @kb-2/local-mcp typecheck
- pnpm --filter @kb-2/web typecheck

E2E not run by request.