### PR TITLE
fix: keep note history scoped to file identity

### DIFF
--- a/packages/vault-core/src/file-history.ts
+++ b/packages/vault-core/src/file-history.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 import type { VaultActor, AuditOperation } from "./audit.js";
-import { validateVaultPath } from "./path.js";
+import { relativeDescendantPath, validateVaultPath } from "./path.js";
 import type { VaultResult } from "./vault-ops.js";
 
 export type FileHistoryOperation = "create" | "update" | "move" | "rename";
@@ -91,6 +91,19 @@ interface GitResult {
   stdout: string;
   stderr: string;
 }
+
+interface CommitValues {
+  get(key: string): string | undefined;
+  getAll(key: string): string[];
+}
+
+type HistoryCommitScope =
+  | { matches: false }
+  | {
+    matches: true;
+    previousPath?: string;
+    stopsTraversal?: boolean;
+  };
 
 type PendingHistoryMap = Map<string, PendingHistoryEntry>;
 
@@ -373,16 +386,26 @@ function commitMessage(
 ): { subject: string; body: string } {
   const bucketEnd = now?.toISOString() ?? entry.updatedAt;
   const contributorLines = entry.contributors.map((actor) => `- ${actorLabel(actor)}`);
+  const displayPath = commitPathDisplay(entry.path);
+  const displayFromPath = entry.fromPath === undefined
+    ? undefined
+    : commitPathDisplay(entry.fromPath);
   const body = [
-    `Path: ${entry.path}`,
-    ...(entry.fromPath ? [`From: ${entry.fromPath}`] : []),
+    `Path: ${displayPath}`,
+    ...(displayFromPath ? [`From: ${displayFromPath}`] : []),
     `Bucket: ${entry.bucketStart} - ${bucketEnd}`,
     "",
     "Contributors:",
     ...contributorLines,
     "",
-    `KB1-Path: ${entry.path}`,
-    ...(entry.fromPath ? [`KB1-From-Path: ${entry.fromPath}`] : []),
+    `KB1-Path-JSON: ${JSON.stringify(entry.path)}`,
+    ...(!hasLineBreak(entry.path) ? [`KB1-Path: ${entry.path}`] : []),
+    ...(entry.fromPath === undefined
+      ? []
+      : [
+        `KB1-From-Path-JSON: ${JSON.stringify(entry.fromPath)}`,
+        ...(!hasLineBreak(entry.fromPath) ? [`KB1-From-Path: ${entry.fromPath}`] : []),
+      ]),
     `KB1-Operation: ${entry.operation}`,
     `KB1-Bucket-Start: ${entry.bucketStart}`,
     `KB1-Bucket-End: ${bucketEnd}`,
@@ -392,7 +415,7 @@ function commitMessage(
   ].join("\n");
 
   return {
-    subject: `KB-1 history: ${entry.operation} ${entry.path}`,
+    subject: `KB-1 history: ${entry.operation} ${displayPath}`,
     body,
   };
 }
@@ -400,42 +423,76 @@ function commitMessage(
 async function readCommittedHistory(root: string, rel: string): Promise<FileHistoryEntry[]> {
   if (!await hasGitRepository(root)) return [];
 
-  let result: GitResult;
-  try {
-    result = await runGit(root, [
-      "log",
-      "--follow",
-      "--format=%H%x00%cI%x00%B%x1e",
-      "--",
-      rel,
-    ]);
-  } catch {
-    /* v8 ignore next -- Git log failures are treated as empty history; normal no-history repos are covered without throwing. */
-    return [];
-  }
-
   const entries: FileHistoryEntry[] = [];
-  for (const raw of result.stdout.split(COMMIT_SEPARATOR)) {
-    const trimmed = raw.trim();
-    if (trimmed.length === 0) continue;
-    const [commitId, committedAt, ...bodyParts] = trimmed.split(FIELD_SEPARATOR);
-    /* v8 ignore next -- Git log format is controlled by this module. */
-    if (!commitId || !committedAt) continue;
-    const body = bodyParts.join(FIELD_SEPARATOR);
-    const parsed = entryFromCommitBody(rel, commitId, committedAt, body);
-    /* v8 ignore next -- Invalid external KB1 history commits are ignored; emitted commits parse successfully. */
-    if (parsed) entries.push(parsed);
+  const seenCommitIds = new Set<string>();
+  let currentPath = rel;
+  let revision: string | undefined;
+
+  while (true) {
+    let result: GitResult;
+    try {
+      result = await runGit(root, [
+        "log",
+        "--no-follow",
+        ...(revision ? [revision] : []),
+        "--format=%H%x00%cI%x00%B%x1e",
+        "--",
+        currentPath,
+      ]);
+    } catch {
+      /* v8 ignore next -- Git log failures are treated as the end of best-effort history traversal. */
+      return entries;
+    }
+
+    let previousSegment: { path: string; revision: string } | undefined;
+    for (const raw of result.stdout.split(COMMIT_SEPARATOR)) {
+      const trimmed = raw.trim();
+      if (trimmed.length === 0) continue;
+      const [commitId, committedAt, ...bodyParts] = trimmed.split(FIELD_SEPARATOR);
+      /* v8 ignore next -- Git log format is controlled by this module. */
+      if (!commitId || !committedAt) continue;
+      const values = commitValues(bodyParts.join(FIELD_SEPARATOR));
+      const parsed = entryFromCommitValues(rel, commitId, committedAt, values);
+      /* v8 ignore next -- Invalid external KB1 history commits are ignored; emitted commits parse successfully. */
+      if (!parsed) continue;
+
+      const scope = historyCommitScope(
+        currentPath,
+        parsed.operation,
+        commitPathValue(values, "KB1-Path"),
+        commitPathValue(values, "KB1-From-Path"),
+      );
+      if (!scope.matches) continue;
+
+      if (!seenCommitIds.has(commitId)) {
+        entries.push(parsed);
+        seenCommitIds.add(commitId);
+      }
+
+      if (parsed.operation === "create" || scope.stopsTraversal) {
+        return entries;
+      }
+      if (scope.previousPath) {
+        previousSegment = {
+          path: scope.previousPath,
+          revision: `${commitId}^`,
+        };
+        break;
+      }
+    }
+
+    if (!previousSegment) return entries;
+    currentPath = previousSegment.path;
+    revision = previousSegment.revision;
   }
-  return entries;
 }
 
-function entryFromCommitBody(
+function entryFromCommitValues(
   requestedPath: string,
   commitId: string,
   committedAt: string,
-  body: string,
+  values: CommitValues,
 ): FileHistoryEntry | undefined {
-  const values = commitValues(body);
   const operation = fileHistoryOperation(values.get("KB1-Operation") ?? "update");
   /* v8 ignore next -- Invalid external operation trailers are ignored; emitted commits use known operations. */
   if (!operation) return undefined;
@@ -465,12 +522,84 @@ function entryFromCommitBody(
   };
 }
 
-function commitValues(body: string): { get(key: string): string | undefined; getAll(key: string): string[] } {
+function historyCommitScope(
+  currentPath: string,
+  operation: FileHistoryOperation,
+  recordedPath: string | null | undefined,
+  fromPath: string | null | undefined,
+): HistoryCommitScope {
+  if (recordedPath === undefined) return { matches: true };
+  if (recordedPath === null) return { matches: false };
+
+  const suffix = recordedPath === currentPath
+    ? ""
+    : operation === "move"
+      ? relativeDescendantPath(recordedPath, currentPath)
+      : null;
+  if (suffix === null) return { matches: false };
+  if (operation !== "move" && operation !== "rename") {
+    return { matches: true };
+  }
+  if (fromPath === undefined || fromPath === null) {
+    return { matches: true, stopsTraversal: true };
+  }
+
+  const previousPath = suffix.length === 0
+    ? fromPath
+    : `${fromPath}/${suffix}`;
+  try {
+    return {
+      matches: true,
+      previousPath: validateVaultPath(previousPath, "file"),
+    };
+  } catch {
+    return { matches: true, stopsTraversal: true };
+  }
+}
+
+function commitPathValue(
+  values: CommitValues,
+  legacyKey: "KB1-Path" | "KB1-From-Path",
+): string | null | undefined {
+  const encoded = values.get(`${legacyKey}-JSON`);
+  if (encoded === undefined) return values.get(legacyKey);
+
+  try {
+    const parsed: unknown = JSON.parse(encoded);
+    return typeof parsed === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function commitPathDisplay(value: string): string {
+  return hasLineBreak(value) ? JSON.stringify(value) : value;
+}
+
+function hasLineBreak(value: string): boolean {
+  return /[\r\n]/u.test(value);
+}
+
+function commitValues(body: string): CommitValues {
   const values = new Map<string, string[]>();
-  for (const line of body.split(/\r?\n/)) {
+  const lines = body
+    .split("\n")
+    .map((line) => line.endsWith("\r") ? line.slice(0, -1) : line);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
     const match = /^(KB1-[A-Za-z0-9-]+):\s*(.*)$/.exec(line);
     if (!match) continue;
-    const [, key, value] = match;
+    const [, key, firstLine] = match;
+    let value = firstLine;
+    if (key === "KB1-Path" || key === "KB1-From-Path") {
+      while (
+        index + 1 < lines.length
+        && !/^(KB1-[A-Za-z0-9-]+):\s*/.test(lines[index + 1] ?? "")
+      ) {
+        index += 1;
+        value += `\n${lines[index] ?? ""}`;
+      }
+    }
     const existing = values.get(key) ?? [];
     existing.push(value);
     values.set(key, existing);

--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -633,6 +633,417 @@ describe("vault-core filesystem operations", () => {
     await expect(flushFileHistory(root)).resolves.toEqual({ ok: true, value: { flushed: 0 } });
   });
 
+  it("keeps independently created copies out of each other's history", async () => {
+    const actor = {
+      kind: "integration" as const,
+      id: "daily-brief-import",
+      client: "migration",
+    };
+    const content = [
+      "# Morning brief",
+      "",
+      "## Today",
+      "",
+      "- Review the launch checklist.",
+      "- Confirm the daemon health check.",
+      "",
+    ].join("\n");
+
+    await writeFileWithParents(
+      path.join(root, "briefs/2026-07-16.md"),
+      content,
+      "utf8",
+    );
+    await recordFileHistory(root, {
+      path: "briefs/2026-07-16.md",
+      operation: "create",
+      actor,
+      content,
+      now: new Date("2026-07-16T13:00:00.000Z"),
+    });
+    await flushFileHistory(root, {
+      paths: ["briefs/2026-07-16.md"],
+      now: new Date("2026-07-16T13:00:30.000Z"),
+    });
+
+    await writeFileWithParents(
+      path.join(root, "briefs/2026-07-17.md"),
+      content,
+      "utf8",
+    );
+    await recordFileHistory(root, {
+      path: "briefs/2026-07-17.md",
+      operation: "create",
+      actor,
+      content,
+      now: new Date("2026-07-17T13:00:00.000Z"),
+    });
+    await flushFileHistory(root, {
+      paths: ["briefs/2026-07-17.md"],
+      now: new Date("2026-07-17T13:00:30.000Z"),
+    });
+    await git(root, ["config", "log.follow", "true"]);
+
+    await expect(
+      listFileHistory(root, { path: "briefs/2026-07-17.md" }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: {
+        hasMore: false,
+        entries: [
+          {
+            path: "briefs/2026-07-17.md",
+            operation: "create",
+            actor,
+          },
+        ],
+      },
+    });
+    const secondHistory = await listFileHistory(root, {
+      path: "briefs/2026-07-17.md",
+    });
+    if (!secondHistory.ok) throw new Error("expected second brief history");
+    expect(secondHistory.value.entries).toHaveLength(1);
+  });
+
+  it("preserves file identity when history paths contain line breaks", async () => {
+    const actor = {
+      kind: "user" as const,
+      id: "line-break-owner",
+      client: "browser",
+    };
+    const unrelatedActor = {
+      kind: "integration" as const,
+      id: "unrelated-file",
+      client: "migration",
+    };
+    const unrelatedPath = "notes/source.md";
+    const sourcePath = "notes/source.md\ncontinued.md";
+    const targetPath = "archive/moved.md";
+
+    await writeFileWithParents(path.join(root, unrelatedPath), "unrelated\n", "utf8");
+    await recordFileHistory(root, {
+      path: unrelatedPath,
+      operation: "create",
+      actor: unrelatedActor,
+      content: "unrelated\n",
+      now: new Date("2026-07-17T13:30:00.000Z"),
+    });
+    await flushFileHistory(root, {
+      paths: [unrelatedPath],
+      now: new Date("2026-07-17T13:30:30.000Z"),
+    });
+
+    await writeFileWithParents(path.join(root, sourcePath), "line break identity\n", "utf8");
+    await recordFileHistory(root, {
+      path: sourcePath,
+      operation: "create",
+      actor,
+      content: "line break identity\n",
+      now: new Date("2026-07-17T13:31:00.000Z"),
+    });
+    await flushFileHistory(root, {
+      paths: [sourcePath],
+      now: new Date("2026-07-17T13:31:30.000Z"),
+    });
+
+    const sourceHistory = await listFileHistory(root, { path: sourcePath });
+    if (!sourceHistory.ok) throw new Error("expected line-break source history");
+    expect(sourceHistory.value.entries).toHaveLength(1);
+    expect(sourceHistory.value.entries).toMatchObject([
+      { path: sourcePath, operation: "create", actor },
+    ]);
+
+    await mkdir(path.join(root, "archive"), { recursive: true });
+    await rename(path.join(root, sourcePath), path.join(root, targetPath));
+    await moveFileHistory(root, {
+      fromPath: sourcePath,
+      toPath: targetPath,
+      actor,
+      content: "line break identity\n",
+      now: new Date("2026-07-17T13:32:00.000Z"),
+    });
+
+    const movedHistory = await listFileHistory(root, { path: targetPath });
+    if (!movedHistory.ok) throw new Error("expected moved line-break history");
+    expect(movedHistory.value.entries).toHaveLength(2);
+    expect(movedHistory.value.entries).toMatchObject([
+      { path: targetPath, operation: "move", actor },
+      { path: targetPath, operation: "create", actor },
+    ]);
+
+    const gitBody = await git(root, ["log", "-1", "--format=%B"]);
+    expect(gitBody.stdout).toContain(
+      `KB1-From-Path-JSON: ${JSON.stringify(sourcePath)}`,
+    );
+    expect(gitBody.stdout).not.toContain(`KB1-From-Path: ${sourcePath}`);
+  });
+
+  it("preserves legacy CRLF history whose raw path trailers contain line breaks", async () => {
+    const actor = {
+      kind: "user" as const,
+      id: "legacy-line-break-owner",
+      client: "browser",
+    };
+    const sourcePath = "legacy/source.md\ncontinued.md";
+    const targetPath = "archive/legacy-moved.md";
+
+    await writeFileWithParents(path.join(root, "seed.md"), "seed\n", "utf8");
+    await recordFileHistory(root, {
+      path: "seed.md",
+      operation: "create",
+      content: "seed\n",
+      now: new Date("2026-07-17T13:40:00.000Z"),
+    });
+    await flushFileHistory(root, {
+      paths: ["seed.md"],
+      now: new Date("2026-07-17T13:40:30.000Z"),
+    });
+
+    await writeFileWithParents(path.join(root, sourcePath), "legacy identity\n", "utf8");
+    await git(root, ["add", "--", sourcePath]);
+    await git(root, [
+      "commit",
+      "-m",
+      "legacy multiline history entry",
+      "-m",
+      [
+        `KB1-Path: ${sourcePath}`,
+        "KB1-Operation: create",
+        "KB1-Bucket-Start: 2026-07-17T13:40:30.000Z",
+        "KB1-Bucket-End: 2026-07-17T13:40:30.000Z",
+        `KB1-Contributor: ${JSON.stringify(actor)}`,
+      ].join("\r\n"),
+    ]);
+
+    const sourceHistory = await listFileHistory(root, { path: sourcePath });
+    if (!sourceHistory.ok) throw new Error("expected legacy multiline source history");
+    expect(sourceHistory.value.entries).toHaveLength(1);
+    expect(sourceHistory.value.entries).toMatchObject([
+      { path: sourcePath, operation: "create", actor },
+    ]);
+
+    await mkdir(path.join(root, "archive"), { recursive: true });
+    await rename(path.join(root, sourcePath), path.join(root, targetPath));
+    await moveFileHistory(root, {
+      fromPath: sourcePath,
+      toPath: targetPath,
+      actor,
+      content: "legacy identity\n",
+      now: new Date("2026-07-17T13:41:00.000Z"),
+    });
+
+    const movedHistory = await listFileHistory(root, { path: targetPath });
+    if (!movedHistory.ok) throw new Error("expected moved legacy multiline history");
+    expect(movedHistory.value.entries).toHaveLength(2);
+    expect(movedHistory.value.entries).toMatchObject([
+      { path: targetPath, operation: "move", actor },
+      { path: targetPath, operation: "create", actor },
+    ]);
+  });
+
+  it("follows explicit move chains without crossing recreated source paths", async () => {
+    const actor = {
+      kind: "user" as const,
+      id: "history-owner",
+      client: "browser",
+    };
+    const originalPath = "notes/original.md";
+    const renamedPath = "notes/renamed.md";
+    const finalPath = "archive/final.md";
+
+    await writeFileWithParents(
+      path.join(root, originalPath),
+      "original identity\n",
+      "utf8",
+    );
+    await recordFileHistory(root, {
+      path: originalPath,
+      operation: "create",
+      actor,
+      content: "original identity\n",
+      now: new Date("2026-07-17T14:00:00.000Z"),
+    });
+    await flushFileHistory(root, {
+      paths: [originalPath],
+      now: new Date("2026-07-17T14:00:30.000Z"),
+    });
+
+    await rename(path.join(root, originalPath), path.join(root, renamedPath));
+    await moveFileHistory(root, {
+      fromPath: originalPath,
+      toPath: renamedPath,
+      actor,
+      content: "original identity\n",
+      now: new Date("2026-07-17T14:01:00.000Z"),
+    });
+
+    await mkdir(path.join(root, "archive"), { recursive: true });
+    await rename(path.join(root, renamedPath), path.join(root, finalPath));
+    await moveFileHistory(root, {
+      fromPath: renamedPath,
+      toPath: finalPath,
+      actor,
+      content: "original identity\n",
+      now: new Date("2026-07-17T14:02:00.000Z"),
+    });
+
+    await writeFileWithParents(
+      path.join(root, originalPath),
+      "replacement identity\n",
+      "utf8",
+    );
+    await recordFileHistory(root, {
+      path: originalPath,
+      operation: "create",
+      actor,
+      content: "replacement identity\n",
+      now: new Date("2026-07-17T14:03:00.000Z"),
+    });
+    await flushFileHistory(root, {
+      paths: [originalPath],
+      now: new Date("2026-07-17T14:03:30.000Z"),
+    });
+
+    const replacementHistory = await listFileHistory(root, {
+      path: originalPath,
+    });
+    if (!replacementHistory.ok) throw new Error("expected replacement history");
+    expect(replacementHistory.value.entries).toHaveLength(1);
+    expect(replacementHistory.value.entries).toMatchObject([
+      { path: originalPath, operation: "create", actor },
+    ]);
+
+    const movedHistory = await listFileHistory(root, { path: finalPath });
+    if (!movedHistory.ok) throw new Error("expected moved history");
+    expect(movedHistory.value.entries).toHaveLength(3);
+    expect(movedHistory.value.entries).toMatchObject([
+      { path: finalPath, operation: "move", actor },
+      { path: finalPath, operation: "rename", actor },
+      { path: finalPath, operation: "create", actor },
+    ]);
+  });
+
+  it("stops at explicit moves with missing or invalid source metadata", async () => {
+    await writeFileWithParents(
+      path.join(root, "notes/seed.md"),
+      "seed\n",
+      "utf8",
+    );
+    await recordFileHistory(root, {
+      path: "notes/seed.md",
+      operation: "create",
+      content: "seed\n",
+      now: new Date("2026-07-17T15:00:00.000Z"),
+    });
+    await flushFileHistory(root, {
+      paths: ["notes/seed.md"],
+      now: new Date("2026-07-17T15:00:30.000Z"),
+    });
+
+    const missingSourcePath = "notes/missing-source.md";
+    await writeFile(path.join(root, missingSourcePath), "missing source\n", "utf8");
+    await git(root, ["add", "--", missingSourcePath]);
+    await git(root, [
+      "commit",
+      "-m",
+      "external move without source",
+      "-m",
+      [
+        `KB1-Path: ${missingSourcePath}`,
+        "KB1-Operation: move",
+      ].join("\n"),
+    ]);
+
+    const invalidSourcePath = "notes/invalid-source.md";
+    await writeFile(path.join(root, invalidSourcePath), "invalid source\n", "utf8");
+    await git(root, ["add", "--", invalidSourcePath]);
+    await git(root, [
+      "commit",
+      "-m",
+      "external move with invalid source",
+      "-m",
+      [
+        `KB1-Path: ${invalidSourcePath}`,
+        "KB1-From-Path: ../outside.md",
+        "KB1-Operation: move",
+      ].join("\n"),
+    ]);
+
+    const malformedSourcePath = "notes/malformed-source.md";
+    await writeFile(path.join(root, malformedSourcePath), "malformed source\n", "utf8");
+    await git(root, ["add", "--", malformedSourcePath]);
+    await git(root, [
+      "commit",
+      "-m",
+      "external move with malformed encoded source",
+      "-m",
+      [
+        `KB1-Path-JSON: ${JSON.stringify(malformedSourcePath)}`,
+        "KB1-From-Path-JSON: {",
+        "KB1-Operation: move",
+      ].join("\n"),
+    ]);
+
+    const nonStringRecordedPath = "notes/non-string-recorded-path.md";
+    await writeFile(path.join(root, nonStringRecordedPath), "non-string path\n", "utf8");
+    await git(root, ["add", "--", nonStringRecordedPath]);
+    await git(root, [
+      "commit",
+      "-m",
+      "external move with non-string encoded path",
+      "-m",
+      [
+        "KB1-Path-JSON: null",
+        "KB1-Operation: move",
+      ].join("\n"),
+    ]);
+
+    const missingSourceHistory = await listFileHistory(root, {
+      path: missingSourcePath,
+    });
+    if (!missingSourceHistory.ok) {
+      throw new Error("expected missing-source history");
+    }
+    expect(missingSourceHistory.value.entries).toHaveLength(1);
+    expect(missingSourceHistory.value.entries[0]).toMatchObject({
+      path: missingSourcePath,
+      operation: "move",
+    });
+
+    const invalidSourceHistory = await listFileHistory(root, {
+      path: invalidSourcePath,
+    });
+    if (!invalidSourceHistory.ok) {
+      throw new Error("expected invalid-source history");
+    }
+    expect(invalidSourceHistory.value.entries).toHaveLength(1);
+    expect(invalidSourceHistory.value.entries[0]).toMatchObject({
+      path: invalidSourcePath,
+      operation: "move",
+    });
+
+    const malformedSourceHistory = await listFileHistory(root, {
+      path: malformedSourcePath,
+    });
+    if (!malformedSourceHistory.ok) {
+      throw new Error("expected malformed-source history");
+    }
+    expect(malformedSourceHistory.value.entries).toHaveLength(1);
+    expect(malformedSourceHistory.value.entries[0]).toMatchObject({
+      path: malformedSourcePath,
+      operation: "move",
+    });
+
+    const nonStringRecordedPathHistory = await listFileHistory(root, {
+      path: nonStringRecordedPath,
+    });
+    if (!nonStringRecordedPathHistory.ok) {
+      throw new Error("expected non-string-recorded-path history");
+    }
+    expect(nonStringRecordedPathHistory.value.entries).toHaveLength(0);
+  });
+
   it("uses structural move commits as history barriers and follows renamed files", async () => {
     const actor = {
       kind: "user" as const,


### PR DESCRIPTION
## Summary

Fixes committed note history so independently created files with similar or identical content are not incorrectly treated as the same note.

## What changed

- Replaced Git’s implicit `--follow` behavior with exact-path history lookup.
- History now follows a note across renames or moves only when explicit KB-1 path metadata confirms the identity transition.
- Added JSON-safe path metadata while preserving compatibility with legacy raw, multiline, and CRLF metadata.
- Added regression coverage for:
  - Identical files created independently
  - Repository-level `log.follow=true`
  - File and folder move chains
  - Recreated source paths
  - Multiline paths and legacy metadata
  - Malformed or incomplete move metadata

## Why

Git’s copy-similarity detection could connect separately created notes—such as dated daily briefs—and return revisions belonging to other files. This affected history reads only; it did not corrupt vault contents or audit data.

The new behavior keeps history scoped to the requested file identity while retaining explicit KB-1 move and rename history.

No vault migration is required.

## Verification

- `pnpm --filter @kb-1/vault-core test` — 91/91 passed
- `pnpm --filter @kb-1/vault-core typecheck`
- `pnpm check`
- Autoreview completed with no actionable findings