### PR TITLE
Add client snapshot cache parity

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
+    "@codemirror/view": "6.41.1",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/inter-tight": "5.2.7",
     "@fontsource/jetbrains-mono": "5.2.8",
@@ -17,8 +18,11 @@
     "@kb-2/doc-session": "workspace:*",
     "@kb-2/editor": "workspace:*",
     "@kb-2/ui": "workspace:*",
+    "@tanstack/query-async-storage-persister": "^5.101.2",
+    "@tanstack/query-persist-client-core": "^5.101.2",
     "@tanstack/svelte-query": "^6.1.18",
     "lib0": "0.2.117",
+    "localforage": "^1.10.0",
     "svelte": "catalog:",
     "y-protocols": "1.0.7",
     "yjs": "13.6.31"

--- a/apps/web/src/lib/note/note-snapshot.test.ts
+++ b/apps/web/src/lib/note/note-snapshot.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
+
+import { DEMO_DOCUMENT_TEXT_NAME } from '$lib/yjs/demo-document-provider';
+import type { NoteSnapshot } from './note-snapshot';
+import { createNoteSnapshotDocument, snapshotFromLiveText } from './note-snapshot';
+
+describe('note snapshot display docs', () => {
+  it('seeds a read-only display document from cached snapshot content', () => {
+    const snapshot = noteSnapshot({ content: '# Cached note' });
+    const display = createNoteSnapshotDocument(snapshot);
+
+    expect(display.snapshot).toBe(snapshot);
+    expect(display.doc.getText(DEMO_DOCUMENT_TEXT_NAME).toDelta()).toEqual([
+      { insert: '# Cached note' },
+    ]);
+
+    display.destroy();
+  });
+
+  it('captures live Y.Text as passive snapshot data', () => {
+    const doc = new Y.Doc();
+    const text = doc.getText(DEMO_DOCUMENT_TEXT_NAME);
+    text.insert(0, 'Live body');
+    const previous = noteSnapshot({
+      version: 12,
+      mtime: 10,
+      content: 'Old body',
+      contentType: 'text/markdown',
+    });
+
+    expect(
+      snapshotFromLiveText({
+        vaultId: 'demo-vault',
+        path: 'a.md',
+        text,
+        previous,
+        now: 20,
+      }),
+    ).toMatchObject({
+      vaultId: 'demo-vault',
+      path: 'a.md',
+      version: 12,
+      mtime: 20,
+      size: 'Live body'.length,
+      contentType: 'text/markdown',
+      content: 'Live body',
+    });
+
+    const unchanged = noteSnapshot({
+      version: 12,
+      mtime: 10,
+      content: 'Live body',
+    });
+    expect(
+      snapshotFromLiveText({
+        vaultId: 'demo-vault',
+        path: 'a.md',
+        text,
+        previous: unchanged,
+        now: 30,
+      }),
+    ).toMatchObject({
+      version: 12,
+      mtime: 10,
+    });
+  });
+});
+
+function noteSnapshot(overrides: Partial<NoteSnapshot> = {}): NoteSnapshot {
+  return {
+    vaultId: 'demo-vault',
+    path: 'note.md',
+    version: 1,
+    mtime: 1,
+    size: overrides.content?.length ?? 0,
+    contentType: 'text/markdown; charset=utf-8',
+    content: '',
+    ...overrides,
+  };
+}

--- a/apps/web/src/lib/note/note-snapshot.ts
+++ b/apps/web/src/lib/note/note-snapshot.ts
@@ -1,0 +1,64 @@
+import * as Y from 'yjs';
+
+import { DEMO_DOCUMENT_TEXT_NAME } from '$lib/yjs/demo-document-provider';
+
+export interface NoteSnapshot {
+  vaultId: string;
+  path: string;
+  version: number;
+  mtime: number;
+  size: number;
+  contentType: string;
+  content: string;
+}
+
+export interface NoteSnapshotDocument {
+  snapshot: NoteSnapshot;
+  doc: Y.Doc;
+  text: Y.Text;
+  destroy: () => void;
+}
+
+export function createNoteSnapshotDocument(snapshot: NoteSnapshot): NoteSnapshotDocument {
+  const doc = new Y.Doc();
+  const text = doc.getText(DEMO_DOCUMENT_TEXT_NAME);
+  text.insert(0, snapshot.content);
+
+  return {
+    snapshot,
+    doc,
+    text,
+    destroy: () => {
+      doc.destroy();
+    },
+  };
+}
+
+export function snapshotFromLiveText(args: {
+  vaultId: string;
+  path: string;
+  text: Y.Text;
+  previous?: NoteSnapshot | null;
+  now?: number;
+}): NoteSnapshot {
+  const content = yTextContent(args.text);
+  const now = args.now ?? Date.now();
+  const contentChanged = args.previous?.content !== content;
+
+  return {
+    vaultId: args.vaultId,
+    path: args.path,
+    version: args.previous?.version ?? now,
+    mtime: contentChanged ? now : (args.previous?.mtime ?? now),
+    size: new TextEncoder().encode(content).byteLength,
+    contentType: args.previous?.contentType ?? 'text/markdown; charset=utf-8',
+    content,
+  };
+}
+
+function yTextContent(text: Y.Text): string {
+  const delta = text.toDelta() as { insert?: unknown }[];
+  return delta
+    .map((entry) => (typeof entry.insert === 'string' ? entry.insert : ''))
+    .join('');
+}

