### PR TITLE
fix: unbreak the Windows dev loop (pnpm spawn + directory fsync)

### DIFF
--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -847,6 +847,14 @@ async function atomicWriteFile(filePath: string, content: string): Promise<void>
 }
 
 async function fsyncDirectory(directory: string): Promise<void> {
+  // Windows opens the directory handle fine but rejects fsync on it with
+  // EPERM, so this durability step cannot be honoured there. MoveFileEx (the
+  // rename in atomicWriteFile) is already atomic on NTFS; skip the directory
+  // fsync on win32, matching the graceful-fs/rimraf convention.
+  if (process.platform === 'win32') {
+    return;
+  }
+
   const handle = await open(directory, 'r');
   try {
     await handle.sync();

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 
+// Windows resolves `pnpm` to pnpm.cmd only through a shell; a bare spawn
+// misses PATHEXT and fails with ENOENT. Every argument below is a hardcoded
+// literal, so the DEP0190 arg-escaping hazard does not apply here.
+const useShell = process.platform === 'win32';
 const skipNxCache = process.argv.includes('--skip-nx-cache');
 const env = {
   ...process.env,
@@ -19,6 +23,7 @@ function run(command, args, env) {
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       env,
+      shell: useShell,
       stdio: 'inherit'
     });
     child.on('exit', (code, signal) => {

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -3,6 +3,10 @@
 import { spawn } from 'node:child_process';
 
 const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+// Node >=20.12 (CVE-2024-27980) refuses to spawn a .cmd/.bat without a shell,
+// so the Windows launcher needs one. Every argument below is a hardcoded
+// literal, so the DEP0190 arg-escaping hazard does not apply here.
+const useShell = process.platform === 'win32';
 const daemonHost = process.env.KB1_HOST || '127.0.0.1';
 const daemonPort = process.env.KB1_PORT || '7382';
 const webPort = process.env.KB1_WEB_PORT || '5173';
@@ -65,6 +69,7 @@ function spawnProcess(name, args, env) {
       ...process.env,
       ...env
     },
+    shell: useShell,
     stdio: ['inherit', 'pipe', 'pipe']
   });
 


### PR DESCRIPTION
KB-1 Local can't currently be developed or run on Windows. All three failures below hit inside the first five minutes of the documented quickstart, and each one is fatal on its own.

| Quickstart step | On Windows today |
|---|---|
| `pnpm dev` | dies instantly: `Error: spawn EINVAL` |
| `pnpm check` | dies instantly: `Error: spawn pnpm ENOENT` |
| open any note | write path throws `EPERM`; note reads 500 |

Environment: Windows 11, Node v24.12.0, pnpm 11.5.3 (the pinned `packageManager`).

## 1. `scripts/dev.mjs` — `spawn EINVAL`

The launcher already resolves `pnpm.cmd` on win32, but the failure is the spawn itself, not the path. Node >=20.12 refuses to spawn a `.cmd`/`.bat` without a shell — that's the CVE-2024-27980 hardening.

```
Error: spawn EINVAL
    at spawnProcess (scripts/dev.mjs:63:17)
  errno: -4071, code: 'EINVAL', syscall: 'spawn'
```

## 2. `scripts/check.mjs` — `spawn pnpm ENOENT`

Separate bug, different failure mode. This one spawns bare `pnpm`, and Node does **not** apply `PATHEXT` when resolving a command without a shell, so it never finds `pnpm.cmd`:

```
Error: spawn pnpm ENOENT
  errno: -4058, code: 'ENOENT', syscall: 'spawn pnpm', path: 'pnpm'
```

Worth stressing: this reproduces with pnpm correctly installed and on `PATH` (`pnpm --version` → `11.5.3` in the same shell). I isolated it to confirm it isn't an install artifact — with a `foo.cmd` on `PATH`, `spawn('foo')` gives ENOENT while `spawn('foo', {shell:true})` runs it. So `pnpm check`, the gate CONTRIBUTING requires before opening a PR, cannot be run on Windows at all.

Both are fixed by setting `shell` only on win32. Off Windows `shell: false` is already the spawn default, so Linux and macOS behaviour is byte-for-byte unchanged.

## 3. `atomicWriteFile` — directory fsync `EPERM`

`fsyncDirectory` durably commits the rename by opening the containing directory and fsyncing it. On Windows the `open()` **succeeds** and the `sync()` is what fails:

```
EPERM: operation not permitted, fsync
```

Every document-session write went through this path, so every note read 500'd. `MoveFileEx` (backing `rename` on NTFS) is already atomic, so this skips only the *directory* fsync on win32 and keeps the file fsync everywhere — the graceful-fs / rimraf convention.

## Verification

`pnpm dev` now boots both processes on Windows:

```
KB-1 dev front door: http://127.0.0.1:7382
Vite dev server: http://127.0.0.1:5173
[web]   VITE v8.0.16  ready in 1580 ms
[daemon] kb1d listening on http://127.0.0.1:7382
```

`pnpm typecheck` ✅ and `pnpm build` ✅ both pass on Windows with this branch.

For the test suite I ran the full suite on stock `main` and on this branch, then diffed the failing-test sets:

| | stock `main` | this branch |
|---|---|---|
| unique failing tests (Windows) | 88 | 26 |

**62 tests fixed, 0 regressions** — the set of tests failing on this branch is a strict subset of those failing on stock `main`. `packages/doc-session` alone goes from 41 failed / 45 passed to 6 failed / 80 passed.

## What is still red on Windows (all pre-existing, none from this PR)

I'd rather flag these than imply the branch makes Windows green. The 26 remaining failures fall into three classes, all of which also fail on stock `main`:

1. **Persist-failure tests can't work on Windows.** They simulate a read-only vault with `chmod(vaultDir, 0o500)`. I verified that's a no-op here — a write into a `0o500` directory succeeds on Windows. Needs a different injection mechanism (fs-layer mock, or ACLs) rather than a production fix.
2. **Trash paths contain colons.** `trashRelativePath` (`packages/vault-core/src/vault-ops.ts:205`) builds `.kb1/trash/<new Date().toISOString()>/…`, and `:` is illegal in Windows filenames, so `mkdir` fails with ENOENT. **This one is a real user-facing bug, not just a test issue — delete/trash is broken on Windows.** I left it alone because changing the on-disk trash format is your design call, not something to slip into a portability PR. Happy to open an issue or send a fix if you tell me which format you'd want.
3. A few `vault-core` history/path cases involving separators and CRLF.

`pnpm licenses:check` also fails, identically on stock `main` — unrelated to this PR.

## Two caveats on the shell approach

- **DEP0190.** Node warns that args under `shell:true` are concatenated, not escaped. Every argument in both scripts is a hardcoded literal with no user input, so there's no injection surface — noted in a comment at each site. The shell-free alternative would be spawning pnpm's JS entry via `process.execPath`, but `npm_execpath` is unset under pnpm, so that reduces to hand-rolling the same concatenation.
- **Process-tree shutdown.** On Windows the direct child is now `cmd.exe`, so `child.kill()` in the shutdown handler may leave the pnpm/node grandchildren alive. I did not solve that here — it needs a tree-kill. Say the word and I'll add one.

## Follow-up worth considering

CI is `ubuntu-latest` only, which is why all three of these shipped. A `windows-latest` leg on typecheck + test would have caught every one. I kept it out of this PR to stay focused per CONTRIBUTING, but I'm glad to send it as a separate PR — though it'd want the three classes above triaged first, or it lands red.
