### PR TITLE
Apply bug-train daemon UI parity fixes

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -2162,7 +2162,7 @@
 </script>
 
 <svelte:head>
-  <title>KB-1 Editor</title>
+  <title>KB-1</title>
 </svelte:head>
 
 <!-- Shared canvas body. Both shells render identical content — the

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -879,10 +879,7 @@
 
   function openRawFile(vaultId: string, path: string): void {
     const url = kbService.rawSrc(vaultId, path);
-    const opened = window.open(url, '_blank', 'noopener,noreferrer');
-    if (!opened) {
-      window.location.assign(url);
-    }
+    window.open(url, '_blank', 'noopener,noreferrer');
   }
 
   function openFilePath(vaultId: string, path: string): void {
@@ -2222,6 +2219,10 @@
             href={kbService.rawSrc(vaultId, activeAttachmentNode.path)}
             target="_blank"
             rel="noreferrer"
+            onclick={(event) => {
+              event.preventDefault();
+              openRawFile(vaultId, activeAttachmentNode.path);
+            }}
           >
             Open {activeAttachmentNode.name}
           </a>

--- a/apps/web/src/test/local-editor-route.test.ts
+++ b/apps/web/src/test/local-editor-route.test.ts
@@ -108,6 +108,7 @@ describe("local editor route", () => {
     mocks.providers = [];
     mocks.delayedSyncPaths.clear();
     mocks.pendingSyncs.clear();
+    document.title = "";
     // The harness builds the app-state store against `localStorage`, which
     // persists tree expansion and vault filters. Clear it so each test
     // starts from the clean first-load defaults rather than inheriting a
@@ -250,6 +251,14 @@ describe("local editor route", () => {
         );
       }),
     );
+  });
+
+  it("uses a stable product tab title", async () => {
+    render(AppStateHarness);
+
+    expect(await screen.findByLabelText("Markdown editor")).toBeTruthy();
+    expect(document.title).toBe("KB-1");
+    expect(document.title).not.toContain("demo-vault");
   });
 
   it("fetches the vault tree, renders it, and rebinds the editor when a file is opened", async () => {

--- a/apps/web/src/test/local-editor-route.test.ts
+++ b/apps/web/src/test/local-editor-route.test.ts
@@ -380,9 +380,24 @@ describe("local editor route", () => {
     expect((link as HTMLAnchorElement).getAttribute("href")).toBe(
       "/api/vaults/demo-vault/raw/attachments/live.png",
     );
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockImplementation(() => ({ closed: false }) as Window);
+
+    await fireEvent.click(link);
+
+    expect(openSpy).toHaveBeenCalledWith(
+      "/api/vaults/demo-vault/raw/attachments/live.png",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(mocks.goto).not.toHaveBeenCalled();
+    expect(window.location.pathname).toBe("/demo-vault/attachments/live.png");
     await waitFor(() => {
       expect(screen.queryByLabelText("Markdown editor")).toBeNull();
     });
+
+    openSpy.mockRestore();
   });
 
   it("hides the vault tree when the vault is toggled off in the filter", async () => {

--- a/packages/ui/src/lib/local-editor/FileNode.svelte
+++ b/packages/ui/src/lib/local-editor/FileNode.svelte
@@ -152,6 +152,7 @@
     align-items: center;
     gap: 7px;
     width: 100%;
+    box-sizing: border-box;
     min-height: 28px;
     border-radius: 6px;
     background: transparent;

--- a/packages/ui/src/lib/local-editor/FilesPanel.svelte
+++ b/packages/ui/src/lib/local-editor/FilesPanel.svelte
@@ -356,7 +356,8 @@
 
   .panel-body {
     min-height: 0;
-    overflow: auto;
+    overflow-x: hidden;
+    overflow-y: auto;
     padding: 6px;
   }
 

--- a/packages/ui/src/lib/local-editor/FolderNode.svelte
+++ b/packages/ui/src/lib/local-editor/FolderNode.svelte
@@ -302,6 +302,7 @@
     align-items: center;
     gap: 7px;
     width: 100%;
+    box-sizing: border-box;
     min-height: 28px;
     border-radius: 6px;
     background: transparent;

--- a/packages/ui/src/lib/local-editor/VaultGroup.svelte
+++ b/packages/ui/src/lib/local-editor/VaultGroup.svelte
@@ -277,6 +277,7 @@
     align-items: center;
     gap: 8px;
     width: 100%;
+    box-sizing: border-box;
     padding: 5px 6px;
     border-radius: 6px;
     background: transparent;


### PR DESCRIPTION
Daemon-side parity for the KB-1 Cloud bug train that has already landed in cloud main.\n\nIncludes three commits that cloud main now points at via the submodule:\n- Keep raw image opens in a new tab\n- Keep files rail left aligned\n- Use stable KB-1 tab title\n\nLocal verification already run from the cloud workspace:\n- pnpm --filter @kb-1/web exec vitest run src/test/local-editor-route.test.ts\n- pnpm --filter @kb-1/ui typecheck\n- pnpm --filter @kb-1/daemon exec vitest run src/main.test.ts -t "drives the full create -> list -> rename -> delete lifecycle live, with no restart"\n\nImportant: merge with a merge commit, not squash/rebase, so submodule SHA c2aec8a remains reachable from daemon main.