--- a/apps/web/src/lib/realtime/query-client.test.ts
+++ b/apps/web/src/lib/realtime/query-client.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { PersistedClient } from '@tanstack/query-persist-client-core';
+
+import { trimPersistedClient } from './query-persistence';
+
+describe('query client persistence', () => {
+  it('keeps persisted note snapshots bounded while preserving other queries', () => {
+    const noteQueries = Array.from({ length: 201 }, (_, index) =>
+      persistedQuery({
+        queryHash: `note-${String(index)}`,
+        queryKey: ['vault', 'v1', 'note', `n${String(index)}`],
+        dataUpdatedAt: index,
+      }),
+    );
+    const treeQuery = persistedQuery({
+      queryHash: 'tree',
+      queryKey: ['vault', 'v1', 'tree'],
+      dataUpdatedAt: 0,
+    });
+    const persistedClient = persistedClientWithQueries([treeQuery, ...noteQueries]);
+
+    const trimmed = trimPersistedClient(persistedClient);
+    const keptHashes = new Set(trimmed.clientState.queries.map((query) => query.queryHash));
+
+    expect(trimmed.clientState.queries).toHaveLength(201);
+    expect(keptHashes.has('tree')).toBe(true);
+    expect(keptHashes.has('note-0')).toBe(false);
+    expect(keptHashes.has('note-1')).toBe(true);
+    expect(keptHashes.has('note-200')).toBe(true);
+  });
+});
+
+function persistedClientWithQueries(
+  queries: PersistedClient['clientState']['queries'],
+): PersistedClient {
+  return {
+    timestamp: 1,
+    buster: 'test',
+    clientState: {
+      mutations: [],
+      queries,
+    },
+  };
+}
+
+function persistedQuery(args: {
+  queryHash: string;
+  queryKey: readonly unknown[];
+  dataUpdatedAt: number;
+}): PersistedClient['clientState']['queries'][number] {
+  return {
+    queryHash: args.queryHash,
+    queryKey: args.queryKey,
+    state: {
+      dataUpdatedAt: args.dataUpdatedAt,
+    },
+  } as PersistedClient['clientState']['queries'][number];
+}

--- a/apps/web/src/lib/realtime/query-client.ts
+++ b/apps/web/src/lib/realtime/query-client.ts
@@ -1,18 +1,56 @@
 import { QueryClient } from '@tanstack/svelte-query';
+import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister';
+import {
+  persistQueryClient,
+  removeOldestQuery,
+  type Persister,
+} from '@tanstack/query-persist-client-core';
+import localforage from 'localforage';
+import { trimPersistedClient } from './query-persistence';
+
+export const CACHE_BUSTER = '20260707-note-snapshots';
+
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 export interface KbQueryClient {
   client: QueryClient;
+  restored: Promise<void>;
 }
 
-export function createKbQueryClient(): KbQueryClient {
-  return {
-    client: new QueryClient({
-      defaultOptions: {
-        queries: {
-          refetchOnWindowFocus: false,
-          staleTime: 0,
-        },
+export interface KbQueryClientOptions {
+  persist?: boolean;
+}
+
+export function createKbQueryClient(options: KbQueryClientOptions = {}): KbQueryClient {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+        staleTime: 0,
       },
-    }),
+    },
+  });
+
+  if (options.persist === false) {
+    return { client, restored: Promise.resolve() };
+  }
+
+  const persister: Persister = createAsyncStoragePersister({
+    storage: localforage,
+    key: 'kb2-query-cache',
+    retry: removeOldestQuery,
+    serialize: (persistedClient) => JSON.stringify(trimPersistedClient(persistedClient)),
+  });
+
+  const [, restored] = persistQueryClient({
+    queryClient: client,
+    persister,
+    maxAge: MAX_AGE_MS,
+    buster: CACHE_BUSTER,
+  });
+
+  return {
+    client,
+    restored,
   };
 }

