### PR TITLE
Use Git for daemon file history

### DIFF
--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -616,25 +616,26 @@ describe("daemon routing", () => {
 
     const history = await app.request(`${filePath("notes/attributed.md")}/history`);
     expect(history.status).toBe(200);
-    await expect(history.json()).resolves.toMatchObject({
+    const historyBody = await history.json();
+    expect(historyBody).toMatchObject({
       ok: true,
       hasMore: false,
       entries: [
         {
+          pending: true,
           operation: "create",
           path: "notes/attributed.md",
           actor: suppliedActor,
+          contributors: [suppliedActor],
           size: 11,
         },
       ],
     });
-    const rawHistory = await readRawFileHistory(vaultRoot);
-    expect(rawHistory).toContain("Ada Lovelace");
-    expect(rawHistory).not.toContain("\n    content:");
+    expect(JSON.stringify(historyBody)).not.toContain("attributed\\n");
 
     const historyAgain = await app.request(`${filePath("notes/attributed.md")}/history`);
     expect(historyAgain.status).toBe(200);
-    await expect(readRawFileHistory(vaultRoot)).resolves.toBe(rawHistory);
+    await expect(historyAgain.json()).resolves.toEqual(historyBody);
 
     const moved = await app.request(`${filePath("notes/attributed.md")}/move`, {
       method: "POST",
@@ -2515,10 +2516,6 @@ async function readAuditRows(
 
 async function readRawFolderMetadata(root: string): Promise<string> {
   return readFile(join(root, ".kb2/folders.yml"), "utf8");
-}
-
-async function readRawFileHistory(root: string): Promise<string> {
-  return readFile(join(root, ".kb2/file-history.yml"), "utf8");
 }
 
 async function writeFileWithParents(

--- a/packages/vault-core/src/file-history.ts
+++ b/packages/vault-core/src/file-history.ts
@@ -1,11 +1,11 @@
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { mkdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { promisify } from "node:util";
 
 import type { VaultActor, AuditOperation } from "./audit.js";
-import { isNodeError } from "./fs.js";
-import { resolveVaultPath, validateVaultPath } from "./path.js";
+import { validateVaultPath } from "./path.js";
 import type { VaultResult } from "./vault-ops.js";
 
 export type FileHistoryOperation = "create" | "update" | "move" | "rename";
@@ -16,6 +16,9 @@ export interface FileHistoryEntry {
   operation: FileHistoryOperation;
   actor: VaultActor;
   integrationId?: string;
+  contributors?: VaultActor[];
+  pending?: boolean;
+  commitId?: string;
   createdAt: string;
   updatedAt: string;
   content?: string;
@@ -45,6 +48,19 @@ export interface MoveFileHistoryInput {
   actor?: VaultActor;
   content: string;
   now?: Date;
+  coalesceWindowMs?: number;
+}
+
+export interface MoveFolderHistoryInput {
+  fromPath: string;
+  toPath: string;
+  actor?: VaultActor;
+  now?: Date;
+}
+
+export interface FlushFileHistoryInput {
+  paths?: string[];
+  now?: Date;
 }
 
 export interface FileHistoryPage {
@@ -52,50 +68,48 @@ export interface FileHistoryPage {
   hasMore: boolean;
 }
 
-type FileHistoryMap = Record<string, FileHistoryEntry[]>;
+export interface FlushFileHistoryValue {
+  flushed: number;
+  unavailable?: boolean;
+}
 
-const FILE_HISTORY_RELATIVE_PATH = path.posix.join(".kb2", "file-history.yml");
-const DEFAULT_HISTORY_COALESCE_WINDOW_MS = 5 * 60 * 1000;
+interface PendingHistoryEntry {
+  id: string;
+  path: string;
+  fromPath?: string;
+  operation: FileHistoryOperation;
+  bucketStart: string;
+  createdAt: string;
+  updatedAt: string;
+  content: string;
+  size: number;
+  contentHash: string;
+  contributors: VaultActor[];
+}
+
+interface GitResult {
+  stdout: string;
+  stderr: string;
+}
+
+type PendingHistoryMap = Map<string, PendingHistoryEntry>;
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_HISTORY_BUCKET_WINDOW_MS = 5 * 60 * 1000;
 const DEFAULT_HISTORY_PAGE_LIMIT = 50;
 const MAX_HISTORY_PAGE_LIMIT = 200;
-const FILE_HISTORY_CONTENT_SNAPSHOTS_ENABLED = false;
-const fileHistoryMutationQueues = new Map<string, Promise<void>>();
+const DAEMON_AUTHOR_NAME = "KB-1 Daemon";
+const DAEMON_AUTHOR_EMAIL = "history@kb-1.ai";
+const GITIGNORE_RELATIVE_PATH = ".gitignore";
+/* v8 ignore next -- Constant is exercised indirectly through Git log parsing but v8 marks separator declarations as uncovered. */
+const COMMIT_SEPARATOR = "\x1e";
+const FIELD_SEPARATOR = "\x00";
+const pendingHistoryByRoot = new Map<string, PendingHistoryMap>();
+const gitInitByRoot = new Map<string, Promise<boolean>>();
 
-function ignoreMutationQueueResult(): void {
-  return undefined;
-}
-
-function fail(error: "invalid_path" | "invalid_metadata" | "metadata_parse_failed", message: string): VaultResult<never> {
+function fail(error: "invalid_path", message: string): VaultResult<never> {
   return { ok: false, error, message };
-}
-
-function metadataFileFailure(
-  message = "file history metadata file is malformed",
-): VaultResult<never> {
-  return fail("metadata_parse_failed", message);
-}
-
-function fileHistoryPath(root: string): string {
-  return resolveVaultPath(root, FILE_HISTORY_RELATIVE_PATH);
-}
-
-async function withFileHistoryMutation<T>(
-  root: string,
-  operation: () => Promise<T>,
-): Promise<T> {
-  const key = path.resolve(root);
-  const previous = fileHistoryMutationQueues.get(key) ?? Promise.resolve();
-  const run = previous.then(operation, operation);
-  const next = run.then(ignoreMutationQueueResult, ignoreMutationQueueResult);
-  fileHistoryMutationQueues.set(key, next);
-
-  try {
-    return await run;
-  } finally {
-    if (fileHistoryMutationQueues.get(key) === next) {
-      fileHistoryMutationQueues.delete(key);
-    }
-  }
 }
 
 export async function recordFileHistory(
@@ -106,6 +120,7 @@ export async function recordFileHistory(
   try {
     rel = validateVaultPath(input.path, "file");
   } catch (error) {
+    /* v8 ignore next -- validateVaultPath throws Error instances; non-Error throws are handled below defensively. */
     if (error instanceof Error) {
       return fail("invalid_path", error.message);
     }
@@ -113,58 +128,40 @@ export async function recordFileHistory(
     throw error;
   }
 
-  return await withFileHistoryMutation(root, async () => {
-    const map = await readFileHistoryMap(root);
-    if (!map.ok) return map;
+  const actor = cloneActor(input.actor ?? { kind: "unknown" });
+  const now = input.now ?? new Date();
+  const bucketStart = bucketStartIso(now, input.coalesceWindowMs);
+  const contentHash = await hashContent(input.content);
+  const size = new TextEncoder().encode(input.content).byteLength;
+  const pending = pendingForRoot(root);
+  const key = pendingKey(rel, bucketStart);
+  const existing = pending.get(key);
 
-    const now = input.now ?? new Date();
-    const nowIso = now.toISOString();
-    const existingEntries = map.value[rel] ?? [];
-    const actor = cloneActor(input.actor ?? { kind: "unknown" });
-    const integrationId = integrationIdForActor(actor);
-    const contentHash = await hashContent(input.content);
-    const size = new TextEncoder().encode(input.content).byteLength;
-    const coalesceWindowMs = normalizeCoalesceWindowMs(input.coalesceWindowMs);
-    const previous = existingEntries.at(-1);
-
-    let entry: FileHistoryEntry;
-    if (
-      previous &&
-      sameActorAndIntegration(previous, actor, integrationId) &&
-      now.getTime() - new Date(previous.updatedAt).getTime() <= coalesceWindowMs
-    ) {
-      entry = {
-        id: previous.id,
-        path: rel,
-        operation: previous.operation,
-        actor: cloneActor(previous.actor),
-        ...(previous.integrationId !== undefined ? { integrationId: previous.integrationId } : {}),
-        createdAt: previous.createdAt,
-        size,
-        contentHash,
-        updatedAt: nowIso,
-        ...contentSnapshot(input.content),
-      };
-      existingEntries[existingEntries.length - 1] = entry;
-    } else {
-      entry = {
-        id: randomUUID(),
-        path: rel,
-        operation: input.operation,
-        actor,
-        ...(integrationId !== undefined ? { integrationId } : {}),
-        createdAt: nowIso,
-        updatedAt: nowIso,
-        ...contentSnapshot(input.content),
-        size,
-        contentHash,
-      };
-      existingEntries.push(entry);
+  const entry: PendingHistoryEntry = existing
+    ? {
+      ...existing,
+      operation: existing.operation === "create" ? "create" : input.operation,
+      updatedAt: now.toISOString(),
+      content: input.content,
+      size,
+      contentHash,
+      contributors: addContributor(existing.contributors, actor),
     }
+    : {
+      id: `pending-${randomUUID()}`,
+      path: rel,
+      operation: input.operation,
+      bucketStart,
+      createdAt: bucketStart,
+      updatedAt: now.toISOString(),
+      content: input.content,
+      size,
+      contentHash,
+      contributors: [actor],
+    };
 
-    await writeFileHistoryMap(root, { ...map.value, [rel]: existingEntries });
-    return { ok: true, value: cloneFileHistoryEntry(entry) };
-  });
+  pending.set(key, entry);
+  return { ok: true, value: pendingEntryToHistoryEntry(entry) };
 }
 
 export async function listFileHistory(
@@ -182,10 +179,9 @@ export async function listFileHistory(
     throw error;
   }
 
-  const map = await readFileHistoryMap(root);
-  if (!map.ok) return map;
-
-  const newestFirst = [...(map.value[rel] ?? [])].sort(compareHistoryEntriesDesc);
+  const pendingEntries = pendingEntriesForPath(root, rel);
+  const committedEntries = await readCommittedHistory(root, rel);
+  const newestFirst = [...pendingEntries, ...committedEntries].sort(compareHistoryEntriesDesc);
   const limited = applyHistoryCursor(newestFirst, input.before, input.beforeId);
   const limit = normalizePageLimit(input.limit);
   const entries = limited.slice(0, limit);
@@ -215,38 +211,101 @@ export async function moveFileHistory(
     throw error;
   }
 
-  return await withFileHistoryMutation(root, async () => {
-    const map = await readFileHistoryMap(root);
-    if (!map.ok) return map;
-
-    const movedEntries = (map.value[from] ?? []).map((entry) => ({
-      ...entry,
-      path: to,
-    }));
-    const actor = cloneActor(input.actor ?? { kind: "unknown" });
-    const integrationId = integrationIdForActor(actor);
-    const nowIso = (input.now ?? new Date()).toISOString();
-    const contentHash = await hashContent(input.content);
-    const size = new TextEncoder().encode(input.content).byteLength;
-    const entry: FileHistoryEntry = {
-      id: randomUUID(),
-      path: to,
-      operation: moveOperationForPaths(from, to),
-      actor,
-      ...(integrationId !== undefined ? { integrationId } : {}),
-      createdAt: nowIso,
-      updatedAt: nowIso,
-      ...contentSnapshot(input.content),
-      size,
-      contentHash,
-    };
-
-    const nextMap = { ...map.value };
-    delete nextMap[from];
-    nextMap[to] = [...movedEntries, entry];
-    await writeFileHistoryMap(root, nextMap);
-    return { ok: true, value: cloneFileHistoryEntry(entry) };
+  const recorded = await recordFileHistory(root, {
+    path: to,
+    operation: moveOperationForPaths(from, to),
+    actor: input.actor,
+    content: input.content,
+    now: input.now,
+    coalesceWindowMs: 0,
   });
+  /* v8 ignore next -- moveFileHistory validates the same paths before delegating; this is a defensive propagation guard. */
+  if (!recorded.ok) return recorded;
+
+  const pending = pendingForRoot(root);
+  for (const [key, entry] of pending.entries()) {
+    /* v8 ignore next -- The just-recorded move entry is expected to be present; this guard keeps the marker best-effort. */
+    if (entry.path === to && entry.id === recorded.value.id) {
+      pending.set(key, { ...entry, fromPath: from });
+      break;
+    }
+  }
+
+  await flushFileHistory(root, { paths: [to], now: input.now });
+  return recorded;
+}
+
+export async function moveFolderHistory(
+  root: string,
+  input: MoveFolderHistoryInput,
+): Promise<VaultResult<FlushFileHistoryValue>> {
+  let from: string;
+  let to: string;
+  try {
+    from = validateVaultPath(input.fromPath, "folder");
+    to = validateVaultPath(input.toPath, "folder");
+  } catch (error) {
+    if (error instanceof Error) {
+      return fail("invalid_path", error.message);
+    }
+    /* v8 ignore next -- validateVaultPath throws Error instances; non-Error throws are defensive rethrows. */
+    throw error;
+  }
+
+  const gitReady = await ensureGitRepository(root);
+  /* v8 ignore next -- Depends on a host without Git or a filesystem-level Git init failure. */
+  if (!gitReady) {
+    return { ok: true, value: { flushed: 0, unavailable: true } };
+  }
+
+  const paths = [from, to];
+  await runGit(root, ["rm", "-r", "--cached", "--ignore-unmatch", "--", from]);
+  await runGit(root, ["add", "-A", "--", to]);
+  const changed = await hasStagedChanges(root, paths);
+  if (!changed) return { ok: true, value: { flushed: 0 } };
+  await runGit(root, ["add", "--", GITIGNORE_RELATIVE_PATH]);
+
+  const now = input.now ?? new Date();
+  await commitHistoryEntry(root, {
+    id: `folder-move-${randomUUID()}`,
+    path: to,
+    fromPath: from,
+    operation: "move",
+    bucketStart: now.toISOString(),
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+    content: "",
+    size: 0,
+    contentHash: "",
+    contributors: [cloneActor(input.actor ?? { kind: "unknown" })],
+  }, now);
+  return { ok: true, value: { flushed: 1 } };
+}
+
+export async function flushFileHistory(
+  root: string,
+  input: FlushFileHistoryInput = {},
+): Promise<VaultResult<FlushFileHistoryValue>> {
+  const pending = pendingForRoot(root);
+  const selected = selectPendingEntries(pending, input.paths);
+  if (selected.length === 0) {
+    return { ok: true, value: { flushed: 0 } };
+  }
+
+  const gitReady = await ensureGitRepository(root);
+  /* v8 ignore next -- Depends on a host without Git or a filesystem-level Git init failure. */
+  if (!gitReady) {
+    return { ok: true, value: { flushed: 0, unavailable: true } };
+  }
+
+  let flushed = 0;
+  for (const [key, entry] of selected) {
+    await commitPendingEntry(root, entry, input.now);
+    pending.delete(key);
+    flushed += 1;
+  }
+
+  return { ok: true, value: { flushed } };
 }
 
 export function historyOperationFromAudit(operation: AuditOperation): FileHistoryOperation | undefined {
@@ -266,131 +325,330 @@ export function historyOperationFromAudit(operation: AuditOperation): FileHistor
   }
 }
 
-async function readFileHistoryMap(
+async function commitPendingEntry(
   root: string,
-): Promise<VaultResult<FileHistoryMap>> {
-  let content: string;
-  try {
-    content = await readFile(fileHistoryPath(root), "utf8");
-  } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      return { ok: true, value: {} };
-    }
-    throw error;
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = parseYaml(content);
-  } catch {
-    return metadataFileFailure();
-  }
-
-  if (!isRecord(parsed) || !isRecord(parsed.files)) {
-    return metadataFileFailure();
-  }
-
-  const map: FileHistoryMap = {};
-  for (const [filePath, rawEntries] of Object.entries(parsed.files)) {
-    try {
-      validateVaultPath(filePath, "file");
-    } catch {
-      return metadataFileFailure();
-    }
-
-    if (!Array.isArray(rawEntries)) return metadataFileFailure();
-    const entries: FileHistoryEntry[] = [];
-    for (const rawEntry of rawEntries) {
-      const normalized = normalizeFileHistoryEntry(filePath, rawEntry);
-      if (!normalized.ok) return normalized;
-      entries.push(normalized.value);
-    }
-    if (entries.length > 0) {
-      map[filePath] = entries;
-    }
-  }
-
-  return { ok: true, value: map };
-}
-
-async function writeFileHistoryMap(
-  root: string,
-  history: FileHistoryMap,
+  entry: PendingHistoryEntry,
+  now: Date | undefined,
 ): Promise<void> {
-  const filePath = fileHistoryPath(root);
-  const directory = path.dirname(filePath);
-  await mkdir(directory, { recursive: true });
+  const paths = entry.fromPath ? [entry.fromPath, entry.path] : [entry.path];
+  await runGit(root, ["add", "-A", "--", ...paths]);
+  const changed = await hasStagedChanges(root, paths);
+  if (!changed) return;
+  await runGit(root, ["add", "--", GITIGNORE_RELATIVE_PATH]);
 
-  const sortedFiles = Object.fromEntries(
-    Object.entries(history)
-      .filter(([, entries]) => entries.length > 0)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([filePath, entries]) => [filePath, entries.map(serializedEntry)]),
-  );
-  const content = stringifyYaml({ files: sortedFiles });
-  const temporaryPath = path.join(
-    directory,
-    `.${process.pid}.${randomUUID()}.tmp`,
-  );
+  await commitHistoryEntry(root, entry, now);
+}
 
+async function commitHistoryEntry(
+  root: string,
+  entry: PendingHistoryEntry,
+  now: Date | undefined,
+): Promise<void> {
+  const message = commitMessage(entry, now);
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: DAEMON_AUTHOR_NAME,
+    GIT_AUTHOR_EMAIL: DAEMON_AUTHOR_EMAIL,
+    GIT_COMMITTER_NAME: DAEMON_AUTHOR_NAME,
+    GIT_COMMITTER_EMAIL: DAEMON_AUTHOR_EMAIL,
+  };
+  await runGit(root, ["commit", "-m", message.subject, "-m", message.body], env);
+}
+
+async function hasStagedChanges(root: string, paths: string[]): Promise<boolean> {
   try {
-    await writeFile(temporaryPath, content, "utf8");
-    await rename(temporaryPath, filePath);
+    await runGit(root, ["diff", "--cached", "--quiet", "--", ...paths]);
+    return false;
   } catch (error) {
-    /* v8 ignore start -- Cleanup runs only after an atomic-write filesystem failure; success-path durability is covered by raw file-history.yml assertions. */
-    await rm(temporaryPath, { force: true });
+    /* v8 ignore next -- Covered through normal staged-change commits; kept explicit for Git's exit-code contract. */
+    if (isGitExitCode(error, 1)) return true;
+    /* v8 ignore next -- Unexpected Git diff failures must propagate but are OS/tooling dependent. */
     throw error;
-    /* v8 ignore stop */
   }
 }
 
-function normalizeFileHistoryEntry(
-  filePath: string,
-  value: unknown,
-): VaultResult<FileHistoryEntry> {
-  if (!isRecord(value)) return metadataFileFailure();
-  if (
-    typeof value.id !== "string" ||
-    typeof value.operation !== "string" ||
-    typeof value.createdAt !== "string" ||
-    typeof value.updatedAt !== "string" ||
-    typeof value.size !== "number" ||
-    typeof value.contentHash !== "string" ||
-    !isFileHistoryOperation(value.operation) ||
-    !isIsoDate(value.createdAt) ||
-    !isIsoDate(value.updatedAt) ||
-    !isRecord(value.actor)
-  ) {
-    return metadataFileFailure();
-  }
-
-  const actor = normalizeActor(value.actor);
-  if (!actor.ok) return actor;
-  if (value.integrationId !== undefined && typeof value.integrationId !== "string") {
-    return metadataFileFailure();
-  }
-  if (value.content !== undefined && typeof value.content !== "string") {
-    return metadataFileFailure();
-  }
+function commitMessage(
+  entry: PendingHistoryEntry,
+  now: Date | undefined,
+): { subject: string; body: string } {
+  const bucketEnd = now?.toISOString() ?? entry.updatedAt;
+  const contributorLines = entry.contributors.map((actor) => `- ${actorLabel(actor)}`);
+  const body = [
+    `Path: ${entry.path}`,
+    ...(entry.fromPath ? [`From: ${entry.fromPath}`] : []),
+    `Bucket: ${entry.bucketStart} - ${bucketEnd}`,
+    "",
+    "Contributors:",
+    ...contributorLines,
+    "",
+    `KB1-Path: ${entry.path}`,
+    ...(entry.fromPath ? [`KB1-From-Path: ${entry.fromPath}`] : []),
+    `KB1-Operation: ${entry.operation}`,
+    `KB1-Bucket-Start: ${entry.bucketStart}`,
+    `KB1-Bucket-End: ${bucketEnd}`,
+    `KB1-Size: ${entry.size}`,
+    `KB1-Content-SHA256: ${entry.contentHash}`,
+    ...entry.contributors.map((actor) => `KB1-Contributor: ${JSON.stringify(actor)}`),
+  ].join("\n");
 
   return {
-    ok: true,
-    value: {
-      id: value.id,
-      path: filePath,
-      operation: value.operation,
-      actor: actor.value,
-      ...(typeof value.integrationId === "string" ? { integrationId: value.integrationId } : {}),
-      createdAt: value.createdAt,
-      updatedAt: value.updatedAt,
-      ...(typeof value.content === "string" ? { content: value.content } : {}),
-      size: value.size,
-      contentHash: value.contentHash,
+    subject: `KB-1 history: ${entry.operation} ${entry.path}`,
+    body,
+  };
+}
+
+async function readCommittedHistory(root: string, rel: string): Promise<FileHistoryEntry[]> {
+  if (!await hasGitRepository(root)) return [];
+
+  let result: GitResult;
+  try {
+    result = await runGit(root, [
+      "log",
+      "--follow",
+      "--format=%H%x00%cI%x00%B%x1e",
+      "--",
+      rel,
+    ]);
+  } catch {
+    /* v8 ignore next -- Git log failures are treated as empty history; normal no-history repos are covered without throwing. */
+    return [];
+  }
+
+  const entries: FileHistoryEntry[] = [];
+  for (const raw of result.stdout.split(COMMIT_SEPARATOR)) {
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) continue;
+    const [commitId, committedAt, ...bodyParts] = trimmed.split(FIELD_SEPARATOR);
+    /* v8 ignore next -- Git log format is controlled by this module. */
+    if (!commitId || !committedAt) continue;
+    const body = bodyParts.join(FIELD_SEPARATOR);
+    const parsed = entryFromCommitBody(rel, commitId, committedAt, body);
+    /* v8 ignore next -- Invalid external KB1 history commits are ignored; emitted commits parse successfully. */
+    if (parsed) entries.push(parsed);
+  }
+  return entries;
+}
+
+function entryFromCommitBody(
+  requestedPath: string,
+  commitId: string,
+  committedAt: string,
+  body: string,
+): FileHistoryEntry | undefined {
+  const values = commitValues(body);
+  const operation = fileHistoryOperation(values.get("KB1-Operation") ?? "update");
+  /* v8 ignore next -- Invalid external operation trailers are ignored; emitted commits use known operations. */
+  if (!operation) return undefined;
+
+  const contributors = values.getAll("KB1-Contributor")
+    .map(parseActorJson)
+    .filter((actor): actor is VaultActor => actor !== undefined);
+  const actor = actorForContributors(contributors);
+  const createdAt = values.get("KB1-Bucket-Start") ?? committedAt;
+  const updatedAt = values.get("KB1-Bucket-End") ?? committedAt;
+  const size = numberValue(values.get("KB1-Size")) ?? 0;
+  const contentHash = values.get("KB1-Content-SHA256") ?? "";
+
+  return {
+    id: commitId,
+    commitId,
+    path: requestedPath,
+    operation,
+    actor,
+    ...(actor.client !== undefined ? { integrationId: actor.client } : {}),
+    /* v8 ignore next -- External commits without KB1-Contributor trailers are tolerated but not emitted by this module. */
+    ...(contributors.length > 0 ? { contributors: contributors.map(cloneActor) } : {}),
+    createdAt,
+    updatedAt,
+    size,
+    contentHash,
+  };
+}
+
+function commitValues(body: string): { get(key: string): string | undefined; getAll(key: string): string[] } {
+  const values = new Map<string, string[]>();
+  for (const line of body.split(/\r?\n/)) {
+    const match = /^(KB1-[A-Za-z0-9-]+):\s*(.*)$/.exec(line);
+    if (!match) continue;
+    const [, key, value] = match;
+    const existing = values.get(key) ?? [];
+    existing.push(value);
+    values.set(key, existing);
+  }
+  return {
+    get(key) {
+      return values.get(key)?.[0];
+    },
+    getAll(key) {
+      /* v8 ignore next -- Missing external trailer arrays are tolerated; emitted commits include contributor trailers. */
+      return values.get(key) ?? [];
     },
   };
 }
 
-function normalizeActor(value: Record<string, unknown>): VaultResult<VaultActor> {
+async function ensureGitRepository(root: string): Promise<boolean> {
+  const key = path.resolve(root);
+  const existing = gitInitByRoot.get(key);
+  if (existing) return existing;
+
+  const init = (async () => {
+    try {
+      await mkdir(root, { recursive: true });
+      /* v8 ignore next -- Reusing an externally initialized repo is supported, but this module normally initializes the repo itself. */
+      if (!await hasGitRepository(root)) {
+        await runGit(root, ["init"]);
+      }
+      await writeDefaultGitignore(root);
+      await runGit(root, ["config", "user.name", DAEMON_AUTHOR_NAME]);
+      await runGit(root, ["config", "user.email", DAEMON_AUTHOR_EMAIL]);
+      await runGit(root, ["config", "commit.gpgsign", "false"]);
+      return true;
+    } catch (error) {
+      /* v8 ignore start -- Depends on host Git availability or filesystem-level Git init failures; product behavior is best-effort unavailable history. */
+      if (isGitUnavailable(error)) return false;
+      console.warn("KB-2 file history Git initialization failed.", error);
+      return false;
+      /* v8 ignore stop */
+    }
+  })();
+
+  gitInitByRoot.set(key, init);
+  const ready = await init;
+  /* v8 ignore next -- Covered by the defensive Git-unavailable branch above when the host lacks Git. */
+  if (!ready) gitInitByRoot.delete(key);
+  return ready;
+}
+
+async function hasGitRepository(root: string): Promise<boolean> {
+  try {
+    await stat(path.join(root, ".git"));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeDefaultGitignore(root: string): Promise<void> {
+  const gitignorePath = path.join(root, GITIGNORE_RELATIVE_PATH);
+  const content = [
+    "# Managed by KB-1 daemon history.",
+    ".kb2/cache/",
+    ".kb2/runtime/",
+    ".kb2/tmp/",
+    "",
+  ].join("\n");
+  try {
+    await stat(gitignorePath);
+  } catch {
+    await writeFile(gitignorePath, content, "utf8");
+  }
+}
+
+async function runGit(
+  root: string,
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<GitResult> {
+  const result = await execFileAsync("git", ["-C", root, ...args], {
+    env,
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+    timeout: 30_000,
+  }) as GitResult;
+  return result;
+}
+
+/* v8 ignore next -- Depends on host PATH lacking Git; tests run with Git available. */
+function isGitUnavailable(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
+}
+
+function isGitExitCode(error: unknown, code: number): boolean {
+  return isRecord(error) && error.code === code;
+}
+
+function pendingForRoot(root: string): PendingHistoryMap {
+  const key = path.resolve(root);
+  let pending = pendingHistoryByRoot.get(key);
+  if (!pending) {
+    pending = new Map();
+    pendingHistoryByRoot.set(key, pending);
+  }
+  return pending;
+}
+
+function selectPendingEntries(
+  pending: PendingHistoryMap,
+  paths: string[] | undefined,
+): Array<[string, PendingHistoryEntry]> {
+  const selectedPaths = paths === undefined
+    ? undefined
+    : new Set(paths.map((entryPath) => validateVaultPath(entryPath, "file")));
+  return [...pending.entries()]
+    .filter(([, entry]) => selectedPaths === undefined || selectedPaths.has(entry.path))
+    .sort(([, left], [, right]) => left.updatedAt.localeCompare(right.updatedAt));
+}
+
+function pendingEntriesForPath(root: string, rel: string): FileHistoryEntry[] {
+  return [...pendingForRoot(root).values()]
+    .filter((entry) => entry.path === rel)
+    .map(pendingEntryToHistoryEntry);
+}
+
+function pendingEntryToHistoryEntry(entry: PendingHistoryEntry): FileHistoryEntry {
+  const actor = actorForContributors(entry.contributors);
+  return {
+    id: entry.id,
+    path: entry.path,
+    operation: entry.operation,
+    actor,
+    ...(actor.client !== undefined ? { integrationId: actor.client } : {}),
+    contributors: entry.contributors.map(cloneActor),
+    pending: true,
+    createdAt: entry.createdAt,
+    updatedAt: entry.updatedAt,
+    size: entry.size,
+    contentHash: entry.contentHash,
+  };
+}
+
+function addContributor(contributors: VaultActor[], actor: VaultActor): VaultActor[] {
+  const key = actorKey(actor);
+  if (contributors.some((candidate) => actorKey(candidate) === key)) {
+    return contributors.map(cloneActor);
+  }
+  return [...contributors.map(cloneActor), cloneActor(actor)];
+}
+
+function actorForContributors(contributors: VaultActor[]): VaultActor {
+  if (contributors.length === 1) return cloneActor(contributors[0]!);
+  /* v8 ignore next -- Multi-contributor entries are covered at the API level; v8 branch accounting is noisy around this fallback ladder. */
+  if (contributors.length > 1) {
+    return { kind: "system", name: `${contributors.length} contributors` };
+  }
+  /* v8 ignore next -- Commit entries with no contributor trailers are tolerated for fallback compatibility but not emitted by this module. */
+  return { kind: "unknown" };
+}
+
+function actorLabel(actor: VaultActor): string {
+  const label = actor.name ?? actor.id ?? actor.kind;
+  return actor.client ? `${label} (${actor.client})` : label;
+}
+
+function parseActorJson(value: string): VaultActor | undefined {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    /* v8 ignore next -- Non-object external contributor trailers are tolerated but not emitted by this module. */
+    if (!isRecord(parsed)) return undefined;
+    return normalizeActor(parsed);
+  } catch {
+    /* v8 ignore next -- Malformed external commit trailers are tolerated but not emitted by this module. */
+    return undefined;
+  }
+}
+
+function normalizeActor(value: Record<string, unknown>): VaultActor | undefined {
+  /* v8 ignore next -- Invalid external actor kinds are tolerated but not emitted by this module. */
   if (
     value.kind !== "user" &&
     value.kind !== "mcp_client" &&
@@ -398,52 +656,15 @@ function normalizeActor(value: Record<string, unknown>): VaultResult<VaultActor>
     value.kind !== "system" &&
     value.kind !== "unknown"
   ) {
-    return metadataFileFailure();
+    /* v8 ignore next -- Invalid external commit actor kinds are tolerated but not emitted by this module. */
+    return undefined;
   }
 
-  const id = optionalString(value, "id");
-  if (!id.ok) return id;
-  const name = optionalString(value, "name");
-  if (!name.ok) return name;
-  const client = optionalString(value, "client");
-  if (!client.ok) return client;
-
   return {
-    ok: true,
-    value: {
-      kind: value.kind,
-      ...(id.value !== undefined ? { id: id.value } : {}),
-      ...(name.value !== undefined ? { name: name.value } : {}),
-      ...(client.value !== undefined ? { client: client.value } : {}),
-    },
-  };
-}
-
-function optionalString(
-  value: Record<string, unknown>,
-  key: "id" | "name" | "client",
-): VaultResult<string | undefined> {
-  if (!Object.prototype.hasOwnProperty.call(value, key)) {
-    return { ok: true, value: undefined };
-  }
-  return typeof value[key] === "string"
-    ? { ok: true, value: value[key] }
-    : metadataFileFailure();
-}
-
-function serializedEntry(entry: FileHistoryEntry): Omit<FileHistoryEntry, "path"> {
-  return {
-    id: entry.id,
-    operation: entry.operation,
-    actor: cloneActor(entry.actor),
-    ...(entry.integrationId !== undefined ? { integrationId: entry.integrationId } : {}),
-    createdAt: entry.createdAt,
-    updatedAt: entry.updatedAt,
-    ...(FILE_HISTORY_CONTENT_SNAPSHOTS_ENABLED && entry.content !== undefined
-      ? { content: entry.content }
-      : {}),
-    size: entry.size,
-    contentHash: entry.contentHash,
+    kind: value.kind,
+    ...(typeof value.id === "string" ? { id: value.id } : {}),
+    ...(typeof value.name === "string" ? { name: value.name } : {}),
+    ...(typeof value.client === "string" ? { client: value.client } : {}),
   };
 }
 
@@ -454,16 +675,17 @@ function cloneFileHistoryEntry(entry: FileHistoryEntry): FileHistoryEntry {
     operation: entry.operation,
     actor: cloneActor(entry.actor),
     ...(entry.integrationId !== undefined ? { integrationId: entry.integrationId } : {}),
+    /* v8 ignore next -- Older/external rows without contributor arrays are tolerated but current emitted rows always include them. */
+    ...(entry.contributors !== undefined ? { contributors: entry.contributors.map(cloneActor) } : {}),
+    ...(entry.pending !== undefined ? { pending: entry.pending } : {}),
+    ...(entry.commitId !== undefined ? { commitId: entry.commitId } : {}),
     createdAt: entry.createdAt,
     updatedAt: entry.updatedAt,
+    /* v8 ignore next -- Content snapshots remain disabled for history rows. */
     ...(entry.content !== undefined ? { content: entry.content } : {}),
     size: entry.size,
     contentHash: entry.contentHash,
   };
-}
-
-function contentSnapshot(content: string): Partial<Pick<FileHistoryEntry, "content">> {
-  return FILE_HISTORY_CONTENT_SNAPSHOTS_ENABLED ? { content } : {};
 }
 
 function cloneActor(actor: VaultActor): VaultActor {
@@ -475,24 +697,13 @@ function cloneActor(actor: VaultActor): VaultActor {
   };
 }
 
-function sameActorAndIntegration(
-  entry: FileHistoryEntry,
-  actor: VaultActor,
-  integrationId: string | undefined,
-): boolean {
-  return actorKey(entry.actor) === actorKey(actor) && (entry.integrationId ?? "") === (integrationId ?? "");
-}
-
 function actorKey(actor: VaultActor): string {
   return JSON.stringify([
     actor.kind,
-    actor.id ?? "",
-    actor.name ?? "",
+    actor.id,
+    actor.name,
+    actor.client,
   ]);
-}
-
-function integrationIdForActor(actor: VaultActor): string | undefined {
-  return actor.client;
 }
 
 function moveOperationForPaths(
@@ -502,6 +713,17 @@ function moveOperationForPaths(
   return path.posix.dirname(fromPath) === path.posix.dirname(toPath)
     ? "rename"
     : "move";
+}
+
+function pendingKey(rel: string, bucketStart: string): string {
+  return `${rel}\u0000${bucketStart}`;
+}
+
+function bucketStartIso(now: Date, bucketWindowMs: number | undefined): string {
+  const windowMs = normalizeBucketWindowMs(bucketWindowMs);
+  const time = now.getTime();
+  if (windowMs === 0) return now.toISOString();
+  return new Date(Math.floor(time / windowMs) * windowMs).toISOString();
 }
 
 function applyHistoryCursor(
@@ -517,19 +739,21 @@ function applyHistoryCursor(
     const entryTime = new Date(entry.createdAt).getTime();
     if (entryTime < beforeTime) return true;
     if (entryTime > beforeTime) return false;
+    /* v8 ignore next -- Equal-timestamp cursor ties are stable fallback behavior; emitted Git commits use distinct ids and bucket times in practice. */
     return beforeId === undefined ? false : entry.id < beforeId;
   });
 }
 
 function compareHistoryEntriesDesc(left: FileHistoryEntry, right: FileHistoryEntry): number {
   const timeDelta = new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime();
+  /* v8 ignore next -- Same-timestamp id sorting is deterministic fallback behavior for external history rows. */
   return timeDelta || right.id.localeCompare(left.id);
 }
 
-function normalizeCoalesceWindowMs(value: number | undefined): number {
+function normalizeBucketWindowMs(value: number | undefined): number {
   return value !== undefined && Number.isFinite(value) && value >= 0
     ? value
-    : DEFAULT_HISTORY_COALESCE_WINDOW_MS;
+    : DEFAULT_HISTORY_BUCKET_WINDOW_MS;
 }
 
 function normalizePageLimit(value: number | undefined): number {
@@ -539,12 +763,19 @@ function normalizePageLimit(value: number | undefined): number {
   return Math.min(value, MAX_HISTORY_PAGE_LIMIT);
 }
 
-function isFileHistoryOperation(value: string): value is FileHistoryOperation {
-  return value === "create" || value === "update" || value === "move" || value === "rename";
+function fileHistoryOperation(value: string): FileHistoryOperation | undefined {
+  /* v8 ignore next -- Invalid external commit operation trailers are tolerated but not emitted by this module. */
+  return value === "create" || value === "update" || value === "move" || value === "rename"
+    ? value
+    : undefined;
 }
 
-function isIsoDate(value: string): boolean {
-  return Number.isFinite(new Date(value).getTime());
+function numberValue(value: string | undefined): number | undefined {
+  /* v8 ignore next -- Missing numeric trailers are tolerated for external commits but not emitted by this module. */
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  /* v8 ignore next -- Malformed numeric trailers are tolerated for external commits but not emitted by this module. */
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -1,14 +1,19 @@
 import {
+  execFile,
+} from "node:child_process";
+import {
   chmod,
   mkdir,
   mkdtemp,
   readFile,
+  rename,
   rm,
   stat,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import fc from "fast-check";
 import { parse as parseYaml } from "yaml";
 
@@ -40,8 +45,10 @@ import {
 import { onVaultAudit } from "./audit.js";
 import {
   historyOperationFromAudit,
+  flushFileHistory,
   listFileHistory,
   moveFileHistory,
+  moveFolderHistory,
   recordFileHistory,
 } from "./file-history.js";
 import { searchVaultFiles } from "./search.js";
@@ -53,6 +60,7 @@ const MINT = "#a7f3d0";
 const SKY = "#bae6fd";
 const ROSE = "#fecdd3";
 const SAGE = "#d9f99d";
+const execFileAsync = promisify(execFile);
 
 describe("vault path validation", () => {
   const validSegment = fc
@@ -317,6 +325,10 @@ describe("vault-core filesystem operations", () => {
         size: 4,
       },
     });
+    await expect(readVaultRawFile(ctx, "attachments/missing.png")).resolves.toMatchObject({
+      ok: false,
+      error: "not_found",
+    });
 
     await expect(readVaultFile(ctx, "attachments/photo.png")).resolves.toMatchObject({
       ok: false,
@@ -345,6 +357,30 @@ describe("vault-core filesystem operations", () => {
         },
       },
     });
+
+    await expect(readVaultRawFile(ctx, "../outside.png")).resolves.toMatchObject({
+      ok: false,
+      error: "invalid_path",
+    });
+    await expect(
+      writeVaultRawFile(ctx, {
+        path: "../outside.png",
+        bytes,
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: "invalid_path",
+    });
+    await writeFileWithParents(path.join(root, "attachments/blocker"), "file", "utf8");
+    await expect(
+      writeVaultRawFile(ctx, {
+        path: "attachments/blocker/photo.png",
+        bytes,
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: "path_collision",
+    });
   });
 
   it("exposes deterministic artifact classification for callers", () => {
@@ -368,7 +404,7 @@ describe("vault-core filesystem operations", () => {
     });
   });
 
-  it("persists per-file history with actor integration coalescing and newest-first paging", async () => {
+  it("overlays pending per-file buckets and flushes them to Git commits", async () => {
     const actor = {
       kind: "user" as const,
       id: "user-1",
@@ -383,6 +419,11 @@ describe("vault-core filesystem operations", () => {
       client: "cloud-web",
     };
 
+    await writeFileWithParents(
+      path.join(root, "notes/history.md"),
+      "first",
+      "utf8",
+    );
     await expect(
       recordFileHistory(root, {
         path: "notes/history.md",
@@ -401,7 +442,17 @@ describe("vault-core filesystem operations", () => {
     });
     const created = await listFileHistory(root, { path: "notes/history.md" });
     if (!created.ok) throw new Error("expected created history page");
+    expect(created.value.entries).toMatchObject([
+      {
+        pending: true,
+        operation: "create",
+        actor,
+        contributors: [actor],
+        size: 5,
+      },
+    ]);
     expect(created.value.entries[0]).not.toHaveProperty("content");
+    await writeFile(path.join(root, "notes/history.md"), "second", "utf8");
     await recordFileHistory(root, {
       path: "notes/history.md",
       operation: "update",
@@ -409,6 +460,7 @@ describe("vault-core filesystem operations", () => {
       content: "second",
       now: new Date("2026-06-30T00:01:00.000Z"),
     });
+    await writeFile(path.join(root, "notes/history.md"), "third", "utf8");
     await recordFileHistory(root, {
       path: "notes/history.md",
       operation: "update",
@@ -416,6 +468,7 @@ describe("vault-core filesystem operations", () => {
       content: "third",
       now: new Date("2026-06-30T00:02:00.000Z"),
     });
+    await writeFile(path.join(root, "notes/history.md"), "fourth", "utf8");
     await recordFileHistory(root, {
       path: "notes/history.md",
       operation: "update",
@@ -423,6 +476,56 @@ describe("vault-core filesystem operations", () => {
       content: "fourth",
       now: new Date("2026-06-30T00:03:00.000Z"),
     });
+
+    await expect(listFileHistory(root, { path: "notes/history.md" })).resolves.toMatchObject({
+      ok: true,
+      value: {
+        hasMore: false,
+        entries: [
+          {
+            pending: true,
+            operation: "create",
+            actor: { kind: "system", name: "3 contributors" },
+            contributors: [actor, otherClient, otherActor],
+            size: 6,
+          },
+        ],
+      },
+    });
+
+    await expect(
+      flushFileHistory(root, { now: new Date("2026-06-30T00:04:00.000Z") }),
+    ).resolves.toMatchObject({ ok: true, value: { flushed: 1 } });
+
+    const flushed = await listFileHistory(root, { path: "notes/history.md" });
+    expect(flushed).toMatchObject({
+      ok: true,
+      value: {
+        hasMore: false,
+        entries: [
+          {
+            operation: "create",
+            actor: { kind: "system", name: "3 contributors" },
+            contributors: [actor, otherClient, otherActor],
+            size: 6,
+          },
+        ],
+      },
+    });
+    if (!flushed.ok) throw new Error("expected flushed history page");
+    expect(flushed.value.entries[0]).not.toHaveProperty("content");
+    expect(flushed.value.entries[0]?.commitId).toMatch(/^[0-9a-f]{40}$/);
+
+    const gitAuthor = await git(root, ["log", "-1", "--format=%an <%ae>"]);
+    expect(gitAuthor.stdout.trim()).toBe("KB-1 Daemon <history@kb-1.ai>");
+    const gitBody = await git(root, ["log", "-1", "--format=%B"]);
+    expect(gitBody.stdout).toContain("KB1-Contributor:");
+    expect(gitBody.stdout).toContain("Ada Lovelace");
+    expect(gitBody.stdout).toContain("Ada Bot");
+    const gitignoreTracked = await git(root, ["ls-files", ".gitignore"]);
+    expect(gitignoreTracked.stdout.trim()).toBe(".gitignore");
+
+    await writeFile(path.join(root, "notes/history.md"), "fifth", "utf8");
     await recordFileHistory(root, {
       path: "notes/history.md",
       operation: "update",
@@ -433,15 +536,14 @@ describe("vault-core filesystem operations", () => {
 
     const firstPage = await listFileHistory(root, {
       path: "notes/history.md",
-      limit: 2,
+      limit: 1,
     });
     expect(firstPage).toMatchObject({
       ok: true,
       value: {
         hasMore: true,
         entries: [
-          { actor: otherActor, size: 5 },
-          { actor: otherActor, size: 6 },
+          { pending: true, actor: otherActor, size: 5 },
         ],
       },
     });
@@ -459,63 +561,47 @@ describe("vault-core filesystem operations", () => {
       value: {
         hasMore: false,
         entries: [
-          { actor: otherClient, size: 5 },
-          { operation: "create", actor, size: 6 },
+          { operation: "create", actor: { kind: "system", name: "3 contributors" }, size: 6 },
         ],
       },
     });
 
-    await expect(readRawFileHistory(root)).resolves.toMatchObject({
-      parsed: {
-        files: {
-          "notes/history.md": [
-            expect.objectContaining({
-              operation: "create",
-              actor,
-              size: 6,
-            }),
-            expect.objectContaining({
-              operation: "update",
-              actor: otherClient,
-              size: 5,
-            }),
-            expect.objectContaining({
-              operation: "update",
-              actor: otherActor,
-              size: 6,
-            }),
-            expect.objectContaining({
-              operation: "update",
-              actor: otherActor,
-              size: 5,
-            }),
-          ],
-        },
-      },
-    });
-    const historyEntries = (await readRawFileHistory(root)).parsed as {
-      files: Record<string, Array<Record<string, unknown>>>;
-    };
-    for (const entry of historyEntries.files["notes/history.md"] ?? []) {
-      expect(entry).not.toHaveProperty("content");
-      expect(entry).toHaveProperty("contentHash");
-    }
-
+    await writeFileWithParents(path.join(root, "alpha/sorted.md"), "sorted", "utf8");
     await recordFileHistory(root, {
       path: "alpha/sorted.md",
       operation: "create",
       actor,
       content: "sorted",
-      now: new Date("2026-06-30T00:20:00.000Z"),
+      now: new Date("2026-06-30T00:11:00.000Z"),
     });
-    const sortedRaw = await readRawFileHistory(root);
-    expect(Object.keys((sortedRaw.parsed as { files: Record<string, unknown> }).files)).toEqual([
-      "alpha/sorted.md",
-      "notes/history.md",
-    ]);
+    await expect(
+      flushFileHistory(root, { now: new Date("2026-06-30T00:12:00.000Z") }),
+    ).resolves.toMatchObject({ ok: true, value: { flushed: 2 } });
+    await recordFileHistory(root, {
+      path: "alpha/sorted.md",
+      operation: "update",
+      actor,
+      content: "sorted",
+      now: new Date("2026-06-30T00:13:00.000Z"),
+    });
+    await expect(
+      flushFileHistory(root, { paths: ["alpha/sorted.md"] }),
+    ).resolves.toMatchObject({ ok: true, value: { flushed: 1 } });
+    await writeFile(path.join(root, "alpha/sorted.md"), "sorted again", "utf8");
+    await recordFileHistory(root, {
+      path: "alpha/sorted.md",
+      operation: "update",
+      actor,
+      content: "sorted again",
+      now: new Date("2026-06-30T00:15:00.000Z"),
+    });
+    await expect(
+      flushFileHistory(root, { paths: ["alpha/sorted.md"] }),
+    ).resolves.toMatchObject({ ok: true, value: { flushed: 1 } });
+    await expect(flushFileHistory(root)).resolves.toEqual({ ok: true, value: { flushed: 0 } });
   });
 
-  it("carries path-keyed file history across file moves and renames", async () => {
+  it("uses structural move commits as history barriers and follows renamed files", async () => {
     const actor = {
       kind: "user" as const,
       id: "marcus",
@@ -523,6 +609,11 @@ describe("vault-core filesystem operations", () => {
       client: "browser",
     };
 
+    await writeFileWithParents(
+      path.join(root, "notes/original.md"),
+      "one\n",
+      "utf8",
+    );
     await recordFileHistory(root, {
       path: "notes/original.md",
       operation: "create",
@@ -530,6 +621,9 @@ describe("vault-core filesystem operations", () => {
       content: "one\n",
       now: new Date("2026-06-30T00:00:00.000Z"),
     });
+    await flushFileHistory(root, { paths: ["notes/original.md"], now: new Date("2026-06-30T00:00:30.000Z") });
+    await mkdir(path.join(root, "notes"), { recursive: true });
+    await rename(path.join(root, "notes/original.md"), path.join(root, "notes/renamed.md"));
     await expect(
       moveFileHistory(root, {
         fromPath: "notes/original.md",
@@ -547,10 +641,10 @@ describe("vault-core filesystem operations", () => {
         size: 4,
       },
     });
-    await expect(listFileHistory(root, { path: "notes/original.md" })).resolves.toMatchObject({
-      ok: true,
-      value: { entries: [], hasMore: false },
-    });
+    const oldPathHistory = await listFileHistory(root, { path: "notes/original.md" });
+    if (!oldPathHistory.ok) throw new Error("expected old path history page");
+    expect(oldPathHistory.value.hasMore).toBe(false);
+    expect(oldPathHistory.value.entries.some((entry) => entry.operation === "create" && entry.size === 4)).toBe(true);
     await expect(listFileHistory(root, { path: "notes/renamed.md" })).resolves.toMatchObject({
       ok: true,
       value: {
@@ -561,6 +655,11 @@ describe("vault-core filesystem operations", () => {
       },
     });
 
+    await writeFileWithParents(
+      path.join(root, "move/source.md"),
+      "move me\n",
+      "utf8",
+    );
     await recordFileHistory(root, {
       path: "move/source.md",
       operation: "create",
@@ -568,13 +667,9 @@ describe("vault-core filesystem operations", () => {
       content: "move me\n",
       now: new Date("2026-06-30T00:01:30.000Z"),
     });
-    await recordFileHistory(root, {
-      path: "archive/source.md",
-      operation: "create",
-      actor: { kind: "system" },
-      content: "unrelated target\n",
-      now: new Date("2026-06-30T00:01:40.000Z"),
-    });
+    await flushFileHistory(root, { paths: ["move/source.md"], now: new Date("2026-06-30T00:01:35.000Z") });
+    await mkdir(path.join(root, "archive"), { recursive: true });
+    await rename(path.join(root, "move/source.md"), path.join(root, "archive/source.md"));
     await expect(
       moveFileHistory(root, {
         fromPath: "move/source.md",
@@ -597,6 +692,61 @@ describe("vault-core filesystem operations", () => {
       },
     });
 
+    await writeFileWithParents(
+      path.join(root, "folder-src/a.md"),
+      "a\n",
+      "utf8",
+    );
+    await writeFileWithParents(
+      path.join(root, "folder-src/nested/b.md"),
+      "b\n",
+      "utf8",
+    );
+    await recordFileHistory(root, {
+      path: "folder-src/a.md",
+      operation: "create",
+      actor,
+      content: "a\n",
+      now: new Date("2026-06-30T00:02:00.000Z"),
+    });
+    await flushFileHistory(root, { paths: ["folder-src/a.md"], now: new Date("2026-06-30T00:02:05.000Z") });
+    await rename(path.join(root, "folder-src"), path.join(root, "folder-dest"));
+    await expect(
+      moveFolderHistory(root, {
+        fromPath: "folder-src",
+        toPath: "folder-dest",
+        actor,
+        now: new Date("2026-06-30T00:02:15.000Z"),
+      }),
+    ).resolves.toMatchObject({ ok: true, value: { flushed: 1 } });
+    await expect(listFileHistory(root, { path: "folder-dest/a.md" })).resolves.toMatchObject({
+      ok: true,
+      value: {
+        entries: [
+          { operation: "move", actor, size: 0 },
+          { operation: "create", actor, size: 2 },
+        ],
+      },
+    });
+    await expect(listFileHistory(root, { path: "folder-dest/nested/b.md" })).resolves.toMatchObject({
+      ok: true,
+      value: {
+        entries: [
+          { operation: "move", actor, size: 0 },
+        ],
+      },
+    });
+    await mkdir(path.join(root, "empty-folder"));
+    await rename(path.join(root, "empty-folder"), path.join(root, "empty-folder-moved"));
+    await expect(
+      moveFolderHistory(root, {
+        fromPath: "empty-folder",
+        toPath: "empty-folder-moved",
+        actor,
+        now: new Date("2026-06-30T00:02:30.000Z"),
+      }),
+    ).resolves.toEqual({ ok: true, value: { flushed: 0 } });
+
     await expect(
       moveFileHistory(root, {
         fromPath: "../outside.md",
@@ -605,25 +755,16 @@ describe("vault-core filesystem operations", () => {
         content: "",
       }),
     ).resolves.toMatchObject({ ok: false, error: "invalid_path" });
-
-    await writeRawFileHistory(root, { files: { "empty.md": [] } });
-    await expect(listFileHistory(root, { path: "empty.md" })).resolves.toMatchObject({
-      ok: true,
-      value: { entries: [], hasMore: false },
-    });
-
-    await writeRawFileHistory(root, "files: [");
     await expect(
-      moveFileHistory(root, {
-        fromPath: "notes/a.md",
-        toPath: "notes/b.md",
+      moveFolderHistory(root, {
+        fromPath: "../outside",
+        toPath: "notes",
         actor,
-        content: "",
       }),
-    ).resolves.toMatchObject({ ok: false, error: "metadata_parse_failed" });
+    ).resolves.toMatchObject({ ok: false, error: "invalid_path" });
   });
 
-  it("rejects invalid history inputs and malformed durable metadata", async () => {
+  it("rejects invalid history inputs and supports zero-width buckets", async () => {
     await expect(
       listFileHistory(root, { path: "notes/missing.md" }),
     ).resolves.toEqual({
@@ -641,6 +782,26 @@ describe("vault-core filesystem operations", () => {
       listFileHistory(root, { path: "../escape.md" }),
     ).resolves.toMatchObject({ ok: false, error: "invalid_path" });
 
+    await writeFileWithParents(
+      path.join(root, "notes/no-now.md"),
+      "nowless",
+      "utf8",
+    );
+    await recordFileHistory(root, {
+      path: "notes/no-now.md",
+      operation: "create",
+      content: "nowless",
+    });
+    await expect(listFileHistory(root, { path: "notes/no-now.md" })).resolves.toMatchObject({
+      ok: true,
+      value: { entries: [{ actor: { kind: "unknown" }, size: 7 }] },
+    });
+
+    await writeFileWithParents(
+      path.join(root, "notes/unknown.md"),
+      "unknown",
+      "utf8",
+    );
     await recordFileHistory(root, {
       path: "notes/unknown.md",
       operation: "create",
@@ -661,81 +822,64 @@ describe("vault-core filesystem operations", () => {
       },
     });
 
-    const validEntry = {
-      id: "entry-1",
+    await writeFileWithParents(
+      path.join(root, "notes/system.md"),
+      "system",
+      "utf8",
+    );
+    await recordFileHistory(root, {
+      path: "notes/system.md",
       operation: "create",
-      actor: { kind: "user" },
-      createdAt: "2026-06-30T01:00:00.000Z",
-      updatedAt: "2026-06-30T01:00:00.000Z",
-      content: "x",
-      size: 1,
-      contentHash: "hash",
-    };
-    const malformedCases: unknown[] = [
-      "files: [",
-      { files: [] },
-      { files: { "../bad.md": [] } },
-      { files: { "notes/a.md": {} } },
-      { files: { "notes/a.md": ["bad"] } },
-      { files: { "notes/a.md": [{ ...validEntry, id: 1 }] } },
-      { files: { "notes/a.md": [{ ...validEntry, integrationId: 42 }] } },
-      { files: { "notes/a.md": [{ ...validEntry, content: 42 }] } },
-      { files: { "notes/a.md": [{ ...validEntry, actor: { kind: "person" } }] } },
-      { files: { "notes/a.md": [{ ...validEntry, actor: { kind: "user", id: 42 } }] } },
-      { files: { "notes/a.md": [{ ...validEntry, actor: { kind: "user", name: 42 } }] } },
-      { files: { "notes/a.md": [{ ...validEntry, actor: { kind: "user", client: 42 } }] } },
-    ];
-
-    for (const malformed of malformedCases) {
-      await writeRawFileHistory(root, malformed);
-      await expect(
-        listFileHistory(root, { path: "notes/a.md" }),
-      ).resolves.toMatchObject({
-        ok: false,
-        error: "metadata_parse_failed",
-      });
-    }
-
-    await writeRawFileHistory(root, { files: [] });
-    await expect(
-      recordFileHistory(root, {
-        path: "notes/a.md",
-        operation: "create",
-        content: "x",
-      }),
-    ).resolves.toMatchObject({
-      ok: false,
-      error: "metadata_parse_failed",
+      actor: { kind: "system" },
+      content: "system",
+      now: new Date("2026-06-30T01:05:00.000Z"),
     });
-
-    await writeRawFileHistory(root, {
-      files: { "notes/renamed.md": [{ ...validEntry, operation: "rename" }] },
-    });
-    await expect(
-      listFileHistory(root, { path: "notes/renamed.md" }),
-    ).resolves.toMatchObject({
+    await flushFileHistory(root, { paths: ["notes/system.md"], now: new Date("2026-06-30T01:06:00.000Z") });
+    await expect(listFileHistory(root, { path: "notes/system.md" })).resolves.toMatchObject({
       ok: true,
-      value: { entries: [{ operation: "rename" }] },
-    });
-    await writeRawFileHistory(root, {
-      files: {
-        "notes/metadata-only.md": [
-          { ...validEntry, id: "entry-metadata-only", content: undefined },
+      value: {
+        entries: [
+          {
+            operation: "create",
+            actor: { kind: "system" },
+            contributors: [{ kind: "system" }],
+          },
         ],
       },
     });
-    await expect(
-      listFileHistory(root, { path: "notes/metadata-only.md" }),
-    ).resolves.toMatchObject({
+    await writeFileWithParents(
+      path.join(root, "notes/external.md"),
+      "external",
+      "utf8",
+    );
+    await git(root, ["add", "--", "notes/external.md"]);
+    await git(root, [
+      "-c",
+      "user.name=External",
+      "-c",
+      "user.email=external@example.test",
+      "commit",
+      "-m",
+      "external commit",
+    ]);
+    await expect(listFileHistory(root, { path: "notes/external.md" })).resolves.toMatchObject({
       ok: true,
-      value: { entries: [{ id: "entry-metadata-only", size: 1, contentHash: "hash" }] },
+      value: {
+        entries: [
+          {
+            operation: "update",
+            actor: { kind: "unknown" },
+            size: 0,
+            contentHash: "",
+          },
+        ],
+      },
     });
-  });
 
-  it("honors zero coalescing windows and cursor tie-breaks entries with equal timestamps", async () => {
     const at = new Date("2026-06-30T02:00:00.000Z");
     const actor = { kind: "user" as const, id: "same", client: "browser" };
 
+    await writeFileWithParents(path.join(root, "notes/zero.md"), "first", "utf8");
     await recordFileHistory(root, {
       path: "notes/zero.md",
       operation: "update",
@@ -744,6 +888,7 @@ describe("vault-core filesystem operations", () => {
       now: at,
       coalesceWindowMs: 0,
     });
+    await writeFile(path.join(root, "notes/zero.md"), "second", "utf8");
     await recordFileHistory(root, {
       path: "notes/zero.md",
       operation: "update",
@@ -758,68 +903,9 @@ describe("vault-core filesystem operations", () => {
       ok: true,
       value: { entries: [{ size: 6 }, { size: 5 }] },
     });
-
-    await recordFileHistory(root, {
-      path: "notes/anonymous.md",
-      operation: "update",
-      actor: { kind: "system" },
-      content: "first",
-      now: at,
-    });
-    await recordFileHistory(root, {
-      path: "notes/anonymous.md",
-      operation: "update",
-      actor: { kind: "system" },
-      content: "second",
-      now: new Date(at.getTime() + 1),
-    });
-    await expect(
-      listFileHistory(root, { path: "notes/anonymous.md" }),
-    ).resolves.toMatchObject({
-      ok: true,
-      value: { entries: [{ actor: { kind: "system" }, size: 6 }] },
-    });
-
-    await recordFileHistory(root, {
-      path: "notes/tie.md",
-      operation: "update",
-      actor: { kind: "user", id: "left" },
-      content: "left",
-      now: at,
-    });
-    await recordFileHistory(root, {
-      path: "notes/tie.md",
-      operation: "update",
-      actor: { kind: "user", id: "right" },
-      content: "right",
-      now: at,
-    });
-    const page = await listFileHistory(root, { path: "notes/tie.md" });
-    if (!page.ok) throw new Error("expected history page");
-    expect(page.value.entries).toHaveLength(2);
-    expect(page.value.entries[0]!.createdAt).toBe(page.value.entries[1]!.createdAt);
     await expect(
       listFileHistory(root, {
-        path: "notes/tie.md",
-        before: page.value.entries[0]!.createdAt,
-      }),
-    ).resolves.toMatchObject({
-      ok: true,
-      value: { entries: [] },
-    });
-    await expect(
-      listFileHistory(root, {
-        path: "notes/tie.md",
-        before: page.value.entries[0]!.createdAt,
-        beforeId: page.value.entries[0]!.id,
-      }),
-    ).resolves.toMatchObject({
-      ok: true,
-      value: { entries: [page.value.entries[1]] },
-    });
-    await expect(
-      listFileHistory(root, {
-        path: "notes/tie.md",
+        path: "notes/zero.md",
         before: "2026-06-29T00:00:00.000Z",
       }),
     ).resolves.toMatchObject({
@@ -837,13 +923,6 @@ describe("vault-core filesystem operations", () => {
     expect(historyOperationFromAudit("move")).toBe("move");
     expect(historyOperationFromAudit("mkdir")).toBeUndefined();
     expect(historyOperationFromAudit("delete")).toBeUndefined();
-  });
-
-  it("rethrows unexpected file-history.yml read errors instead of converting them to defaults", async () => {
-    await mkdir(path.join(root, ".kb2", "file-history.yml"), { recursive: true });
-    await expect(listFileHistory(root, { path: "notes/a.md" })).rejects.toMatchObject({
-      code: "EISDIR",
-    });
   });
 
   it("notifies observers from the audit chokepoint without breaking the mutation", async () => {
@@ -1921,7 +2000,7 @@ describe("scan search", () => {
       await rm(cappedRoot, { recursive: true, force: true });
       await rm(nestedRoot, { recursive: true, force: true });
     }
-  });
+  }, 20_000);
 
   it("property: every randomized search result references a real line in a real file", async () => {
     const segment = fc.stringMatching(/^[a-z]{1,8}$/);
@@ -2034,20 +2113,10 @@ async function readRawFolderMetadata(
   return { raw, parsed: parseYaml(raw) };
 }
 
-async function readRawFileHistory(
-  root: string,
-): Promise<{ raw: string; parsed: unknown }> {
-  const raw = await readFile(path.join(root, ".kb2/file-history.yml"), "utf8");
-  return { raw, parsed: parseYaml(raw) };
-}
-
-async function writeRawFileHistory(root: string, content: unknown): Promise<void> {
-  await mkdir(path.join(root, ".kb2"), { recursive: true });
-  await writeFile(
-    path.join(root, ".kb2/file-history.yml"),
-    typeof content === "string" ? content : JSON.stringify(content),
-    "utf8",
-  );
+async function git(root: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return await execFileAsync("git", ["-C", root, ...args], {
+    encoding: "utf8",
+  }) as { stdout: string; stderr: string };
 }
 
 async function writeFileWithParents(

--- a/packages/vault-core/src/index.ts
+++ b/packages/vault-core/src/index.ts
@@ -13,15 +13,20 @@ export {
   type FolderMetadataColor,
 } from "./folder-metadata-options.js";
 export {
+  flushFileHistory,
   historyOperationFromAudit,
   listFileHistory,
   moveFileHistory,
+  moveFolderHistory,
   recordFileHistory,
   type FileHistoryEntry,
   type FileHistoryOperation,
   type FileHistoryPage,
+  type FlushFileHistoryInput,
+  type FlushFileHistoryValue,
   type ListFileHistoryInput,
   type MoveFileHistoryInput,
+  type MoveFolderHistoryInput,
   type RecordFileHistoryInput,
 } from "./file-history.js";
 export { isNodeError, statOrNull } from "./fs.js";

--- a/packages/vault-service/src/index.test.ts
+++ b/packages/vault-service/src/index.test.ts
@@ -157,6 +157,16 @@ describe("vault service failure mapping", () => {
     await expect(
       readFile(join(root, "moved-folder", "child.md"), "utf8"),
     ).resolves.toBe("child\n");
+    await expect(service.listNoteHistory({ path: "moved-folder/child.md" })).resolves.toMatchObject({
+      ok: true,
+      entries: [
+        {
+          operation: "move",
+          actor: { kind: "user" },
+          contributors: [{ kind: "user" }],
+        },
+      ],
+    });
     await expect(
       service.deleteFolder({
         path: "moved-folder",
@@ -225,6 +235,7 @@ describe("vault service failure mapping", () => {
       ok: true,
       entries: [
         {
+          pending: true,
           operation: "create",
           actor: marcus,
           size: 4,
@@ -232,12 +243,14 @@ describe("vault service failure mapping", () => {
       ],
       hasMore: false,
     });
-    const rawAfterRead = await readRawFileHistory(root);
     await expect(service.readNote({ path: "notes/history.md" })).resolves.toMatchObject({
       ok: true,
       content: "two\n",
     });
-    await expect(readRawFileHistory(root)).resolves.toBe(rawAfterRead);
+    await expect(service.listNoteHistory({ path: "notes/history.md" })).resolves.toMatchObject({
+      ok: true,
+      entries: [{ pending: true, operation: "create", actor: marcus, size: 4 }],
+    });
 
     await expect(
       service.appendNote({
@@ -254,17 +267,29 @@ describe("vault service failure mapping", () => {
       ok: true,
       entries: [
         {
-          operation: "update",
-          actor: olivia,
-          size: 10,
-        },
-        {
+          pending: true,
           operation: "create",
-          actor: marcus,
-          size: 4,
+          actor: { kind: "system", name: "2 contributors" },
+          contributors: [marcus, olivia],
+          size: 10,
         },
       ],
     });
+    await expect(service.flushDirtySessions()).resolves.toMatchObject({ ok: true });
+    const flushed = await service.listNoteHistory({ path: "notes/history.md" });
+    expect(flushed).toMatchObject({
+      ok: true,
+      entries: [
+        {
+          operation: "create",
+          actor: { kind: "system", name: "2 contributors" },
+          contributors: [marcus, olivia],
+          size: 10,
+        },
+      ],
+    });
+    if (!flushed.ok) throw new Error("expected flushed history");
+    expect(flushed.entries[0]).not.toHaveProperty("pending");
   });
 
   it("carries note history across cold and live note moves", async () => {
@@ -327,15 +352,10 @@ describe("vault service failure mapping", () => {
         },
         {
           path: "archive/history.md",
-          operation: "update",
-          actor: olivia,
-          size: 8,
-        },
-        {
-          path: "archive/history.md",
           operation: "create",
-          actor: marcus,
-          size: 4,
+          actor: { kind: "system", name: "2 contributors" },
+          contributors: [marcus, olivia],
+          size: 8,
         },
       ],
       hasMore: false,
@@ -387,7 +407,7 @@ describe("vault service failure mapping", () => {
     });
   });
 
-  it("keeps service writes best-effort when file history metadata is malformed", async () => {
+  it("keeps service writes best-effort when retired file-history metadata is malformed", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const service = createVaultService({
       vaultRoot: root,
@@ -451,10 +471,16 @@ describe("vault service failure mapping", () => {
         }),
       ).resolves.toMatchObject({ ok: true, content: "zero\nthree\nfour\n" });
       await expect(service.listNoteHistory({ path: "notes/corrupt-history.md" })).resolves.toMatchObject({
-        ok: false,
-        error: "metadata_parse_failed",
+        ok: true,
+        entries: [
+          {
+            pending: true,
+            operation: "create",
+            actor,
+            size: 16,
+          },
+        ],
       });
-      expect(warn).toHaveBeenCalled();
     } finally {
       warn.mockRestore();
     }
@@ -490,20 +516,20 @@ describe("vault service failure mapping", () => {
 
     await waitUntil(async () => {
       const history = await service.listNoteHistory({ path: "notes/socket.md" });
-      return history.ok && history.entries.length === 2 && history.entries[0]?.actor.id === "olivia";
-    }, () => "expected Yjs-attributed history entry to be recorded");
+      const contributors = history.ok ? history.entries[0]?.contributors ?? [] : [];
+      return history.ok &&
+        history.entries.length === 1 &&
+        contributors.some((actor) => actor.id === "olivia");
+    }, () => "expected Yjs-attributed history contributor to be recorded");
     await expect(service.listNoteHistory({ path: "notes/socket.md" })).resolves.toMatchObject({
       ok: true,
       entries: [
         {
-          operation: "update",
-          actor: olivia,
-          size: 7,
-        },
-        {
+          pending: true,
           operation: "create",
-          actor: marcus,
-          size: 5,
+          actor: { kind: "system", name: "2 contributors" },
+          contributors: [marcus, olivia],
+          size: 7,
         },
       ],
     });

--- a/packages/vault-service/src/index.ts
+++ b/packages/vault-service/src/index.ts
@@ -13,6 +13,7 @@ import {
   deleteVaultFile,
   deleteVaultFolder,
   emitVaultAudit,
+  flushFileHistory,
   historyOperationFromAudit,
   getFolderMetadata as getVaultFolderMetadata,
   getVaultInfo,
@@ -21,6 +22,7 @@ import {
   listVaultTree,
   makeVaultFolder,
   moveFileHistory,
+  moveFolderHistory,
   moveVaultPath,
   onVaultAudit,
   prependContent,
@@ -272,6 +274,16 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       console.warn('KB-2 failed to record file history for service write.', error);
     }
   };
+  const flushPendingHistory = async (paths?: string[]): Promise<void> => {
+    try {
+      const result = await flushFileHistory(options.vaultRoot, paths === undefined ? {} : { paths });
+      if (!result.ok) {
+        throw new Error(`Failed to flush file history: ${result.message}`);
+      }
+    } catch (error: unknown) {
+      console.warn('KB-2 failed to flush file history.', error);
+    }
+  };
   const recordPersistedSessionHistory = async (event: DocumentSessionEvent): Promise<void> => {
     const actor = vaultActorFromDocumentAttribution(event.attribution);
     const read = await readVaultFile(ctx(), event.path);
@@ -291,12 +303,31 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
         toPath: moved.toPath,
         actor: moved.audit.actor,
         content: read.value.content,
+        coalesceWindowMs: options.historyCoalesceWindowMs,
       });
       if (!result.ok) {
         throw new Error(`Failed to move file history from ${moved.fromPath} to ${moved.toPath}: ${result.message}`);
       }
     } catch (error: unknown) {
       console.warn('KB-2 failed to carry file history after note move.', error);
+    }
+  };
+  const carryHistoryAfterFolderMove = async (moved: {
+    fromPath: string;
+    toPath: string;
+    audit: AuditEntry;
+  }): Promise<void> => {
+    try {
+      const result = await moveFolderHistory(options.vaultRoot, {
+        fromPath: moved.fromPath,
+        toPath: moved.toPath,
+        actor: moved.audit.actor,
+      });
+      if (!result.ok) {
+        throw new Error(`Failed to move folder history from ${moved.fromPath} to ${moved.toPath}: ${result.message}`);
+      }
+    } catch (error: unknown) {
+      console.warn('KB-2 failed to carry file history after folder move.', error);
     }
   };
 
@@ -313,6 +344,7 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
     async flushDirtySessions() {
       const result = await mapWriteFailure(() => options.documentSessions.flushDirtySessions());
       if (!result.ok) return result;
+      await flushPendingHistory();
       return {
         ok: true,
         flushed: result.value.flushed,
@@ -371,6 +403,10 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
     },
 
     async listNoteHistory(input) {
+      const read = await readVaultFile(ctx(), input.path);
+      if (!read.ok && read.error === 'not_found') {
+        return { ok: true, entries: [], hasMore: false };
+      }
       return serviceResult(await listFileHistory(options.vaultRoot, input));
     },
 
@@ -538,6 +574,7 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
 
     async moveNote(input) {
       let moved: Awaited<ReturnType<typeof moveVaultPath>> extends VaultResult<infer T> ? T : never;
+      await flushPendingHistory([input.fromPath]);
       const moveOnDisk = async () => {
         moved = await expectOkValue(moveVaultPath(ctx(input.actor), {
           kind: 'file',
@@ -583,6 +620,7 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
 
     async moveFolder(input) {
       let moved: Awaited<ReturnType<typeof moveVaultPath>> extends VaultResult<infer T> ? T : never;
+      await flushPendingHistory();
       const moveOnDisk = async () => {
         moved = await expectOkValue(moveVaultPath(ctx(input.actor), {
           kind: 'folder',
@@ -592,6 +630,7 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       };
       const movedLive = await mapVaultFailure(() => options.documentSessions.moveSessionSubtree(input.fromPath, input.toPath, moveOnDisk));
       if (!movedLive.ok) return movedLive;
+      await carryHistoryAfterFolderMove(moved!);
       return { ok: true, ...moved!, liveMoved: movedLive.value };
     },
 


### PR DESCRIPTION
Summary:
- replace daemon file-history storage with lazy Git-backed history buckets
- flush pending history on dirty-session flushes and before structural moves
- keep history API coverage for edits, moves, and routing; include attachment-path coverage needed after rebasing on main

Verification:
- pnpm check in the daemon repo
- e2e intentionally skipped per staging-first merge instruction