### PR TITLE
Hide git metadata files from vault APIs

### DIFF
--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -102,6 +102,10 @@ describe("vault path validation", () => {
     [".kb1/audit.md", "file"],
     [".kb1/audit.bin", "artifact"],
     [".git", "folder"],
+    [".gitignore", "artifact"],
+    [".gitattributes", "artifact"],
+    [".gitmodules", "artifact"],
+    ["notes/.gitignore", "artifact"],
     [".git/COMMIT_EDITMSG", "artifact"],
     [".git/objects/aa/bb.txt", "file"],
     [`${"a".repeat(256)}.md`, "file"],
@@ -129,6 +133,8 @@ describe("vault path validation", () => {
   it("identifies daemon-internal path segments without hiding all dotfolders", () => {
     expect(isInternalVaultPath("")).toBe(false);
     expect(isInternalVaultPath("notes/.git/COMMIT_EDITMSG")).toBe(true);
+    expect(isInternalVaultPath(".gitignore")).toBe(true);
+    expect(isInternalVaultPath("notes/.gitattributes")).toBe(true);
     expect(isInternalVaultPath("notes/.obsidian/config.json")).toBe(false);
   });
 
@@ -377,9 +383,14 @@ describe("vault-core filesystem operations", () => {
       "internal commit\n",
       "utf8",
     );
+    await writeFile(path.join(root, ".gitignore"), "*\n", "utf8");
     await expect(
       readVaultRawFile(ctx, ".git/COMMIT_EDITMSG"),
     ).resolves.toMatchObject({
+      ok: false,
+      error: "invalid_path",
+    });
+    await expect(readVaultRawFile(ctx, ".gitignore")).resolves.toMatchObject({
       ok: false,
       error: "invalid_path",
     });
@@ -1009,6 +1020,9 @@ describe("vault-core filesystem operations", () => {
       "internal object\n",
       "utf8",
     );
+    await writeFile(path.join(root, ".gitignore"), "*\n", "utf8");
+    await writeFile(path.join(root, ".gitattributes"), "* text=auto\n", "utf8");
+    await writeFile(path.join(root, ".gitmodules"), "[submodule]\n", "utf8");
 
     const tree = await listVaultTree(ctx);
     expect(tree.ok).toBe(true);
@@ -1017,6 +1031,7 @@ describe("vault-core filesystem operations", () => {
       : [];
     expect(paths).toEqual(["normal.md", "notes"]);
     expect(paths.some((entryPath) => entryPath.startsWith(".git"))).toBe(false);
+    expect(paths.some((entryPath) => entryPath.startsWith(".gitattributes"))).toBe(false);
     await expect(listVaultTree(ctx, { under: ".git" })).resolves.toMatchObject({
       ok: false,
       error: "invalid_path",
@@ -2000,6 +2015,12 @@ describe("scan search", () => {
     await writeFile(
       path.join(root, ".git", "objects", "aa", "bb.txt"),
       "target internal object\n",
+      "utf8",
+    );
+    await writeFile(path.join(root, ".gitignore"), "target ignored\n", "utf8");
+    await writeFile(
+      path.join(root, ".gitattributes"),
+      "target attributes\n",
       "utf8",
     );
 

--- a/packages/vault-core/src/path.ts
+++ b/packages/vault-core/src/path.ts
@@ -2,7 +2,13 @@ import path from 'node:path';
 
 const MAX_PATH_LENGTH = 1024;
 const MAX_SEGMENT_LENGTH = 255;
-const INTERNAL_VAULT_PATH_SEGMENTS = new Set(['.git', '.kb1']);
+const INTERNAL_VAULT_PATH_SEGMENTS = new Set([
+  '.git',
+  '.gitattributes',
+  '.gitignore',
+  '.gitmodules',
+  '.kb1',
+]);
 
 type VaultPathKind = 'file' | 'folder' | 'artifact';
 


### PR DESCRIPTION
## Summary
- Treat root/nested Git metadata files such as .gitignore, .gitattributes, and .gitmodules as daemon-internal vault paths
- Keep .obsidian and other non-Git dotfolders visible
- Add tree/search/raw-read regressions for Git metadata filtering

## Verification
- pnpm --dir local --filter @kb-1/vault-core test
- pnpm --dir local check