--- a/apps/web/src/lib/realtime/query-keys.ts
+++ b/apps/web/src/lib/realtime/query-keys.ts
@@ -2,4 +2,5 @@ export const queryKeys = {
   vaults: () => ['vaults'] as const,
   vault: (vaultId: string) => ['vault', vaultId] as const,
   tree: (vaultId: string) => ['vault', vaultId, 'tree'] as const,
+  note: (vaultId: string, path: string) => ['vault', vaultId, 'note', path] as const,
 } as const;

--- a/apps/web/src/lib/realtime/query-persistence.ts
+++ b/apps/web/src/lib/realtime/query-persistence.ts
@@ -1,0 +1,36 @@
+import type { PersistedClient } from '@tanstack/query-persist-client-core';
+
+const MAX_PERSISTED_NOTE_QUERIES = 200;
+
+export function trimPersistedClient(persistedClient: PersistedClient): PersistedClient {
+  const queries = persistedClient.clientState.queries;
+  const noteQueries = queries.filter((query) => isPersistedNoteQuery(query.queryKey));
+  if (noteQueries.length <= MAX_PERSISTED_NOTE_QUERIES) return persistedClient;
+
+  const noteQueriesToKeep = new Set(
+    [...noteQueries]
+      .sort((a, b) => b.state.dataUpdatedAt - a.state.dataUpdatedAt)
+      .slice(0, MAX_PERSISTED_NOTE_QUERIES)
+      .map((query) => query.queryHash),
+  );
+
+  return {
+    ...persistedClient,
+    clientState: {
+      ...persistedClient.clientState,
+      queries: queries.filter(
+        (query) =>
+          !isPersistedNoteQuery(query.queryKey) || noteQueriesToKeep.has(query.queryHash),
+      ),
+    },
+  };
+}
+
+function isPersistedNoteQuery(queryKey: unknown): boolean {
+  return (
+    Array.isArray(queryKey) &&
+    queryKey[0] === 'vault' &&
+    typeof queryKey[1] === 'string' &&
+    queryKey[2] === 'note'
+  );
+}

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -13,7 +13,11 @@
   // store instance.
   const appState = createAppState({ storage: window.localStorage });
   setAppStateContext(appState);
-  const { client: queryClient } = createKbQueryClient();
+  const { client: queryClient, restored: queryCacheRestored } = createKbQueryClient();
+  let queryCacheReady = $state(false);
+  void queryCacheRestored.finally(() => {
+    queryCacheReady = true;
+  });
 
   // Color-mode resolver. Subscribes to the persisted `colorMode`, then
   // resolves `'system'` against `prefers-color-scheme` and writes:
@@ -58,6 +62,8 @@
   });
 </script>
 
-<QueryClientProvider client={queryClient}>
-  {@render children()}
-</QueryClientProvider>
+{#if queryCacheReady}
+  <QueryClientProvider client={queryClient}>
+    {@render children()}
+  </QueryClientProvider>
+{/if}

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -58,9 +58,16 @@
     type FavoriteEntry,
   } from '$lib/app-state';
   import { buildStarredViewData } from '$lib/favorites-data';
+  import {
+    createNoteSnapshotDocument,
+    snapshotFromLiveText,
+    type NoteSnapshot,
+    type NoteSnapshotDocument,
+  } from '$lib/note/note-snapshot';
   import { createViewportStore } from '$lib/viewport.svelte';
   import { onDestroy, onMount, untrack } from 'svelte';
   import { createQueries, createQuery, useQueryClient } from '@tanstack/svelte-query';
