### PR TITLE
Add tree drag/drop move parity

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -37,6 +37,7 @@
     type DialogField,
     type LocalFolderNode,
     type LocalFolderMetadata,
+    type LocalTreeMoveDrop,
     type LocalTreeAction,
     type LocalTreeNode,
     type NewVaultSubmit,
@@ -1314,6 +1315,12 @@
     return path.split('/').filter(Boolean).at(-1) ?? path;
   }
 
+  function movedDescendantPath(openPath: string, sourcePath: string, targetPath: string): string | null {
+    if (openPath === sourcePath) return targetPath;
+    if (!openPath.startsWith(`${sourcePath}/`)) return null;
+    return joinPath(targetPath, openPath.slice(sourcePath.length + 1));
+  }
+
   // Ensure a note name carries a `.md` extension so the daemon writes a
   // markdown file regardless of what the user typed.
   function withMarkdownExtension(name: string): string {
@@ -1403,6 +1410,38 @@
       openFolderDialog(action);
     } else {
       openVaultDialog(action);
+    }
+  }
+
+  async function handleTreeMoveDrop(move: LocalTreeMoveDrop): Promise<void> {
+    if (move.source.vaultId !== move.target.vaultId) return;
+    if (!knownVaults.some((v) => v.id === move.source.vaultId)) return;
+
+    try {
+      error = null;
+      if (move.source.kind === 'file') {
+        const wasViewing =
+          move.source.vaultId === activeVaultId &&
+          !viewingFolder &&
+          documentPath === move.source.path;
+        await kbService.moveNote(move.source.vaultId, move.source.path, move.targetPath);
+        appState.favoritesOnNoteRenamed(move.source.vaultId, move.source.path, move.targetPath);
+        if (wasViewing) await goto(vaultRoute(move.source.vaultId, move.targetPath), { noScroll: true, keepFocus: true });
+      } else {
+        const movedActivePath =
+          move.source.vaultId === activeVaultId
+            ? movedDescendantPath(documentPath, move.source.path, move.targetPath)
+            : null;
+        await kbService.moveFolder(move.source.vaultId, move.source.path, move.targetPath);
+        appState.favoritesOnFolderRenamed(move.source.vaultId, move.source.path, move.targetPath);
+        if (movedActivePath) {
+          await goto(vaultRoute(move.source.vaultId, movedActivePath), { noScroll: true, keepFocus: true });
+        }
+      }
+
+      await refreshTreeForVault(move.source.vaultId);
+    } catch (caught) {
+      error = caught instanceof Error ? caught.message : String(caught);
     }
   }
 
@@ -2321,6 +2360,9 @@
     onOpenFolder={openFolder}
     onOpenVault={openVaultFromKey}
     onTreeAction={handleTreeAction}
+    onTreeMoveDrop={(move) => {
+      void handleTreeMoveDrop(move);
+    }}
     onNewVault={openNewVaultDialog}
   >
     {@render canvasBody()}
@@ -2368,6 +2410,9 @@
     onOpenFolder={openFolder}
     onOpenVault={openVaultFromKey}
     onTreeAction={handleTreeAction}
+    onTreeMoveDrop={(move) => {
+      void handleTreeMoveDrop(move);
+    }}
     onNewVault={openNewVaultDialog}
   >
     {@render canvasBody()}

