### PR TITLE
Add gated plaintext mention autocomplete

### DIFF
--- a/packages/editor/src/lib/MentionAutocompletePopover.svelte
+++ b/packages/editor/src/lib/MentionAutocompletePopover.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  import { Avatar, accentForId } from '@kb-1/ui';
+  import type { OrgPerson } from './markdown-core';
+
+  interface Props {
+    people: readonly OrgPerson[];
+    selectedIndex: number;
+    onSelect: (person: OrgPerson) => void;
+  }
+
+  let { people, selectedIndex, onSelect }: Props = $props();
+
+  let listEl: HTMLUListElement | undefined = $state();
+
+  function initialFor(person: OrgPerson): string {
+    return (person.name[0] ?? person.email[0] ?? '?').toUpperCase();
+  }
+
+  $effect(() => {
+    const idx = selectedIndex;
+    if (!listEl) return;
+    const item = listEl.children[idx] as HTMLElement | undefined;
+    item?.scrollIntoView({ block: 'nearest' });
+  });
+</script>
+
+{#if people.length === 0}
+  <div class="kb1-mention-autocomplete-empty">No matches</div>
+{:else}
+  <ul
+    role="listbox"
+    class="kb1-mention-autocomplete-list"
+    bind:this={listEl}
+  >
+    {#each people as person, i}
+      <li
+        role="option"
+        aria-selected={i === selectedIndex}
+        class="kb1-mention-autocomplete-item{i === selectedIndex ? ' selected' : ''}"
+        onmousedown={(event) => {
+          event.preventDefault();
+          onSelect(person);
+        }}
+      >
+        <Avatar
+          kind="human"
+          accent={accentForId(person.id)}
+          letter={initialFor(person)}
+          image={person.image}
+          size={24}
+          ariaLabel={person.name}
+        />
+        <span class="kb1-mention-autocomplete-name">{person.name}</span>
+        <span class="kb1-mention-autocomplete-email">{person.email}</span>
+      </li>
+    {/each}
+  </ul>
+{/if}
+
+<style>
+  :global(.kb1-mention-autocomplete) {
+    position: absolute;
+    display: none;
+    z-index: 50;
+    min-width: 220px;
+    max-width: 340px;
+    max-height: 240px;
+    overflow-y: auto;
+    border: 1px solid var(--rd-border, #d7dee8);
+    border-radius: 8px;
+    background: var(--rd-panel, #ffffff);
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.14);
+  }
+
+  :global(.kb1-mention-autocomplete[data-show='true']) {
+    display: block;
+  }
+
+  .kb1-mention-autocomplete-list {
+    margin: 0;
+    padding: 4px 0;
+    list-style: none;
+  }
+
+  .kb1-mention-autocomplete-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    cursor: pointer;
+    color: var(--rd-ink-1, #1a1d22);
+    font: 500 13px/1.25 var(--rd-ui, system-ui, sans-serif);
+  }
+
+  .kb1-mention-autocomplete-item:hover,
+  .kb1-mention-autocomplete-item.selected {
+    background: var(--rd-hover, rgba(80, 120, 180, 0.12));
+  }
+
+  .kb1-mention-autocomplete-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .kb1-mention-autocomplete-email {
+    min-width: 0;
+    margin-left: auto;
+    overflow: hidden;
+    color: var(--rd-ink-3, #6b7785);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 12px;
+    font-weight: 400;
+  }
+
+  .kb1-mention-autocomplete-empty {
+    padding: 8px 10px;
+    color: var(--rd-ink-3, #6b7785);
+    font: 500 13px/1.25 var(--rd-ui, system-ui, sans-serif);
+  }
+</style>

--- a/packages/editor/src/lib/PlaintextEditor.svelte
+++ b/packages/editor/src/lib/PlaintextEditor.svelte
@@ -31,6 +31,7 @@
     plaintextLinkHover,
   } from './plaintext-link-affordance';
   import { plaintextMentionKeymap } from './plaintext-mention-keymap';
+  import { plaintextMentionAutocomplete } from './plaintext-mention-autocomplete.svelte';
   import { plaintextListKeymap } from './plaintext-list-keymap';
   import { plaintextLinkPaste } from './plaintext-link-paste';
   import { plaintextImageUpload } from './plaintext-image-upload';
@@ -208,6 +209,10 @@
      *  removed), the editor dispatches a `mentionDirectoryChangedEffect`
      *  so the decoration field re-resolves without needing a doc edit. */
     orgPeople?: readonly OrgPerson[];
+    /** Enables cloud people search / insertion for `@` mentions. Off by
+     *  default so daemon contexts can render mention chips from markdown
+     *  without exposing cloud org-directory picker semantics. */
+    enableMentionAutocomplete?: boolean;
     /** Wikilink click handler (Slice 6). Fires with the URL-encoded
      *  target so the host can decode + resolve + navigate. Mirrors
      *  MarkdownEditor's prop of the same name — both editors feed the
@@ -244,6 +249,7 @@
     attachmentSrc,
     livePaths = [],
     orgPeople = [],
+    enableMentionAutocomplete = false,
     onWikilinkClick,
     uploadImage,
     onUploadStart,
@@ -473,6 +479,9 @@
       // handler ran. Caret INSIDE the mention falls through to default
       // delete (typo-fix carve-out for the display name).
       plaintextMentionKeymap(),
+      ...(enableMentionAutocomplete
+        ? [plaintextMentionAutocomplete({ getOrgPeople: stableGetOrgPeople })]
+        : []),
       // Tab / Shift-Tab indent / outdent for list items (Apple lane
       // Feature 3). Gates on lezer `ListItem` ancestry; Tab outside
       // any list falls through (returns false) so browser focus

--- a/packages/editor/src/lib/markdown-core.ts
+++ b/packages/editor/src/lib/markdown-core.ts
@@ -23,6 +23,11 @@ export function parseMentionUrl(href: string): MentionParts | null {
   return { email: decoded };
 }
 
+export function formatMentionUrl(email: string): string {
+  const encoded = encodeURIComponent(email).replace(/%40/g, '@');
+  return `${MENTION_URL_SCHEME}${encoded}`;
+}
+
 export interface OrgPerson {
   id: string;
   email: string;

--- a/packages/editor/src/lib/plaintext-mention-autocomplete-helpers.ts
+++ b/packages/editor/src/lib/plaintext-mention-autocomplete-helpers.ts
@@ -1,0 +1,47 @@
+import type { EditorState } from '@codemirror/state';
+import { formatMentionUrl, type OrgPerson } from './markdown-core';
+import { findMentionAt } from './plaintext-mention-keymap';
+
+/** Pattern: `@` preceded by start-of-line or whitespace, then non-whitespace query chars. */
+export const TRIGGER_RE = /(^|[\s])@([^\s]*)$/;
+
+export function getQueryRange(
+  state: EditorState,
+): { query: string; from: number; to: number } | null {
+  const sel = state.selection.main;
+  if (!sel.empty) return null;
+  const cursor = sel.head;
+  const line = state.doc.lineAt(cursor);
+  const textBefore = state.sliceDoc(line.from, cursor);
+  const match = TRIGGER_RE.exec(textBefore);
+  if (!match) return null;
+  const query = match[2] ?? '';
+  const prefixLen = match[1].length;
+  const atOffset = match.index + prefixLen;
+  return {
+    query,
+    from: line.from + atOffset,
+    to: cursor,
+  };
+}
+
+export function formatMentionInsertion(person: OrgPerson): string {
+  return `[${person.name}](${formatMentionUrl(person.email)}) `;
+}
+
+export function isInsideMentionLink(state: EditorState, pos: number): boolean {
+  return findMentionAt(state, pos, -1) !== null;
+}
+
+export function filterPeople(
+  people: readonly OrgPerson[],
+  query: string,
+): readonly OrgPerson[] {
+  const q = query.toLowerCase();
+  if (q.length === 0) return people.slice();
+  return people.filter(
+    (person) =>
+      person.name.toLowerCase().includes(q) ||
+      person.email.toLowerCase().includes(q),
+  );
+}

--- a/packages/editor/src/lib/plaintext-mention-autocomplete.svelte.ts
+++ b/packages/editor/src/lib/plaintext-mention-autocomplete.svelte.ts
@@ -1,0 +1,282 @@
+import {
+  EditorView,
+  ViewPlugin,
+  keymap,
+  type PluginValue,
+  type ViewUpdate,
+} from '@codemirror/view';
+import { Prec, type Extension } from '@codemirror/state';
+import { mount, unmount } from 'svelte';
+import type { OrgPerson } from './markdown-core';
+import MentionAutocompletePopover from './MentionAutocompletePopover.svelte';
+import {
+  filterPeople,
+  formatMentionInsertion,
+  getQueryRange,
+  isInsideMentionLink,
+} from './plaintext-mention-autocomplete-helpers';
+
+interface Controller {
+  isVisible: () => boolean;
+  filteredCount: () => number;
+  cycle: (delta: 1 | -1) => void;
+  selectFocused: () => boolean;
+  hide: () => void;
+}
+
+const controllers = new WeakMap<EditorView, Controller>();
+
+function positionPopover(
+  popoverEl: HTMLElement,
+  caretCoords: { top: number; bottom: number; left: number },
+): void {
+  const margin = 4;
+  const popoverHeight = popoverEl.offsetHeight;
+  const popoverWidth = popoverEl.offsetWidth;
+  const viewportHeight = window.innerHeight;
+  const viewportWidth = window.innerWidth;
+
+  let top = caretCoords.bottom + margin;
+  if (
+    top + popoverHeight > viewportHeight &&
+    caretCoords.top - popoverHeight - margin >= 0
+  ) {
+    top = caretCoords.top - popoverHeight - margin;
+  }
+  let left = caretCoords.left;
+  if (left + popoverWidth > viewportWidth) {
+    left = Math.max(margin, viewportWidth - popoverWidth - margin);
+  }
+
+  popoverEl.style.top = `${String(top)}px`;
+  popoverEl.style.left = `${String(left)}px`;
+}
+
+export function plaintextMentionAutocomplete({
+  getOrgPeople,
+}: {
+  getOrgPeople: () => readonly OrgPerson[];
+}): Extension {
+  const plugin = ViewPlugin.fromClass(
+    class implements PluginValue {
+      private readonly view: EditorView;
+      private readonly popoverEl: HTMLElement;
+      private readonly component: ReturnType<typeof mount>;
+
+      private filteredPeople = $state<readonly OrgPerson[]>([]);
+      private selectedIndex = $state(0);
+      private visible = false;
+      private triggerRange: { from: number; to: number } | null = null;
+      private disposed = false;
+
+      constructor(view: EditorView) {
+        this.view = view;
+
+        this.popoverEl = document.createElement('div');
+        this.popoverEl.className = 'kb1-mention-autocomplete';
+        this.popoverEl.setAttribute('data-show', 'false');
+        document.body.appendChild(this.popoverEl);
+
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const self = this;
+        this.component = mount(MentionAutocompletePopover, {
+          target: this.popoverEl,
+          props: {
+            get people() {
+              return self.filteredPeople;
+            },
+            get selectedIndex() {
+              return self.selectedIndex;
+            },
+            onSelect: (person: OrgPerson) => {
+              self.handleSelect(person);
+            },
+          },
+        });
+
+        controllers.set(view, {
+          isVisible: () => this.visible,
+          filteredCount: () => this.filteredPeople.length,
+          cycle: (delta) => {
+            this.cycle(delta);
+          },
+          selectFocused: () => {
+            const choice = this.filteredPeople[this.selectedIndex];
+            if (!choice) return false;
+            this.handleSelect(choice);
+            return true;
+          },
+          hide: () => {
+            this.hide();
+          },
+        });
+
+        this.refresh();
+      }
+
+      update(update: ViewUpdate): void {
+        if (update.docChanged || update.selectionSet || update.focusChanged) {
+          this.refresh();
+        } else if (this.visible) {
+          this.reposition();
+        }
+      }
+
+      destroy(): void {
+        this.disposed = true;
+        controllers.delete(this.view);
+        void unmount(this.component);
+        this.popoverEl.remove();
+      }
+
+      private refresh(): void {
+        const { state } = this.view;
+
+        if (!this.view.hasFocus || !state.facet(EditorView.editable)) {
+          this.hide();
+          return;
+        }
+
+        const sel = state.selection.main;
+        if (!sel.empty) {
+          this.hide();
+          return;
+        }
+
+        if (isInsideMentionLink(state, sel.head)) {
+          this.hide();
+          return;
+        }
+
+        const range = getQueryRange(state);
+        if (range === null) {
+          this.hide();
+          return;
+        }
+
+        this.filteredPeople = filterPeople(getOrgPeople(), range.query);
+        if (this.filteredPeople.length === 0) {
+          this.selectedIndex = 0;
+        } else {
+          this.selectedIndex = Math.max(
+            0,
+            Math.min(this.selectedIndex, this.filteredPeople.length - 1),
+          );
+        }
+        this.triggerRange = { from: range.from, to: range.to };
+        this.show();
+        this.reposition();
+      }
+
+      private show(): void {
+        if (this.visible) return;
+        this.visible = true;
+        this.popoverEl.setAttribute('data-show', 'true');
+      }
+
+      private hide(): void {
+        if (!this.visible) return;
+        this.visible = false;
+        this.triggerRange = null;
+        this.popoverEl.setAttribute('data-show', 'false');
+      }
+
+      private reposition(): void {
+        if (!this.visible) return;
+        this.view.requestMeasure<{
+          top: number;
+          bottom: number;
+          left: number;
+        } | null>({
+          key: 'kb1-mention-autocomplete-reposition',
+          read: (view) => {
+            if (this.disposed || !this.visible) return null;
+            const cursor = view.state.selection.main.head;
+            return view.coordsAtPos(cursor);
+          },
+          write: (coords) => {
+            if (this.disposed || !this.visible || coords === null) return;
+            positionPopover(this.popoverEl, coords);
+          },
+        });
+      }
+
+      private cycle(delta: 1 | -1): void {
+        const len = this.filteredPeople.length;
+        if (len === 0) return;
+        if (delta === 1) {
+          this.selectedIndex = Math.min(this.selectedIndex + 1, len - 1);
+        } else {
+          this.selectedIndex = Math.max(this.selectedIndex - 1, 0);
+        }
+      }
+
+      private handleSelect(person: OrgPerson): void {
+        if (this.triggerRange === null) return;
+        const { from, to } = this.triggerRange;
+        const insert = formatMentionInsertion(person);
+        this.view.dispatch({
+          changes: { from, to, insert },
+          selection: { anchor: from + insert.length },
+        });
+        this.hide();
+        this.view.focus();
+      }
+    },
+  );
+
+  const handlers = keymap.of([
+    {
+      key: 'ArrowDown',
+      run(view) {
+        const controller = controllers.get(view);
+        if (!controller?.isVisible()) return false;
+        if (controller.filteredCount() === 0) return false;
+        controller.cycle(1);
+        return true;
+      },
+    },
+    {
+      key: 'ArrowUp',
+      run(view) {
+        const controller = controllers.get(view);
+        if (!controller?.isVisible()) return false;
+        if (controller.filteredCount() === 0) return false;
+        controller.cycle(-1);
+        return true;
+      },
+    },
+    {
+      key: 'Enter',
+      run(view) {
+        const controller = controllers.get(view);
+        if (!controller?.isVisible()) return false;
+        if (controller.filteredCount() === 0) {
+          controller.hide();
+          return false;
+        }
+        return controller.selectFocused();
+      },
+    },
+    {
+      key: 'Escape',
+      run(view) {
+        const controller = controllers.get(view);
+        if (!controller?.isVisible()) return false;
+        controller.hide();
+        return true;
+      },
+    },
+    {
+      key: ' ',
+      run(view) {
+        const controller = controllers.get(view);
+        if (!controller?.isVisible()) return false;
+        controller.hide();
+        return false;
+      },
+    },
+  ]);
+
+  return [Prec.high(handlers), plugin];
+}

--- a/packages/editor/src/lib/plaintext-mention-autocomplete.test.ts
+++ b/packages/editor/src/lib/plaintext-mention-autocomplete.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { EditorSelection, EditorState } from '@codemirror/state';
+import type { OrgPerson } from './markdown-core';
+import { plaintextDecorations } from './plaintext-decorations';
+import {
+  TRIGGER_RE,
+  formatMentionInsertion,
+  getQueryRange,
+  isInsideMentionLink,
+} from './plaintext-mention-autocomplete-helpers';
+
+function makeState(doc: string, cursor: number) {
+  return EditorState.create({
+    doc,
+    selection: EditorSelection.single(cursor),
+    extensions: [plaintextDecorations()],
+  });
+}
+
+describe('TRIGGER_RE', () => {
+  it('matches a bare `@` at start of line', () => {
+    expect(TRIGGER_RE.exec('@')).not.toBeNull();
+  });
+
+  it('matches `@alice` after whitespace', () => {
+    const match = TRIGGER_RE.exec('hi @alice');
+    expect(match).not.toBeNull();
+    expect(match?.[2]).toBe('alice');
+  });
+
+  it('matches an empty query immediately after a space', () => {
+    const match = TRIGGER_RE.exec('hi @');
+    expect(match).not.toBeNull();
+    expect(match?.[2]).toBe('');
+  });
+
+  it('does not match mid-word `foo@bar`', () => {
+    expect(TRIGGER_RE.exec('foo@bar')).toBeNull();
+  });
+
+  it('does not match when there is whitespace inside the query', () => {
+    expect(TRIGGER_RE.exec('@ali ce')).toBeNull();
+  });
+});
+
+describe('getQueryRange', () => {
+  it('extracts the right range for `@<query>` at start of line', () => {
+    const doc = '@alice';
+    const range = getQueryRange(makeState(doc, doc.length));
+    expect(range).not.toBeNull();
+    expect(range?.from).toBe(0);
+    expect(range?.to).toBe(doc.length);
+    expect(range?.query).toBe('alice');
+  });
+
+  it('extracts the right range after leading text + space', () => {
+    const doc = 'hi @bob';
+    const range = getQueryRange(makeState(doc, doc.length));
+    expect(range).not.toBeNull();
+    expect(range?.from).toBe(doc.indexOf('@'));
+    expect(range?.to).toBe(doc.length);
+    expect(range?.query).toBe('bob');
+  });
+
+  it('returns the `@` position when query is empty', () => {
+    const doc = 'hi @';
+    const range = getQueryRange(makeState(doc, doc.length));
+    expect(range).not.toBeNull();
+    expect(range?.from).toBe(doc.indexOf('@'));
+    expect(range?.to).toBe(doc.length);
+    expect(range?.query).toBe('');
+  });
+
+  it('returns null when the caret is mid-word adjacent to `@`', () => {
+    const doc = 'foo@bar';
+    expect(getQueryRange(makeState(doc, doc.length))).toBeNull();
+  });
+
+  it('returns null when the selection is non-empty', () => {
+    const doc = '@alice';
+    const state = EditorState.create({
+      doc,
+      selection: EditorSelection.range(0, 3),
+      extensions: [plaintextDecorations()],
+    });
+    expect(getQueryRange(state)).toBeNull();
+  });
+
+  it('respects per-line scope', () => {
+    const doc = 'first line\n@alice';
+    const range = getQueryRange(makeState(doc, doc.length));
+    expect(range).not.toBeNull();
+    expect(range?.from).toBe(doc.indexOf('@'));
+    expect(range?.query).toBe('alice');
+  });
+});
+
+describe('isInsideMentionLink', () => {
+  it('returns true when the caret is inside an existing mention chip', () => {
+    const doc = '[Alice](mention:alice@kb-1.dev)';
+    expect(isInsideMentionLink(makeState(doc, 3), 3)).toBe(true);
+  });
+
+  it('returns false in plain text far from any mention', () => {
+    const doc = 'just some plain text';
+    expect(isInsideMentionLink(makeState(doc, 5), 5)).toBe(false);
+  });
+
+  it('returns false inside a non-mention link', () => {
+    const doc = '[Anthropic](https://anthropic.com)';
+    expect(isInsideMentionLink(makeState(doc, 3), 3)).toBe(false);
+  });
+});
+
+describe('formatMentionInsertion', () => {
+  const alice: OrgPerson = {
+    id: 'user-alice',
+    email: 'alice@kb-1.dev',
+    name: 'Alice',
+    image: null,
+  };
+
+  it('produces `[Name](mention:email) ` with the trailing space', () => {
+    expect(formatMentionInsertion(alice)).toBe(
+      '[Alice](mention:alice@kb-1.dev) ',
+    );
+  });
+
+  it('ends with exactly one space', () => {
+    const out = formatMentionInsertion(alice);
+    expect(out.endsWith(') ')).toBe(true);
+    expect(out.endsWith(')  ')).toBe(false);
+  });
+
+  it('encodes unsafe email characters while keeping `@` readable', () => {
+    const person: OrgPerson = {
+      id: 'user-percent',
+      email: 'foo%bar@kb-1.dev',
+      name: 'Percent',
+      image: null,
+    };
+    expect(formatMentionInsertion(person)).toBe(
+      '[Percent](mention:foo%25bar@kb-1.dev) ',
+    );
+  });
+});

--- a/packages/editor/src/lib/plaintext-mention-keymap.ts
+++ b/packages/editor/src/lib/plaintext-mention-keymap.ts
@@ -36,7 +36,7 @@ import { extractLinkUrl } from './plaintext-link-affordance';
  * Internal helper — callers go through the keymap's `run` handlers
  * below.
  */
-function findMentionAt(
+export function findMentionAt(
   state: EditorState,
   pos: number,
   side: -1 | 1,


### PR DESCRIPTION
## Summary\n- Port KB-1 plaintext @mention autocomplete into the shared editor package\n- Keep autocomplete disabled by default so daemon UI can render mention chips without cloud people-picker semantics\n- Export the mention helpers needed by the autocomplete path\n\n## Verification\n- pnpm --filter @kb-1/editor test -- plaintext-mention-autocomplete.test.ts\n- pnpm --filter @kb-1/editor typecheck\n- pnpm check from kb-1-cloud main worktree\n- Browser: cloud editor opens Marcus picker and inserts mention chip; daemon UI typing @mar does not show picker