+  import { EditorView } from '@codemirror/view';
   import { queryKeys } from '$lib/realtime';
 
   interface TreeEntry {
@@ -84,6 +91,21 @@
   interface VaultChangeEvent {
     kind: string;
     path?: string;
+  }
+
+  type TextSelectionSnapshot =
+    | {
+        kind: 'input';
+        start: number;
+        end: number;
+        direction: 'forward' | 'backward' | 'none';
+      }
+    | { kind: 'dom'; anchorOffset: number; focusOffset: number }
+    | { kind: 'codemirror'; anchorOffset: number; focusOffset: number };
+
+  interface TextPosition {
+    node: Node;
+    offset: number;
   }
 
   const TREE_DIRTY_EVENT_KINDS = new Set<string>([
@@ -162,6 +184,11 @@
   let dialog = $state<DialogState>({ kind: 'none' });
 
   let provider = $state<DemoDocumentProvider | null>(null);
+  let noteSnapshotDocument = $state.raw<NoteSnapshotDocument | null>(null);
+  let noteSnapshotDocumentKey = $state<string | null>(null);
+  let previousSnapshotHydrationActive = false;
+  let snapshotSelection = $state<TextSelectionSnapshot | null>(null);
+  let docBody = $state<HTMLDivElement | null>(null);
   let providerGeneration = 0;
   let providerSynced = $state(false);
   let status = $state<DemoDocumentProviderStatus>('connecting');
@@ -802,6 +829,7 @@
     const generation = providerGeneration + 1;
     providerGeneration = generation;
     providerSynced = false;
+    snapshotSelection = null;
     status = 'connecting';
     saveState = { status: 'saved', pending: 0 };
     error = null;
@@ -918,11 +946,236 @@
   function teardownProvider(): void {
     provider?.destroy();
     provider = null;
+    destroyNoteSnapshotDocument();
+    snapshotSelection = null;
+    previousSnapshotHydrationActive = false;
     providerSynced = false;
     status = 'connecting';
     saveState = { status: 'saved', pending: 0 };
     notFoundPath = null;
     docDeleted = false;
+  }
+
+  function destroyNoteSnapshotDocument(): void {
+    noteSnapshotDocument?.destroy();
+    noteSnapshotDocument = null;
+    noteSnapshotDocumentKey = null;
+  }
+
+  function noteSnapshotKey(
+    vaultId: string,
+    path: string,
+    snapshot: NoteSnapshot,
+  ): string {
+    return `${vaultId}\u0000${path}\u0000${contentFingerprint(snapshot.content)}`;
+  }
+
+  function contentFingerprint(content: string): string {
+    let hash = 0x811c9dc5;
+    for (let index = 0; index < content.length; index += 1) {
+      hash ^= content.charCodeAt(index);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    return `${content.length}:${(hash >>> 0).toString(36)}`;
+  }
+
+  function snapshotSelectionRoot(): HTMLElement | null {
+    return docBody?.querySelector('.snapshot-editor-layer') ?? null;
+  }
+
+  function liveSelectionRoot(): HTMLElement | null {
+    return docBody?.querySelector('.live-editor-layer') ?? null;
+  }
+
+  function captureTextSelection(root: HTMLElement | null): TextSelectionSnapshot | null {
+    if (!root) return null;
+
+    const active = document.activeElement;
+    if (
+      active instanceof HTMLTextAreaElement &&
+      root.contains(active) &&
+      active.selectionStart !== null &&
+      active.selectionEnd !== null
+    ) {
+      return {
+        kind: 'input',
+        start: active.selectionStart,
+        end: active.selectionEnd,
+        direction: active.selectionDirection ?? 'none',
+      };
+    }
+
+    const cmSelection = captureCodeMirrorSelection(root);
+    if (
+      cmSelection &&
+      (root.contains(document.activeElement) ||
+        cmSelection.anchorOffset !== cmSelection.focusOffset)
+    ) return cmSelection;
+
+    const selection = window.getSelection();
+    if (
+      selection === null ||
+      selection.rangeCount === 0 ||
+      selection.anchorNode === null ||
+      selection.focusNode === null ||
+      !root.contains(selection.anchorNode) ||
+      !root.contains(selection.focusNode)
+    ) return null;
+
+    const anchorOffset = textOffsetWithin(root, selection.anchorNode, selection.anchorOffset);
+    const focusOffset = textOffsetWithin(root, selection.focusNode, selection.focusOffset);
+    if (anchorOffset === null || focusOffset === null) return null;
+    return { kind: 'dom', anchorOffset, focusOffset };
+  }
+
+  function restoreTextSelection(
+    root: HTMLElement | null,
+    selection: TextSelectionSnapshot | null,
+  ): boolean {
+    if (!root || !selection) return false;
+
+    if (selection.kind === 'input') {
+      const target = root.querySelector<HTMLTextAreaElement>(
+        'textarea[aria-label="Markdown editor"]',
+      );
+      if (!target) return false;
+      target.focus({ preventScroll: true });
+      target.setSelectionRange(selection.start, selection.end, selection.direction);
+      return true;
+    }
+
+    if (
+      selection.kind === 'codemirror' &&
+      restoreCodeMirrorSelection(root, selection.anchorOffset, selection.focusOffset)
+    ) return true;
+
+    const anchor = textPositionAtOffset(root, selection.anchorOffset);
+    const focus = textPositionAtOffset(root, selection.focusOffset);
+    if (!anchor || !focus) return false;
+    const browserSelection = window.getSelection();
+    if (!browserSelection) return false;
+
+    const editable = root.querySelector<HTMLElement>(
+      '[contenteditable="true"], [role="textbox"][aria-label="Markdown editor"]',
+    );
+    editable?.focus({ preventScroll: true });
+
+    const range = document.createRange();
+    range.setStart(anchor.node, anchor.offset);
+    range.collapse(true);
+    browserSelection.removeAllRanges();
+    browserSelection.addRange(range);
+    if (browserSelection.extend) {
+      browserSelection.extend(focus.node, focus.offset);
+    } else {
+      range.setEnd(focus.node, focus.offset);
+      browserSelection.removeAllRanges();
+      browserSelection.addRange(range);
+    }
+    document.dispatchEvent(new Event('selectionchange'));
+    return true;
+  }
+
+  function scheduleLiveSelectionRestore(
+    selection: TextSelectionSnapshot | null,
+  ): void {
+    let attempts = 0;
+    const tryRestore = () => {
+      const restored = restoreTextSelection(liveSelectionRoot(), selection);
+      attempts += 1;
+      if (!restored && attempts < 8) requestAnimationFrame(tryRestore);
+    };
+    requestAnimationFrame(tryRestore);
+  }
+
+  function captureCodeMirrorSelection(
+    root: HTMLElement,
+  ): Extract<TextSelectionSnapshot, { kind: 'codemirror' }> | null {
+    const view = codeMirrorView(root);
+    if (!view) return null;
+    const main = view.state.selection.main;
+    return {
+      kind: 'codemirror',
+      anchorOffset: main.anchor,
+      focusOffset: main.head,
+    };
+  }
+
+  function restoreCodeMirrorSelection(
+    root: HTMLElement,
+    anchorOffset: number,
+    focusOffset: number,
+  ): boolean {
+    const view = codeMirrorView(root);
+    if (!view) return false;
+    const docLength = view.state.doc.length;
+    view.focus();
+    view.dispatch({
+      selection: {
+        anchor: clampTextOffset(anchorOffset, docLength),
+        head: clampTextOffset(focusOffset, docLength),
+      },
+      scrollIntoView: true,
+    });
+    return true;
+  }
+
+  function codeMirrorView(root: HTMLElement): EditorView | null {
+    const editor = root.querySelector<HTMLElement>('.cm-editor, .cm-content');
+    return EditorView.findFromDOM(editor ?? root);
+  }
+
+  function textOffsetWithin(
+    root: HTMLElement,
+    targetNode: Node,
+    targetOffset: number,
+  ): number | null {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let offset = 0;
+    let current = walker.nextNode();
+    while (current) {
+      if (current === targetNode) {
+        return offset + clampTextOffset(targetOffset, current.textContent?.length ?? 0);
+      }
+      offset += current.textContent?.length ?? 0;
+      current = walker.nextNode();
+    }
+    if (targetNode === root) return clampTextOffset(targetOffset, offset);
+    return null;
+  }
+
+  function textPositionAtOffset(
+    root: HTMLElement,
+    requestedOffset: number,
+  ): TextPosition | null {
+    const targetOffset = Math.max(0, requestedOffset);
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let consumed = 0;
+    let current = walker.nextNode();
+    let lastText: Text | null = null;
+
+    while (current) {
+      const text = current as Text;
+      const length = text.textContent?.length ?? 0;
+      lastText = text;
+      if (targetOffset <= consumed + length) {
+        return {
+          node: text,
+          offset: clampTextOffset(targetOffset - consumed, length),
+        };
+      }
+      consumed += length;
+      current = walker.nextNode();
+    }
+
+    if (lastText) {
+      return { node: lastText, offset: lastText.textContent?.length ?? 0 };
+    }
+    return null;
+  }
+
+  function clampTextOffset(offset: number, length: number): number {
+    return Math.max(0, Math.min(offset, length));
   }
 
   function toggleFolder(key: string): void {
@@ -1709,8 +1962,99 @@
     untrack(() => {
       provider?.destroy();
       provider = null;
+      destroyNoteSnapshotDocument();
       providerSynced = false;
     });
+  });
+
+  $effect(() => {
+    const id = activeVaultId;
+    const path = documentPath;
+    const activeProvider = provider;
+    const synced = providerSynced;
+    if (
+      !id ||
+      !path ||
+      !activeProvider ||
+      synced ||
+      notFoundPath === path ||
+      viewingFolder ||
+      activeAttachmentNode
+    ) {
+      destroyNoteSnapshotDocument();
+      return;
+    }
+
+    const snapshot = queryClient.getQueryData<NoteSnapshot>(queryKeys.note(id, path));
+    if (!snapshot || snapshot.vaultId !== id || snapshot.path !== path) {
+      destroyNoteSnapshotDocument();
+      return;
+    }
+
+    const nextKey = noteSnapshotKey(id, path, snapshot);
+    if (noteSnapshotDocumentKey === nextKey) return;
+    const previous = noteSnapshotDocument;
+    noteSnapshotDocument = createNoteSnapshotDocument(snapshot);
+    noteSnapshotDocumentKey = nextKey;
+    previous?.destroy();
+  });
+
+  $effect(() => {
+    const id = activeVaultId;
+    const path = documentPath;
+    const activeProvider = provider;
+    const synced = providerSynced;
+    if (!id || !path || !activeProvider || !synced) return;
+
+    const text = activeProvider.text;
+    const writeSnapshot = () => {
+      const key = queryKeys.note(id, path);
+      const previous = queryClient.getQueryData<NoteSnapshot | null>(key);
+      queryClient.setQueryData<NoteSnapshot>(
+        key,
+        snapshotFromLiveText({
+          vaultId: id,
+          path,
+          text,
+          previous,
+        }),
+      );
+    };
+
+    writeSnapshot();
+    text.observe(writeSnapshot);
+    return () => text.unobserve(writeSnapshot);
+  });
+
+  const snapshotHydrationActive = $derived(
+    provider !== null &&
+      !providerSynced &&
+      noteSnapshotDocument !== null &&
+      !viewingFolder &&
+      !activeAttachmentNode &&
+      notFoundPath !== documentPath,
+  );
+  const snapshotEditorReady = $derived(snapshotHydrationActive && noteSnapshotDocument !== null);
+  const liveEditorReady = $derived(provider !== null && (providerSynced || snapshotEditorReady));
+
+  $effect(() => {
+    if (!snapshotHydrationActive) return;
+    const updateSelection = () => {
+      snapshotSelection = captureTextSelection(snapshotSelectionRoot());
+    };
+
+    updateSelection();
+    document.addEventListener('selectionchange', updateSelection);
+    return () => document.removeEventListener('selectionchange', updateSelection);
+  });
+
+  $effect(() => {
+    const active = snapshotHydrationActive;
+    if (previousSnapshotHydrationActive && !active) {
+      const selection = snapshotSelection;
+      scheduleLiveSelectionRestore(selection);
+    }
+    previousSnapshotHydrationActive = active;
   });
 
   // First-load bootstrap. Load the vault list, then — when the URL is the
@@ -1774,6 +2118,7 @@
       }
       provider?.destroy();
       provider = null;
+      destroyNoteSnapshotDocument();
       providerSynced = false;
       saveState = { status: 'saved', pending: 0 };
     };
@@ -1853,10 +2198,10 @@
          to `.doc-body`. There are no side gutter columns, so no dark bands
          beside the document. -->
     <div class="doc-body-wrap">
-      <div class="doc-body">
+      <div bind:this={docBody} class="doc-body">
         {#if notFoundPath === documentPath}
           <DocumentNotFoundState path={documentPath} />
-        {:else if provider && providerSynced}
+        {:else if provider && liveEditorReady}
           <div class:history-open={historyPanelOpen} class="document-workspace">
             <div class="doc-column">
               <DocumentByline
@@ -1864,20 +2209,45 @@
                 statusTone={bylineStatusTone}
                 onHistory={openHistoryPanel}
               />
-              {#key provider}
-                <PlaintextEditor
-                  ydoc={provider.doc}
-                  ytext={provider.text}
-                  livePaths={livePaths}
-                  orgPeople={orgPeople}
-                  readOnly={docDeleted}
-                  scroll="external"
-                  class="vault-editor"
-                  attachmentSrc={rawAttachmentSrc}
-                  uploadImage={uploadImageAttachment}
-                  onWikilinkClick={handleWikilinkClick}
-                />
-              {/key}
+              <div class="editor-stage" class:snapshot-active={snapshotEditorReady}>
+                <div
+                  class="editor-layer live-editor-layer"
+                  class:snapshot-covered={snapshotEditorReady}
+                  aria-hidden={snapshotEditorReady}
+                >
+                  {#key provider}
+                    <PlaintextEditor
+                      ydoc={provider.doc}
+                      ytext={provider.text}
+                      livePaths={livePaths}
+                      orgPeople={orgPeople}
+                      readOnly={docDeleted || !providerSynced || snapshotEditorReady}
+                      scroll="external"
+                      class="vault-editor"
+                      attachmentSrc={rawAttachmentSrc}
+                      uploadImage={providerSynced ? uploadImageAttachment : undefined}
+                      onWikilinkClick={handleWikilinkClick}
+                    />
+                  {/key}
+                </div>
+                {#if snapshotEditorReady && noteSnapshotDocument}
+                  <div class="editor-layer snapshot-editor-layer">
+                    {#key noteSnapshotDocumentKey}
+                      <PlaintextEditor
+                        ydoc={noteSnapshotDocument.doc}
+                        ytext={noteSnapshotDocument.text}
+                        livePaths={livePaths}
+                        orgPeople={orgPeople}
+                        readOnly={true}
+                        scroll="external"
+                        class="vault-editor"
+                        attachmentSrc={rawAttachmentSrc}
+                        onWikilinkClick={handleWikilinkClick}
+                      />
+                    {/key}
+                  </div>
+                {/if}
+              </div>
             </div>
             {#if historyPanelOpen}
               <DocumentHistoryPanel
@@ -2135,6 +2505,26 @@
      band. */
   .doc-body :global(.vault-editor) {
     background: transparent;
+  }
+
+  .editor-stage {
+    display: grid;
+    min-width: 0;
+    position: relative;
+  }
+
+  .editor-layer {
+    grid-area: 1 / 1;
+    min-width: 0;
+  }
+
+  .live-editor-layer.snapshot-covered {
+    visibility: hidden;
+    pointer-events: none;
+  }
+
+  .snapshot-editor-layer {
+    z-index: 1;
   }
 
   @media (max-width: 1180px) {

--- a/apps/web/src/test/AppStateHarness.svelte
+++ b/apps/web/src/test/AppStateHarness.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
   import { QueryClientProvider } from '@tanstack/svelte-query';
+  import type { QueryClient } from '@tanstack/svelte-query';
   import { createAppState, setAppStateContext } from '$lib/app-state';
   import { createKbQueryClient } from '$lib/realtime';
   import Page from '../routes/+page.svelte';
+
+  let {
+    seedQueryClient,
+  }: {
+    seedQueryClient?: (client: QueryClient) => void;
+  } = $props();
 
   // Mirror the root layout: build the app-state store once and publish it
   // on context so the page's `useAppState()` resolves a provider. This is
@@ -10,7 +17,11 @@
   // so the harness stands in for the layout.
   const appState = createAppState({ storage: window.localStorage });
   setAppStateContext(appState);
-  const { client: queryClient } = createKbQueryClient();
+  const { client: queryClient } = createKbQueryClient({ persist: false });
+  function seedClient(): void {
+    seedQueryClient?.(queryClient);
+  }
+  seedClient();
 </script>
 
 <QueryClientProvider client={queryClient}>

--- a/apps/web/src/test/local-editor-route.test.ts
+++ b/apps/web/src/test/local-editor-route.test.ts
@@ -5,8 +5,11 @@ import {
   waitFor,
   within,
 } from "@testing-library/svelte";
+import type { QueryClient } from "@tanstack/svelte-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
+import { queryKeys } from "$lib/realtime";
+import type { NoteSnapshot } from "$lib/note/note-snapshot";
 import AppStateHarness from "./AppStateHarness.svelte";
 import { setPageUrl } from "./page-state.svelte";
 
@@ -14,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   goto: vi.fn(),
   destroyProvider: vi.fn(),
   providers: [] as Array<{ path: string; doc: Y.Doc; text: Y.Text }>,
+  delayedSyncPaths: new Set<string>(),
+  pendingSyncs: new Map<string, () => void>(),
 }));
 
 // The route derives the active vault + open document from the URL, so the
@@ -67,8 +72,15 @@ vi.mock("$lib/yjs/demo-document-provider", async () => {
         );
       } else {
         text.insert(0, `content:${path}`);
-        options.onStatus?.("open");
-        options.onSynced?.();
+        const open = () => {
+          options.onStatus?.("open");
+          options.onSynced?.();
+        };
+        if (mocks.delayedSyncPaths.has(path)) {
+          mocks.pendingSyncs.set(path, open);
+        } else {
+          open();
+        }
       }
       mocks.providers.push({ path, doc, text });
       return {
@@ -85,6 +97,8 @@ describe("local editor route", () => {
     mocks.goto.mockReset();
     mocks.destroyProvider.mockReset();
     mocks.providers = [];
+    mocks.delayedSyncPaths.clear();
+    mocks.pendingSyncs.clear();
     // The harness builds the app-state store against `localStorage`, which
     // persists tree expansion and vault filters. Clear it so each test
     // starts from the clean first-load defaults rather than inheriting a
@@ -275,6 +289,48 @@ describe("local editor route", () => {
     expect(treeProvider?.path).toBe("projects/active/editor-shell.md");
     expect(treeProvider?.text.toString()).toBe("typed into tree-opened file");
     expect(mocks.providers[0]?.text.toString()).toBe("content:hello-world.md");
+  });
+
+  it("paints a cached snapshot while syncing and preserves selection on live hydration", async () => {
+    mocks.delayedSyncPaths.add("hello-world.md");
+    const { container } = render(AppStateHarness, {
+      props: {
+        seedQueryClient: (client: QueryClient) => {
+          client.setQueryData(
+            queryKeys.note("demo-vault", "hello-world.md"),
+            noteSnapshot({
+              path: "hello-world.md",
+              content: "cached hello world",
+            }),
+          );
+        },
+      },
+    });
+
+    let snapshotEditor!: HTMLTextAreaElement;
+    await waitFor(() => {
+      snapshotEditor = container.querySelector(
+        ".snapshot-editor-layer textarea",
+      ) as HTMLTextAreaElement;
+      expect(snapshotEditor?.value).toBe("cached hello world");
+    });
+
+    snapshotEditor.focus();
+    snapshotEditor.setSelectionRange(7, 12, "forward");
+    document.dispatchEvent(new Event("selectionchange"));
+    mocks.pendingSyncs.get("hello-world.md")?.();
+
+    await waitFor(() => {
+      expect(container.querySelector(".snapshot-editor-layer")).toBeNull();
+    });
+    const liveEditor = container.querySelector(
+      ".live-editor-layer textarea",
+    ) as HTMLTextAreaElement;
+    expect(liveEditor.value).toBe("content:hello-world.md");
+    await waitFor(() => {
+      expect(liveEditor.selectionStart).toBe(7);
+      expect(liveEditor.selectionEnd).toBe(12);
+    });
   });
 
   it("opens attachment rows through the raw route instead of the document provider", async () => {
@@ -480,6 +536,19 @@ function json(body: unknown, status = 200): Response {
     status,
     headers: { "content-type": "application/json" },
   });
+}
+
+function noteSnapshot(overrides: Partial<NoteSnapshot> = {}): NoteSnapshot {
+  return {
+    vaultId: "demo-vault",
+    path: "hello-world.md",
+    version: 1,
+    mtime: 1,
+    size: overrides.content?.length ?? 0,
+    contentType: "text/markdown; charset=utf-8",
+    content: "",
+    ...overrides,
+  };
 }
 
 // History navigation (back/forward, deep-link) lands a new URL. The route

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@codemirror/view':
+        specifier: 6.41.1
+        version: 6.41.1
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.9
@@ -153,12 +156,21 @@ importers:
       '@kb-2/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@tanstack/query-async-storage-persister':
+        specifier: ^5.101.2
+        version: 5.101.2
+      '@tanstack/query-persist-client-core':
+        specifier: ^5.101.2
+        version: 5.101.2
       '@tanstack/svelte-query':
         specifier: ^6.1.18
         version: 6.1.36(svelte@5.55.5)
       lib0:
         specifier: 0.2.117
         version: 0.2.117
+      localforage:
+        specifier: ^1.10.0
+        version: 1.10.0
       svelte:
         specifier: 'catalog:'
         version: 5.55.5
@@ -1465,8 +1477,14 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@tanstack/query-async-storage-persister@5.101.2':
+    resolution: {integrity: sha512-jf7zvVKZ5q2j/xuhbTIBUpw5xt6cw/ioOFQquxK7fRY0AmMQP8A0JVMOgYoeQLA4PKdeT7RxsuLAF0Lft9oJ8Q==}
+
   '@tanstack/query-core@5.101.2':
     resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+
+  '@tanstack/query-persist-client-core@5.101.2':
+    resolution: {integrity: sha512-rgMsbvBVpSPDUsprC9FYxojdG0Q1LH6yq1i3DXz2aps4VEqv2l4Msj3YDqIifU3xkl/DrYe9YWntZAJLrM6xTg==}
 
   '@tanstack/svelte-query@6.1.36':
     resolution: {integrity: sha512-AVyvXPzBh5OQnWFB7rk9gskciPouayAhU9Vm24uMai+Imf+ZfBEbjOAEtdM41oexFK/cdXmpAIySDSVaAzy9zw==}
@@ -2143,6 +2161,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -2252,6 +2273,9 @@ packages:
     resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
     engines: {node: '>=16'}
     hasBin: true
+
+  lie@3.1.1:
+    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -2404,6 +2428,9 @@ packages:
   lines-and-columns@2.0.3:
     resolution: {integrity: sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  localforage@1.10.0:
+    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
 
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
@@ -3978,7 +4005,16 @@ snapshots:
       tailwindcss: 4.1.18
       vite: 7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
 
+  '@tanstack/query-async-storage-persister@5.101.2':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
+      '@tanstack/query-persist-client-core': 5.101.2
+
   '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/query-persist-client-core@5.101.2':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
 
   '@tanstack/svelte-query@6.1.36(svelte@5.55.5)':
     dependencies:
@@ -4074,7 +4110,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.2)(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -4695,6 +4731,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immediate@3.0.6: {}
+
   indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
@@ -4769,6 +4807,10 @@ snapshots:
   lib0@0.2.117:
     dependencies:
       isomorphic.js: 0.2.5
+
+  lie@3.1.1:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -4869,6 +4911,10 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.32.0
 
   lines-and-columns@2.0.3: {}
+
+  localforage@1.10.0:
+    dependencies:
+      lie: 3.1.1
 
   locate-character@3.0.0: {}
 


### PR DESCRIPTION
## Summary
- persist bounded note snapshots in the daemon web query cache
- show cached note content while the live Yjs provider is still syncing
- preserve text selection when hydration switches from cached snapshot to live editor

## Verification
- pnpm --filter @kb-2/web exec vitest run src/lib/note/note-snapshot.test.ts src/lib/realtime/query-client.test.ts src/test/local-editor-route.test.ts
- pnpm --filter @kb-2/web typecheck
- pnpm check