--- a/apps/web/src/test/local-tree-drag-drop-ui.test.ts
+++ b/apps/web/src/test/local-tree-drag-drop-ui.test.ts
@@ -1,0 +1,184 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FilesPanel, type LocalTreeMoveDrop, type LocalTreeNode } from "@kb-1/ui";
+
+afterEach(() => {
+  cleanup();
+});
+
+function dataTransfer(): DataTransfer {
+  const values = new Map<string, string>();
+  return {
+    effectAllowed: "all",
+    dropEffect: "none",
+    get types() {
+      return Array.from(values.keys());
+    },
+    setData(type: string, value: string) {
+      values.set(type, value);
+    },
+    getData(type: string) {
+      return values.get(type) ?? "";
+    },
+    clearData(type?: string) {
+      if (type) values.delete(type);
+      else values.clear();
+    },
+  } as unknown as DataTransfer;
+}
+
+function folder(path: string, children: LocalTreeNode[] = []): LocalTreeNode {
+  return {
+    kind: "folder",
+    path,
+    name: path.split("/").at(-1) ?? path,
+    children,
+  };
+}
+
+function file(path: string): LocalTreeNode {
+  return {
+    kind: "file",
+    path,
+    name: path.split("/").at(-1) ?? path,
+  };
+}
+
+function renderPanel(
+  tree: LocalTreeNode[],
+  onTreeMoveDrop: (move: LocalTreeMoveDrop) => void,
+) {
+  return render(FilesPanel, {
+    vaultName: "Demo vault",
+    vaultId: "demo-vault",
+    tree,
+    expandedFolderIds: new Set([
+      "folder:demo-vault:dnd-target",
+      "folder:demo-vault:dnd-parent",
+    ]),
+    onTreeMoveDrop,
+  });
+}
+
+describe("FilesPanel tree drag/drop moves", () => {
+  it("emits a file move when a file is dropped on a same-vault folder", async () => {
+    const onTreeMoveDrop = vi.fn();
+    renderPanel([folder("dnd-target"), file("dnd-file.md")], onTreeMoveDrop);
+    const transfer = dataTransfer();
+
+    await fireEvent.dragStart(screen.getByRole("button", { name: "dnd-file.md" }), {
+      dataTransfer: transfer,
+    });
+    await fireEvent.dragOver(screen.getByText("dnd-target"), {
+      dataTransfer: transfer,
+    });
+    await fireEvent.drop(screen.getByText("dnd-target"), {
+      dataTransfer: transfer,
+    });
+
+    expect(onTreeMoveDrop).toHaveBeenCalledWith({
+      source: {
+        kind: "file",
+        vaultId: "demo-vault",
+        path: "dnd-file.md",
+      },
+      target: {
+        kind: "folder",
+        vaultId: "demo-vault",
+        path: "dnd-target",
+      },
+      destinationFolderPath: "dnd-target",
+      targetPath: "dnd-target/dnd-file.md",
+    });
+  });
+
+  it("emits a folder move when a folder is dropped on a same-vault folder", async () => {
+    const onTreeMoveDrop = vi.fn();
+    renderPanel([folder("dnd-folder-dest"), folder("dnd-folder-source")], onTreeMoveDrop);
+    const transfer = dataTransfer();
+
+    await fireEvent.dragStart(screen.getByText("dnd-folder-source"), {
+      dataTransfer: transfer,
+    });
+    await fireEvent.dragOver(screen.getByText("dnd-folder-dest"), {
+      dataTransfer: transfer,
+    });
+    await fireEvent.drop(screen.getByText("dnd-folder-dest"), {
+      dataTransfer: transfer,
+    });
+
+    expect(onTreeMoveDrop).toHaveBeenCalledWith({
+      source: {
+        kind: "folder",
+        vaultId: "demo-vault",
+        path: "dnd-folder-source",
+      },
+      target: {
+        kind: "folder",
+        vaultId: "demo-vault",
+        path: "dnd-folder-dest",
+      },
+      destinationFolderPath: "dnd-folder-dest",
+      targetPath: "dnd-folder-dest/dnd-folder-source",
+    });
+  });
+
+  it("emits a root move when an item is dropped on the vault row", async () => {
+    const onTreeMoveDrop = vi.fn();
+    renderPanel([folder("dnd-target", [file("dnd-target/dnd-file.md")])], onTreeMoveDrop);
+    const transfer = dataTransfer();
+
+    await fireEvent.dragStart(screen.getByRole("button", { name: "dnd-file.md" }), {
+      dataTransfer: transfer,
+    });
+    await fireEvent.dragOver(screen.getByTestId("vault-row"), {
+      dataTransfer: transfer,
+    });
+    await fireEvent.drop(screen.getByTestId("vault-row"), {
+      dataTransfer: transfer,
+    });
+
+    expect(onTreeMoveDrop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destinationFolderPath: "",
+        targetPath: "dnd-file.md",
+      }),
+    );
+  });
+
+  it("rejects dropping a folder into its descendant", async () => {
+    const onTreeMoveDrop = vi.fn();
+    renderPanel([folder("dnd-parent", [folder("dnd-parent/child")])], onTreeMoveDrop);
+    const transfer = dataTransfer();
+
+    await fireEvent.dragStart(screen.getByText("dnd-parent"), {
+      dataTransfer: transfer,
+    });
+    await fireEvent.dragOver(screen.getByText("child"), {
+      dataTransfer: transfer,
+    });
+    await fireEvent.drop(screen.getByText("child"), {
+      dataTransfer: transfer,
+    });
+
+    expect(transfer.dropEffect).toBe("none");
+    expect(onTreeMoveDrop).not.toHaveBeenCalled();
+  });
+
+  it("cancels a tree drag when dropped on the panel outside a target", async () => {
+    const onTreeMoveDrop = vi.fn();
+    const { container } = renderPanel([folder("dnd-target"), file("dnd-file.md")], onTreeMoveDrop);
+    const transfer = dataTransfer();
+    const panel = container.querySelector(".files-panel");
+    expect(panel).not.toBeNull();
+
+    await fireEvent.dragStart(screen.getByRole("button", { name: "dnd-file.md" }), {
+      dataTransfer: transfer,
+    });
+    await fireEvent.drop(panel as Element, {
+      dataTransfer: transfer,
+    });
+
+    expect(onTreeMoveDrop).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/lib/dialogs/MovePickerDialog.svelte
+++ b/packages/ui/src/lib/dialogs/MovePickerDialog.svelte
@@ -29,15 +29,16 @@
     oncancel,
   }: Props = $props();
 
-  let selected = $state<string>('');
+  let selected = $state<string | null>(null);
 
   $effect(() => {
-    if (open) selected = currentParent;
+    if (open) selected = null;
   });
 
   const sortedPaths = $derived(
     [...folderPaths].sort((a, b) => a.localeCompare(b)),
   );
+  const canSubmit = $derived(selected !== null && selected !== currentParent);
 </script>
 
 <DialogShell {open} onclose={oncancel} {title} {description}>
@@ -46,20 +47,36 @@
       <li>
         <button
           type="button"
-          class={cn('move-option', selected === '' && 'selected')}
+          class={cn(
+            'move-option',
+            selected === '' && 'selected',
+            currentParent === '' && 'current',
+          )}
+          aria-current={currentParent === '' ? 'location' : undefined}
           onclick={() => (selected = '')}
         >
           <span class="move-label">Vault root</span>
+          {#if currentParent === ''}
+            <span class="move-current">Current</span>
+          {/if}
         </button>
       </li>
       {#each sortedPaths as path (path)}
         <li>
           <button
             type="button"
-            class={cn('move-option', selected === path && 'selected')}
+            class={cn(
+              'move-option',
+              selected === path && 'selected',
+              currentParent === path && 'current',
+            )}
+            aria-current={currentParent === path ? 'location' : undefined}
             onclick={() => (selected = path)}
           >
             <span class="move-label">{path}</span>
+            {#if currentParent === path}
+              <span class="move-current">Current</span>
+            {/if}
           </button>
         </li>
       {/each}
@@ -75,9 +92,11 @@
     <Button
       size="sm"
       onclick={() => {
-        onsubmit(selected);
+        const destination = selected;
+        if (destination === null || destination === currentParent) return;
+        onsubmit(destination);
       }}
-      disabled={busy}
+      disabled={busy || !canSubmit}
     >
       {busy ? 'Working…' : submitLabel}
     </Button>
@@ -126,6 +145,10 @@
     color: var(--accent-foreground);
   }
 
+  .move-option.current:not(.selected) {
+    color: var(--muted-foreground);
+  }
+
   .move-option:focus-visible {
     outline: 2px solid color-mix(in srgb, var(--ring) 50%, transparent);
     outline-offset: -2px;
@@ -133,9 +156,18 @@
 
   .move-label {
     min-width: 0;
+    flex: 1;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .move-current {
+    flex-shrink: 0;
+    color: inherit;
+    font-family: var(--rd-mono);
+    font-size: 11px;
+    opacity: 0.72;
   }
 
   .dialog-error {

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -73,6 +73,20 @@ export {
   type FolderPresentation,
   type FolderPresentationResolver,
 } from "./local-editor/folder-presentation";
+export {
+  LOCAL_TREE_DRAG_MIME,
+  joinTreePath,
+  leafTreeName,
+  parentTreePath,
+  parseLocalTreeDragSource,
+  resolveLocalTreeDrop,
+  serializeLocalTreeDragSource,
+  type LocalTreeDragSource,
+  type LocalTreeDropRejectionReason,
+  type LocalTreeDropResolution,
+  type LocalTreeDropTarget,
+  type LocalTreeMoveDrop,
+} from "./local-editor/tree-drag-drop";
 export { default as LocalEditorShell } from "./local-editor/LocalEditorShell.svelte";
 export { default as LocalEditorMobileShell } from "./local-editor/LocalEditorMobileShell.svelte";
 export { default as StarredPanel } from "./local-editor/StarredPanel.svelte";

--- a/packages/ui/src/lib/local-editor/FileNode.svelte
+++ b/packages/ui/src/lib/local-editor/FileNode.svelte
@@ -2,6 +2,7 @@
   import Icon from '../primitives/Icon.svelte';
   import ContextMenu from '../menus/ContextMenu.svelte';
   import { noteKey } from './expansion';
+  import type { LocalTreeDragSource } from './tree-drag-drop';
   import type { LocalFileNode, LocalTreeAction } from './types';
   import type { MenuItem } from '../menus/ContextMenu.svelte';
 
@@ -27,6 +28,9 @@
         one. */
     onOpen?: (key: string) => void;
     onAction?: (action: LocalTreeAction) => void;
+    dragSource?: LocalTreeDragSource | null;
+    onTreeDragStart?: (source: LocalTreeDragSource, event: DragEvent) => void;
+    onTreeDragEnd?: () => void;
   }
 
   let {
@@ -38,6 +42,9 @@
     kebabAlwaysVisible = false,
     onOpen,
     onAction,
+    dragSource = null,
+    onTreeDragStart,
+    onTreeDragEnd,
   }: Props = $props();
   // The kebab and right-click open the same menu; the kebab hangs from the
   // button rect (anchor) while right-click pins to the cursor.
@@ -49,6 +56,16 @@
   // Mirror the folder indent (12 + depth * 14) plus a 4px nudge so the
   // file icon lands under the folder label, not under the caret.
   const indent = $derived(12 + depth * 14 + 4);
+  const source = $derived<LocalTreeDragSource>({
+    kind: 'file',
+    vaultId,
+    path: node.path,
+  });
+  const dragging = $derived(
+    dragSource?.kind === source.kind &&
+      dragSource.vaultId === source.vaultId &&
+      dragSource.path === source.path,
+  );
 
   const items = $derived<MenuItem[]>([
     favorited
@@ -80,13 +97,18 @@
   <div
     class="row"
     class:active
+    class:dragging
+    draggable="true"
     style="padding-left: {indent}px;"
     oncontextmenu={openMenu}
+    ondragstart={(event) => onTreeDragStart?.(source, event)}
+    ondragend={() => onTreeDragEnd?.()}
   >
     <button
       type="button"
       class="activate"
       aria-current={active ? 'page' : undefined}
+      draggable="false"
       onclick={() => onOpen?.(noteKey(vaultId, node.path))}
     >
       <span class="spacer" aria-hidden="true"></span>
@@ -101,6 +123,7 @@
       class:always-visible={kebabAlwaysVisible}
       aria-label={`Actions for ${node.name}`}
       title={`Actions for ${node.name}`}
+      draggable="false"
       onclick={openKebabMenu}
     >
       <Icon name="dots" size={14} weight="bold" />
@@ -147,6 +170,14 @@
     background: var(--rd-active);
     color: var(--rd-ink-1);
     font-weight: 500;
+  }
+
+  .row.dragging {
+    opacity: 0.48;
+  }
+
+  .row.dragging .activate {
+    cursor: grabbing;
   }
 
   .activate {

--- a/packages/ui/src/lib/local-editor/FilesPanel.svelte
+++ b/packages/ui/src/lib/local-editor/FilesPanel.svelte
@@ -4,6 +4,15 @@
   import VaultFilterPopover from './VaultFilterPopover.svelte';
   import FilesPanelFooter from './FilesPanelFooter.svelte';
   import type { AccentName } from '../primitives/accent';
+  import {
+    LOCAL_TREE_DRAG_MIME,
+    parseLocalTreeDragSource,
+    resolveLocalTreeDrop,
+    serializeLocalTreeDragSource,
+    type LocalTreeDragSource,
+    type LocalTreeDropTarget,
+    type LocalTreeMoveDrop,
+  } from './tree-drag-drop';
   import type {
     LocalTreeAction,
     LocalTreeNode,
@@ -61,6 +70,7 @@
     /** Navigate to the vault root. */
     onOpenVault?: (key: string) => void;
     onTreeAction?: (action: LocalTreeAction) => void;
+    onTreeMoveDrop?: (move: LocalTreeMoveDrop) => void;
     /** Add/remove a vault id from the hide-list. */
     onToggleVaultHidden?: (vaultId: string) => void;
     /** Create a new vault (footer affordance). The host collects a name. */
@@ -90,11 +100,14 @@
     onOpenFolder,
     onOpenVault,
     onTreeAction,
+    onTreeMoveDrop,
     onToggleVaultHidden,
     onNewVault,
   }: Props = $props();
 
   let filterOpen = $state(false);
+  let dragSource = $state<LocalTreeDragSource | null>(null);
+  let dragOverTarget = $state<LocalTreeDropTarget | null>(null);
 
   // The vault groups the rail renders. When the host supplies an explicit
   // set, use it (the multi-vault rail); otherwise synthesize a single
@@ -136,9 +149,87 @@
   // The rail renders only the groups the user hasn't hidden. Hiding every
   // vault empties the body; the filter stays available to bring them back.
   const visibleGroups = $derived(groups.filter((g) => !hidden.has(g.id)));
+
+  function isSameDropTarget(
+    left: LocalTreeDropTarget | null,
+    right: LocalTreeDropTarget,
+  ): boolean {
+    return left?.kind === right.kind && left.vaultId === right.vaultId && left.path === right.path;
+  }
+
+  function readTreeDragSource(event: DragEvent): LocalTreeDragSource | null {
+    if (dragSource) return dragSource;
+    return parseLocalTreeDragSource(event.dataTransfer?.getData(LOCAL_TREE_DRAG_MIME) ?? null);
+  }
+
+  function clearTreeDragState(): void {
+    dragSource = null;
+    dragOverTarget = null;
+  }
+
+  function handleTreeDragStart(source: LocalTreeDragSource, event: DragEvent): void {
+    dragSource = source;
+    dragOverTarget = null;
+    if (!event.dataTransfer) return;
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData(LOCAL_TREE_DRAG_MIME, serializeLocalTreeDragSource(source));
+    event.dataTransfer.setData('text/plain', source.path);
+  }
+
+  function handleTreeDropTargetOver(target: LocalTreeDropTarget, event: DragEvent): void {
+    const source = readTreeDragSource(event);
+    if (!source || !event.dataTransfer) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    dragOverTarget = target;
+    event.dataTransfer.dropEffect = resolveLocalTreeDrop(source, target).valid ? 'move' : 'none';
+  }
+
+  function handleTreeDropTargetLeave(target: LocalTreeDropTarget, event: DragEvent): void {
+    event.stopPropagation();
+    const currentTarget = event.currentTarget;
+    const relatedTarget = event.relatedTarget;
+    if (
+      currentTarget instanceof Node &&
+      relatedTarget instanceof Node &&
+      currentTarget.contains(relatedTarget)
+    ) {
+      return;
+    }
+    if (isSameDropTarget(dragOverTarget, target)) dragOverTarget = null;
+  }
+
+  function handleTreeDropTargetDrop(target: LocalTreeDropTarget, event: DragEvent): void {
+    const source = readTreeDragSource(event);
+    event.preventDefault();
+    event.stopPropagation();
+    clearTreeDragState();
+    if (!source) return;
+
+    const resolution = resolveLocalTreeDrop(source, target);
+    if (resolution.valid) onTreeMoveDrop?.(resolution.move);
+  }
+
+  function handlePanelDragOver(event: DragEvent): void {
+    if (!dragSource || !event.dataTransfer) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'none';
+  }
+
+  function handlePanelDrop(event: DragEvent): void {
+    if (!dragSource) return;
+    event.preventDefault();
+    clearTreeDragState();
+  }
 </script>
 
-<aside class="files-panel" aria-label="Vault files">
+<aside
+  class="files-panel"
+  aria-label="Vault files"
+  ondragover={handlePanelDragOver}
+  ondrop={handlePanelDrop}
+>
   <header class="panel-header">
     <div class="title-row">
       <h2>Files &amp; Vaults</h2>
@@ -190,6 +281,13 @@
             {onOpenFolder}
             {onOpenVault}
             {onTreeAction}
+            {dragSource}
+            {dragOverTarget}
+            onTreeDragStart={handleTreeDragStart}
+            onTreeDragEnd={clearTreeDragState}
+            onTreeDropTargetOver={handleTreeDropTargetOver}
+            onTreeDropTargetLeave={handleTreeDropTargetLeave}
+            onTreeDropTargetDrop={handleTreeDropTargetDrop}
           />
         {/each}
       </nav>

--- a/packages/ui/src/lib/local-editor/FolderNode.svelte
+++ b/packages/ui/src/lib/local-editor/FolderNode.svelte
@@ -6,6 +6,11 @@
   import FolderNode from './FolderNode.svelte';
   import { folderKey } from './expansion';
   import { ROOT_DEFAULT_COLOR, resolveFolderColor } from './folder-presentation';
+  import {
+    resolveLocalTreeDrop,
+    type LocalTreeDragSource,
+    type LocalTreeDropTarget,
+  } from './tree-drag-drop';
   import type { LocalFolderNode, LocalTreeAction, LocalTreeNode } from './types';
   import type { MenuItem } from '../menus/ContextMenu.svelte';
 
@@ -53,6 +58,13 @@
         collapsing. When unset, that branch is a no-op. */
     onOpenFolder?: (key: string) => void;
     onAction?: (action: LocalTreeAction) => void;
+    dragSource?: LocalTreeDragSource | null;
+    dragOverTarget?: LocalTreeDropTarget | null;
+    onTreeDragStart?: (source: LocalTreeDragSource, event: DragEvent) => void;
+    onTreeDragEnd?: () => void;
+    onTreeDropTargetOver?: (target: LocalTreeDropTarget, event: DragEvent) => void;
+    onTreeDropTargetLeave?: (target: LocalTreeDropTarget, event: DragEvent) => void;
+    onTreeDropTargetDrop?: (target: LocalTreeDropTarget, event: DragEvent) => void;
   }
 
   let {
@@ -70,6 +82,13 @@
     onOpen,
     onOpenFolder,
     onAction,
+    dragSource = null,
+    dragOverTarget = null,
+    onTreeDragStart,
+    onTreeDragEnd,
+    onTreeDropTargetOver,
+    onTreeDropTargetLeave,
+    onTreeDropTargetDrop,
   }: Props = $props();
 
   // The kebab and right-click open the same menu; the kebab hangs from the
@@ -87,6 +106,32 @@
   // count shown on the folder row.
   const count = $derived(countNotes(node.children));
   const folderColor = $derived(resolveFolderColor(node.metadata, inheritedColor));
+  const source = $derived<LocalTreeDragSource>({
+    kind: 'folder',
+    vaultId,
+    path: node.path,
+  });
+  const dropTarget = $derived<LocalTreeDropTarget>({
+    kind: 'folder',
+    vaultId,
+    path: node.path,
+  });
+  const dragging = $derived(
+    dragSource?.kind === source.kind &&
+      dragSource.vaultId === source.vaultId &&
+      dragSource.path === source.path,
+  );
+  const dropState = $derived.by<'valid' | 'invalid' | null>(() => {
+    if (!dragSource || !dragOverTarget) return null;
+    if (
+      dragOverTarget.kind !== dropTarget.kind ||
+      dragOverTarget.vaultId !== dropTarget.vaultId ||
+      dragOverTarget.path !== dropTarget.path
+    ) {
+      return null;
+    }
+    return resolveLocalTreeDrop(dragSource, dropTarget).valid ? 'valid' : 'invalid';
+  });
 
   const items = $derived<MenuItem[]>([
     { label: 'New Note', onSelect: () => onAction?.({ kind: 'folder', action: 'new-note', path: node.path }) },
@@ -145,21 +190,37 @@
   <div
     class="row"
     class:active
+    class:dragging
+    class:drop-valid={dropState === 'valid'}
+    class:drop-invalid={dropState === 'invalid'}
+    draggable="true"
     style="padding-left: {indent}px;"
     oncontextmenu={openMenu}
+    ondragstart={(event) => onTreeDragStart?.(source, event)}
+    ondragend={() => onTreeDragEnd?.()}
+    ondragover={(event) => onTreeDropTargetOver?.(dropTarget, event)}
+    ondragleave={(event) => onTreeDropTargetLeave?.(dropTarget, event)}
+    ondrop={(event) => onTreeDropTargetDrop?.(dropTarget, event)}
   >
     <button
       type="button"
       class="caret"
       aria-label={open ? `Collapse ${node.name}` : `Expand ${node.name}`}
       aria-expanded={open}
+      draggable="false"
       onclick={handleCaretClick}
     >
       <span class="chev" class:collapsed={!open} aria-hidden="true">
         <Icon name="chevron-down" size={12} weight="bold" />
       </span>
     </button>
-    <button type="button" class="activate" onclick={handleClick}>
+    <button
+      type="button"
+      class="activate"
+      aria-current={active ? 'page' : undefined}
+      draggable="false"
+      onclick={handleClick}
+    >
       <FolderIcon color={folderColor} size="sm" variant="filled" label={`${node.name} folder`} />
       <span class="name">{node.name}</span>
     </button>
@@ -170,6 +231,7 @@
       class:always-visible={kebabAlwaysVisible}
       aria-label={`Actions for ${node.name}`}
       title={`Actions for ${node.name}`}
+      draggable="false"
       onclick={openKebabMenu}
     >
       <Icon name="dots" size={14} weight="bold" />
@@ -195,6 +257,13 @@
             {onOpen}
             {onOpenFolder}
             {onAction}
+            {dragSource}
+            {dragOverTarget}
+            {onTreeDragStart}
+            {onTreeDragEnd}
+            {onTreeDropTargetOver}
+            {onTreeDropTargetLeave}
+            {onTreeDropTargetDrop}
           />
         {:else}
           <FileNode
@@ -206,6 +275,9 @@
             {kebabAlwaysVisible}
             {onOpen}
             {onAction}
+            {dragSource}
+            {onTreeDragStart}
+            {onTreeDragEnd}
           />
         {/if}
       {/each}
@@ -247,6 +319,28 @@
     background: var(--rd-active);
     color: var(--rd-ink-1);
     font-weight: 500;
+  }
+
+  .row.dragging {
+    opacity: 0.48;
+  }
+
+  .row.drop-valid {
+    background: color-mix(in srgb, var(--rd-active) 78%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--rd-ink-3) 34%, transparent);
+  }
+
+  .row.drop-invalid {
+    background: color-mix(in srgb, var(--rd-danger-ink, #a13a3a) 12%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--rd-danger-ink, #a13a3a) 42%, transparent);
+  }
+
+  .row.dragging .activate {
+    cursor: grabbing;
+  }
+
+  .row.drop-invalid .activate {
+    cursor: not-allowed;
   }
 
   .caret {

--- a/packages/ui/src/lib/local-editor/LocalEditorMobileShell.svelte
+++ b/packages/ui/src/lib/local-editor/LocalEditorMobileShell.svelte
@@ -20,6 +20,7 @@
   import Icon from '../primitives/Icon.svelte';
   import type { AccentName } from '../primitives/accent';
   import type { BreadcrumbItem } from '../primitives/Breadcrumb.svelte';
+  import type { LocalTreeMoveDrop } from './tree-drag-drop';
   import type {
     LocalTreeAction,
     LocalTreeNode,
@@ -74,6 +75,7 @@
     onOpenFolder?: (key: string) => void;
     onOpenVault?: (key: string) => void;
     onTreeAction?: (action: LocalTreeAction) => void;
+    onTreeMoveDrop?: (move: LocalTreeMoveDrop) => void;
     onToggleVaultHidden?: (vaultId: string) => void;
     /** Create a new vault (files-rail footer). The host collects a name. */
     onNewVault?: () => void;
@@ -120,6 +122,7 @@
     onOpenFolder,
     onOpenVault,
     onTreeAction,
+    onTreeMoveDrop,
     onToggleVaultHidden,
     onNewVault,
     navOpen = $bindable(false),
@@ -245,6 +248,7 @@
             {onToggleFolder}
             {onToggleVault}
             {onTreeAction}
+            {onTreeMoveDrop}
             {onToggleVaultHidden}
             {onNewVault}
           />

--- a/packages/ui/src/lib/local-editor/LocalEditorShell.svelte
+++ b/packages/ui/src/lib/local-editor/LocalEditorShell.svelte
@@ -6,6 +6,7 @@
   import PrimaryRail, { type RailNavId } from './primary-rail/PrimaryRail.svelte';
   import type { AccentName } from '../primitives/accent';
   import type { BreadcrumbItem } from '../primitives/Breadcrumb.svelte';
+  import type { LocalTreeMoveDrop } from './tree-drag-drop';
   import type {
     LocalTreeAction,
     LocalTreeNode,
@@ -98,6 +99,7 @@
     /** Navigate to the vault root. */
     onOpenVault?: (key: string) => void;
     onTreeAction?: (action: LocalTreeAction) => void;
+    onTreeMoveDrop?: (move: LocalTreeMoveDrop) => void;
     /** Add/remove a vault id from the hide-list. */
     onToggleVaultHidden?: (vaultId: string) => void;
     /** Create a new vault (files-rail footer). The host collects a name. */
@@ -150,6 +152,7 @@
     onOpenFolder,
     onOpenVault,
     onTreeAction,
+    onTreeMoveDrop,
     onToggleVaultHidden,
     onNewVault,
     onResizeRail,
@@ -202,6 +205,7 @@
       {onOpenFolder}
       {onOpenVault}
       {onTreeAction}
+      {onTreeMoveDrop}
       {onToggleVaultHidden}
       {onNewVault}
     />

--- a/packages/ui/src/lib/local-editor/VaultGroup.svelte
+++ b/packages/ui/src/lib/local-editor/VaultGroup.svelte
@@ -9,6 +9,11 @@
   import FolderNode from './FolderNode.svelte';
   import { vaultKey } from './expansion';
   import { ROOT_DEFAULT_COLOR, resolveFolderColor } from './folder-presentation';
+  import {
+    resolveLocalTreeDrop,
+    type LocalTreeDragSource,
+    type LocalTreeDropTarget,
+  } from './tree-drag-drop';
   import type { LocalFolderMetadata, LocalTreeAction, LocalTreeNode } from './types';
 
   interface Props {
@@ -59,6 +64,13 @@
         row click. */
     onOpenFolder?: (key: string) => void;
     onTreeAction?: (action: LocalTreeAction) => void;
+    dragSource?: LocalTreeDragSource | null;
+    dragOverTarget?: LocalTreeDropTarget | null;
+    onTreeDragStart?: (source: LocalTreeDragSource, event: DragEvent) => void;
+    onTreeDragEnd?: () => void;
+    onTreeDropTargetOver?: (target: LocalTreeDropTarget, event: DragEvent) => void;
+    onTreeDropTargetLeave?: (target: LocalTreeDropTarget, event: DragEvent) => void;
+    onTreeDropTargetDrop?: (target: LocalTreeDropTarget, event: DragEvent) => void;
   }
 
   let {
@@ -82,6 +94,13 @@
     onOpenVault,
     onOpenFolder,
     onTreeAction,
+    dragSource = null,
+    dragOverTarget = null,
+    onTreeDragStart,
+    onTreeDragEnd,
+    onTreeDropTargetOver,
+    onTreeDropTargetLeave,
+    onTreeDropTargetDrop,
   }: Props = $props();
 
   const key = $derived(vaultKey(vaultId));
@@ -92,6 +111,22 @@
   const active = $derived(activeVaultId === key);
   const inheritedColor = $derived(resolveFolderColor(metadata, ROOT_DEFAULT_COLOR));
   const customColor = $derived(colorHex ?? (metadata?.color && metadata.color !== 'inherit' ? metadata.color : null));
+  const dropTarget = $derived<LocalTreeDropTarget>({
+    kind: 'vault',
+    vaultId,
+    path: '',
+  });
+  const dropState = $derived.by<'valid' | 'invalid' | null>(() => {
+    if (!dragSource || !dragOverTarget) return null;
+    if (
+      dragOverTarget.kind !== dropTarget.kind ||
+      dragOverTarget.vaultId !== dropTarget.vaultId ||
+      dragOverTarget.path !== dropTarget.path
+    ) {
+      return null;
+    }
+    return resolveLocalTreeDrop(dragSource, dropTarget).valid ? 'valid' : 'invalid';
+  });
 
   // The kebab and right-click open the same menu; the kebab hangs from the
   // button rect (anchor) while right-click pins to the cursor.
@@ -134,8 +169,25 @@
 
 <div class="vault-block">
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="vault-header" class:active data-testid="vault-row" oncontextmenu={openMenu}>
-    <button type="button" class="activate" onclick={handleClick} aria-expanded={open}>
+  <div
+    class="vault-header"
+    class:active
+    class:drop-valid={dropState === 'valid'}
+    class:drop-invalid={dropState === 'invalid'}
+    data-testid="vault-row"
+    oncontextmenu={openMenu}
+    ondragover={(event) => onTreeDropTargetOver?.(dropTarget, event)}
+    ondragleave={(event) => onTreeDropTargetLeave?.(dropTarget, event)}
+    ondrop={(event) => onTreeDropTargetDrop?.(dropTarget, event)}
+  >
+    <button
+      type="button"
+      class="activate"
+      onclick={handleClick}
+      aria-expanded={open}
+      aria-current={active ? 'page' : undefined}
+      draggable="false"
+    >
       <span class="chev" class:collapsed={!open} aria-hidden="true">
         <Icon name="chevron-down" size={12} weight="bold" />
       </span>
@@ -152,6 +204,7 @@
       class:always-visible={kebabAlwaysVisible}
       aria-label={`Actions for ${vaultName}`}
       title={`Actions for ${vaultName}`}
+      draggable="false"
       onclick={openKebabMenu}
     >
       <Icon name="dots" size={16} weight="bold" />
@@ -176,6 +229,13 @@
             onOpen={onOpenFile}
             {onOpenFolder}
             onAction={onTreeAction}
+            {dragSource}
+            {dragOverTarget}
+            {onTreeDragStart}
+            {onTreeDragEnd}
+            {onTreeDropTargetOver}
+            {onTreeDropTargetLeave}
+            {onTreeDropTargetDrop}
           />
         {:else}
           <FileNode
@@ -186,6 +246,9 @@
             {kebabAlwaysVisible}
             onOpen={onOpenFile}
             onAction={onTreeAction}
+            {dragSource}
+            {onTreeDragStart}
+            {onTreeDragEnd}
           />
         {/if}
       {/each}
@@ -230,6 +293,20 @@
   .vault-header.active {
     background: var(--rd-active);
     color: var(--rd-ink-1);
+  }
+
+  .vault-header.drop-valid {
+    background: color-mix(in srgb, var(--rd-active) 78%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--rd-ink-3) 34%, transparent);
+  }
+
+  .vault-header.drop-invalid {
+    background: color-mix(in srgb, var(--rd-danger-ink, #a13a3a) 12%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--rd-danger-ink, #a13a3a) 42%, transparent);
+  }
+
+  .vault-header.drop-invalid .activate {
+    cursor: not-allowed;
   }
 
   .activate {

--- a/packages/ui/src/lib/local-editor/tree-drag-drop.test.ts
+++ b/packages/ui/src/lib/local-editor/tree-drag-drop.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseLocalTreeDragSource,
+  resolveLocalTreeDrop,
+  serializeLocalTreeDragSource,
+  type LocalTreeDragSource,
+} from "./tree-drag-drop";
+
+const fileSource: LocalTreeDragSource = {
+  kind: "file",
+  vaultId: "demo-vault",
+  path: "projects/active/launch.md",
+};
+
+const folderSource: LocalTreeDragSource = {
+  kind: "folder",
+  vaultId: "demo-vault",
+  path: "projects/active",
+};
+
+describe("local tree drag/drop move guards", () => {
+  it("moves a file inside a same-vault folder", () => {
+    expect(
+      resolveLocalTreeDrop(fileSource, {
+        kind: "folder",
+        vaultId: "demo-vault",
+        path: "archive",
+      }),
+    ).toEqual({
+      valid: true,
+      move: {
+        source: fileSource,
+        target: {
+          kind: "folder",
+          vaultId: "demo-vault",
+          path: "archive",
+        },
+        destinationFolderPath: "archive",
+        targetPath: "archive/launch.md",
+      },
+    });
+  });
+
+  it("supports explicit moves to the vault root", () => {
+    expect(
+      resolveLocalTreeDrop(fileSource, {
+        kind: "vault",
+        vaultId: "demo-vault",
+        path: "",
+      }),
+    ).toEqual({
+      valid: true,
+      move: {
+        source: fileSource,
+        target: {
+          kind: "vault",
+          vaultId: "demo-vault",
+          path: "",
+        },
+        destinationFolderPath: "",
+        targetPath: "launch.md",
+      },
+    });
+  });
+
+  it("rejects folder drops onto itself or descendants", () => {
+    expect(
+      resolveLocalTreeDrop(folderSource, {
+        kind: "folder",
+        vaultId: "demo-vault",
+        path: "projects/active",
+      }),
+    ).toEqual({ valid: false, reason: "self" });
+
+    expect(
+      resolveLocalTreeDrop(folderSource, {
+        kind: "folder",
+        vaultId: "demo-vault",
+        path: "projects/active/research",
+      }),
+    ).toEqual({ valid: false, reason: "descendant" });
+  });
+
+  it("rejects cross-vault and same-location no-op drops", () => {
+    expect(
+      resolveLocalTreeDrop(fileSource, {
+        kind: "folder",
+        vaultId: "other-vault",
+        path: "archive",
+      }),
+    ).toEqual({ valid: false, reason: "cross-vault" });
+
+    expect(
+      resolveLocalTreeDrop(fileSource, {
+        kind: "folder",
+        vaultId: "demo-vault",
+        path: "projects/active",
+      }),
+    ).toEqual({ valid: false, reason: "same-location" });
+
+    expect(
+      resolveLocalTreeDrop(
+        {
+          kind: "file",
+          vaultId: "demo-vault",
+          path: "root-note.md",
+        },
+        {
+          kind: "vault",
+          vaultId: "demo-vault",
+          path: "",
+        },
+      ),
+    ).toEqual({ valid: false, reason: "same-location" });
+  });
+
+  it("round-trips only valid drag source payloads", () => {
+    expect(parseLocalTreeDragSource(serializeLocalTreeDragSource(fileSource))).toEqual(fileSource);
+    expect(parseLocalTreeDragSource(null)).toBeNull();
+    expect(parseLocalTreeDragSource("{")).toBeNull();
+    expect(parseLocalTreeDragSource(JSON.stringify({ kind: "vault", vaultId: "demo", path: "" }))).toBeNull();
+  });
+});

--- a/packages/ui/src/lib/local-editor/tree-drag-drop.ts
+++ b/packages/ui/src/lib/local-editor/tree-drag-drop.ts
@@ -1,0 +1,102 @@
+export const LOCAL_TREE_DRAG_MIME = "application/x-kb1-tree-node";
+
+export interface LocalTreeDragSource {
+  kind: "file" | "folder";
+  vaultId: string;
+  path: string;
+}
+
+export interface LocalTreeDropTarget {
+  kind: "vault" | "folder";
+  vaultId: string;
+  path: string;
+}
+
+export interface LocalTreeMoveDrop {
+  source: LocalTreeDragSource;
+  target: LocalTreeDropTarget;
+  destinationFolderPath: string;
+  targetPath: string;
+}
+
+export type LocalTreeDropRejectionReason =
+  | "cross-vault"
+  | "self"
+  | "descendant"
+  | "same-location";
+
+export type LocalTreeDropResolution =
+  | { valid: true; move: LocalTreeMoveDrop }
+  | { valid: false; reason: LocalTreeDropRejectionReason };
+
+export function serializeLocalTreeDragSource(source: LocalTreeDragSource): string {
+  return JSON.stringify(source);
+}
+
+export function parseLocalTreeDragSource(value: string | null): LocalTreeDragSource | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<LocalTreeDragSource>;
+    if (
+      (parsed.kind === "file" || parsed.kind === "folder") &&
+      typeof parsed.vaultId === "string" &&
+      typeof parsed.path === "string" &&
+      parsed.path.length > 0
+    ) {
+      return {
+        kind: parsed.kind,
+        vaultId: parsed.vaultId,
+        path: parsed.path,
+      };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export function parentTreePath(path: string): string {
+  const index = path.lastIndexOf("/");
+  return index === -1 ? "" : path.slice(0, index);
+}
+
+export function leafTreeName(path: string): string {
+  return path.split("/").filter(Boolean).at(-1) ?? path;
+}
+
+export function joinTreePath(parent: string, name: string): string {
+  return parent ? `${parent}/${name}` : name;
+}
+
+export function resolveLocalTreeDrop(
+  source: LocalTreeDragSource,
+  target: LocalTreeDropTarget,
+): LocalTreeDropResolution {
+  if (source.vaultId !== target.vaultId) {
+    return { valid: false, reason: "cross-vault" };
+  }
+
+  const destinationFolderPath = target.path;
+  if (source.kind === "folder") {
+    if (destinationFolderPath === source.path) {
+      return { valid: false, reason: "self" };
+    }
+    if (destinationFolderPath.startsWith(`${source.path}/`)) {
+      return { valid: false, reason: "descendant" };
+    }
+  }
+
+  if (parentTreePath(source.path) === destinationFolderPath) {
+    return { valid: false, reason: "same-location" };
+  }
+
+  return {
+    valid: true,
+    move: {
+      source,
+      target,
+      destinationFolderPath,
+      targetPath: joinTreePath(destinationFolderPath, leafTreeName(source.path)),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add same-vault tree drag/drop move behavior to the daemon web UI
- keep Move dialog root/no-op behavior safe by requiring an explicit non-current selection
- add shared drag/drop guard tests plus daemon web component tests for file move, folder move, root move, invalid descendant drop, and outside-panel cancel

## Verification
- pnpm --dir local --filter @kb-1/ui test
- pnpm --dir local --filter @kb-1/ui typecheck
- pnpm --dir local --filter @kb-1/web test
- pnpm --dir local --filter @kb-1/web typecheck
- pnpm --dir local check
- Browser verified daemon UI at http://127.0.0.1:7390/demo-vault: file->folder, folder->folder, folder->root, invalid descendant drop, outside-tree cancel