### PR TITLE
Hide git internals from vault enumeration

### DIFF
--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -52,7 +52,7 @@ import {
   recordFileHistory,
 } from "./file-history.js";
 import { searchVaultFiles } from "./search.js";
-import { validateVaultPath } from "./path.js";
+import { isInternalVaultPath, validateVaultPath } from "./path.js";
 import { anchoredSpliceContractCases } from "./splice-contract-cases.test-support.js";
 
 const CORAL = "#fda4af";
@@ -101,6 +101,9 @@ describe("vault path validation", () => {
     ["folder/trailing.", "file"],
     [".kb1/audit.md", "file"],
     [".kb1/audit.bin", "artifact"],
+    [".git", "folder"],
+    [".git/COMMIT_EDITMSG", "artifact"],
+    [".git/objects/aa/bb.txt", "file"],
     [`${"a".repeat(256)}.md`, "file"],
     [`${"a".repeat(1025)}.md`, "file"],
   ] as const)("rejects invalid %s as %s", (input, kind) => {
@@ -121,6 +124,12 @@ describe("vault path validation", () => {
     expect(() => validateVaultPath(123 as unknown as string, "file")).toThrow(
       "path must be a string",
     );
+  });
+
+  it("identifies daemon-internal path segments without hiding all dotfolders", () => {
+    expect(isInternalVaultPath("")).toBe(false);
+    expect(isInternalVaultPath("notes/.git/COMMIT_EDITMSG")).toBe(true);
+    expect(isInternalVaultPath("notes/.obsidian/config.json")).toBe(false);
   });
 
   it("property: valid file paths validate idempotently and resolve inside the vault root", () => {
@@ -359,6 +368,18 @@ describe("vault-core filesystem operations", () => {
     });
 
     await expect(readVaultRawFile(ctx, "../outside.png")).resolves.toMatchObject({
+      ok: false,
+      error: "invalid_path",
+    });
+    await mkdir(path.join(root, ".git"), { recursive: true });
+    await writeFile(
+      path.join(root, ".git", "COMMIT_EDITMSG"),
+      "internal commit\n",
+      "utf8",
+    );
+    await expect(
+      readVaultRawFile(ctx, ".git/COMMIT_EDITMSG"),
+    ).resolves.toMatchObject({
       ok: false,
       error: "invalid_path",
     });
@@ -971,14 +992,35 @@ describe("vault-core filesystem operations", () => {
     });
     await writeVaultFile(ctx, { path: "notes/a.md", content: "a" });
     await deleteVaultFile(ctx, { path: "notes/a.md" });
-    await mkdir(path.join(root, ".git", "objects"), { recursive: true });
-    await writeFile(path.join(root, ".git", "HEAD"), "ref: refs/heads/main\n", "utf8");
+    await writeVaultFile(ctx, { path: "normal.md", content: "normal" });
+    await mkdir(path.join(root, ".git", "objects", "aa"), { recursive: true });
+    await writeFile(
+      path.join(root, ".git", "HEAD"),
+      "ref: refs/heads/main\n",
+      "utf8",
+    );
+    await writeFile(
+      path.join(root, ".git", "COMMIT_EDITMSG"),
+      "internal commit\n",
+      "utf8",
+    );
+    await writeFile(
+      path.join(root, ".git", "objects", "aa", "bb.txt"),
+      "internal object\n",
+      "utf8",
+    );
 
     const tree = await listVaultTree(ctx);
     expect(tree.ok).toBe(true);
-    expect(
-      tree.ok ? tree.value.entries.map((entry) => entry.path) : [],
-    ).toEqual(["notes"]);
+    const paths = tree.ok
+      ? tree.value.entries.map((entry) => entry.path).sort()
+      : [];
+    expect(paths).toEqual(["normal.md", "notes"]);
+    expect(paths.some((entryPath) => entryPath.startsWith(".git"))).toBe(false);
+    await expect(listVaultTree(ctx, { under: ".git" })).resolves.toMatchObject({
+      ok: false,
+      error: "invalid_path",
+    });
   });
 
   it("lists subtrees with depth limits and entry-cap errors", async () => {
@@ -1009,6 +1051,17 @@ describe("vault-core filesystem operations", () => {
   it("reports vault counts from durable files", async () => {
     await writeVaultFile(ctx, { path: "notes/a.md", content: "a" });
     await writeVaultFile(ctx, { path: "notes/deep/b.md", content: "b" });
+    await mkdir(path.join(root, ".git", "objects", "aa"), { recursive: true });
+    await writeFile(
+      path.join(root, ".git", "COMMIT_EDITMSG"),
+      "internal commit\n",
+      "utf8",
+    );
+    await writeFile(
+      path.join(root, ".git", "objects", "aa", "bb.txt"),
+      "internal object\n",
+      "utf8",
+    );
 
     const info = await getVaultInfo(ctx);
     expect(info).toMatchObject({
@@ -1938,6 +1991,18 @@ describe("scan search", () => {
   });
 
   it("searches from the vault root and excludes metadata and trash folders", async () => {
+    await mkdir(path.join(root, ".git", "objects", "aa"), { recursive: true });
+    await writeFile(
+      path.join(root, ".git", "COMMIT_EDITMSG"),
+      "target internal commit\n",
+      "utf8",
+    );
+    await writeFile(
+      path.join(root, ".git", "objects", "aa", "bb.txt"),
+      "target internal object\n",
+      "utf8",
+    );
+
     const result = await searchVaultFiles(root, {
       q: "target",
       context: 0,
@@ -1949,6 +2014,9 @@ describe("scan search", () => {
       "notes/a.md",
       "notes/deep/b.txt",
     ]);
+    expect(result.results.some((hit) => hit.path.startsWith(".git"))).toBe(
+      false,
+    );
     expect(
       result.results.every(
         (hit) =>

--- a/packages/vault-core/src/path.ts
+++ b/packages/vault-core/src/path.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 const MAX_PATH_LENGTH = 1024;
 const MAX_SEGMENT_LENGTH = 255;
+const INTERNAL_VAULT_PATH_SEGMENTS = new Set(['.git', '.kb1']);
 
 type VaultPathKind = 'file' | 'folder' | 'artifact';
 
@@ -43,8 +44,8 @@ export function validateVaultPath(input: string, kind: VaultPathKind): string {
     if (segment.length > MAX_SEGMENT_LENGTH) {
       throw new InvalidPathError(input, `segment exceeds ${MAX_SEGMENT_LENGTH} chars`);
     }
-    if (segment === '.kb1') {
-      throw new InvalidPathError(input, '.kb1 is reserved for vault metadata');
+    if (INTERNAL_VAULT_PATH_SEGMENTS.has(segment)) {
+      throw new InvalidPathError(input, `${segment} is reserved for vault metadata`);
     }
   }
 
@@ -62,6 +63,11 @@ export function validateVaultPath(input: string, kind: VaultPathKind): string {
 export function validateOptionalVaultPath(input: string | undefined, kind: VaultPathKind): string | undefined {
   if (input === undefined || input.length === 0) return undefined;
   return validateVaultPath(input, kind);
+}
+
+export function isInternalVaultPath(input: string): boolean {
+  if (input.length === 0) return false;
+  return input.split('/').some((segment) => INTERNAL_VAULT_PATH_SEGMENTS.has(segment));
 }
 
 export function relativeDescendantPath(parent: string, child: string): string | null {

--- a/packages/vault-core/src/search.ts
+++ b/packages/vault-core/src/search.ts
@@ -2,7 +2,7 @@ import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { isNodeError, statOrNull } from './fs.js';
-import { InvalidPathError, resolveVaultPath, validateOptionalVaultPath } from './path.js';
+import { InvalidPathError, isInternalVaultPath, resolveVaultPath, validateOptionalVaultPath } from './path.js';
 
 export interface SearchInput {
   q: string;
@@ -120,8 +120,7 @@ function vaultPath(root: string, relPath: string): string {
 }
 
 function isExcludedSearchPath(relPath: string): boolean {
-  return relPath === '.kb1' ||
-    relPath.startsWith('.kb1/') ||
+  return isInternalVaultPath(relPath) ||
     relPath === 'trash' ||
     relPath.startsWith('trash/');
 }

--- a/packages/vault-core/src/vault-ops.ts
+++ b/packages/vault-core/src/vault-ops.ts
@@ -20,6 +20,7 @@ import {
 import { isNodeError, statOrNull } from "./fs.js";
 import {
   InvalidPathError,
+  isInternalVaultPath,
   relativeDescendantPath,
   resolveVaultPath,
   validateOptionalVaultPath,
@@ -206,15 +207,6 @@ function trashRelativePath(originalPath: string): string {
   );
 }
 
-function isHiddenMetadataPath(relPath: string): boolean {
-  return (
-    relPath === ".kb1" ||
-    relPath.startsWith(".kb1/") ||
-    relPath === ".git" ||
-    relPath.startsWith(".git/")
-  );
-}
-
 const TEXT_ARTIFACT_EXTENSIONS: Record<string, { contentType: string; preview: ArtifactPreview }> = {
   ".md": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
   ".markdown": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
@@ -328,7 +320,7 @@ async function walkEntries(
   for (const dirent of dirents) {
     const rel =
       relDir.length === 0 ? dirent.name : path.posix.join(relDir, dirent.name);
-    if (isHiddenMetadataPath(rel)) continue;
+    if (isInternalVaultPath(rel)) continue;
     const abs = vaultPath(root, rel);
     const s = await stat(abs);
     if (dirent.isDirectory()) {


### PR DESCRIPTION
## Summary
- centralize daemon-internal vault path segments in vault-core
- reject .git paths through public vault path validation
- exclude .git from tree, info, raw-file, and search behavior at source

## Verification
- pnpm --dir local --filter @kb-1/vault-core test
- pnpm --dir local --filter @kb-1/vault-service test
- pnpm --dir local --filter @kb-1/daemon test
- pnpm --dir local check