### PR TITLE
Fix relay control liveness across hibernation

### DIFF
--- a/packages/tunnel-client/src/heartbeat.test.ts
+++ b/packages/tunnel-client/src/heartbeat.test.ts
@@ -58,7 +58,12 @@ describe('TunnelClient control heartbeat', () => {
   });
 
   it('terminates a missed-pong control socket to trip the existing reconnect path', async () => {
-    const { CONTROL_HEARTBEAT_INTERVAL_MS, CONTROL_HEARTBEAT_TIMEOUT_MS, TunnelClient } = await import('./index.js');
+    const {
+      CONTROL_DURABLE_LIVENESS_INTERVAL_MS,
+      CONTROL_HEARTBEAT_INTERVAL_MS,
+      CONTROL_HEARTBEAT_TIMEOUT_MS,
+      TunnelClient,
+    } = await import('./index.js');
     const logger = { log: vi.fn() };
     const client = new TunnelClient({
       relayUrl: new URL('http://relay.example/t/dev1'),
@@ -81,13 +86,19 @@ describe('TunnelClient control heartbeat', () => {
 
     await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_INTERVAL_MS);
     expect(sentText(firstControl, 1)).toBe(encodeTunnelMessage({ type: 'control.ping' }));
+    expect(typeof firstControl.sent[1]).toBe('string');
+    expect(firstControl.sent).toHaveLength(2);
 
     firstControl.message(encodeTunnelMessage({ type: 'control.pong' }));
     await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_TIMEOUT_MS);
     expect(firstControl.terminated).toBe(false);
 
     await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_INTERVAL_MS);
+    expect(CONTROL_DURABLE_LIVENESS_INTERVAL_MS).toBe(2 * CONTROL_HEARTBEAT_INTERVAL_MS);
     expect(sentText(firstControl, 2)).toBe(encodeTunnelMessage({ type: 'control.ping' }));
+    expect(typeof firstControl.sent[2]).toBe('string');
+    expect(Buffer.isBuffer(firstControl.sent[3])).toBe(true);
+    expect(sentText(firstControl, 3)).toBe(encodeTunnelMessage({ type: 'control.ping' }));
 
     await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_TIMEOUT_MS);
     expect(firstControl.terminated).toBe(true);

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -72,6 +72,7 @@ const DEFAULT_BACKOFF_MAX_MS = 10_000;
 const DEFAULT_BACKOFF_JITTER_RATIO = 0.25;
 export const CONTROL_HEARTBEAT_INTERVAL_MS = 15_000;
 export const CONTROL_HEARTBEAT_TIMEOUT_MS = 5_000;
+export const CONTROL_DURABLE_LIVENESS_INTERVAL_MS = 30_000;
 
 const hopByHopHeaders = new Set([
   'connection',
@@ -344,13 +345,23 @@ export class TunnelClient {
 
   private startControlHeartbeat(control: WebSocket): void {
     this.clearControlHeartbeat();
+    let durableLivenessElapsedMs = 0;
     this.controlHeartbeatInterval = setInterval(() => {
       if (this.control !== control || this.stopped || control.readyState !== WebSocket.OPEN) {
         return;
       }
 
       this.clearControlHeartbeatDeadline();
+      durableLivenessElapsedMs += CONTROL_HEARTBEAT_INTERVAL_MS;
+      // Keep the frequent text ping for the relay's non-waking auto-pong. A
+      // bounded binary pulse lets OrgChannel durably record liveness when
+      // Cloudflare does not expose that auto-response after hibernation,
+      // without waking and rewriting the Durable Object on every heartbeat.
       control.send(encodeTunnelMessage({ type: 'control.ping' }));
+      if (durableLivenessElapsedMs >= CONTROL_DURABLE_LIVENESS_INTERVAL_MS) {
+        durableLivenessElapsedMs = 0;
+        control.send(encodeJsonBytes({ type: 'control.ping' }));
+      }
       this.controlHeartbeatDeadline = setTimeout(() => {
         if (this.control !== control || this.stopped) return;
 


### PR DESCRIPTION
## What changed

- Keep the existing 15-second text heartbeat so Cloudflare can return a low-cost automatic pong without waking the OrgChannel.
- Send the same authenticated heartbeat as a binary frame every 30 seconds so the OrgChannel handler records durable control activity.
- Extend the heartbeat regression to verify the text/binary cadence, frame encoding, missed-pong termination, and reconnect behavior.

## Why

In production, the daemon continued receiving automatic pongs, but after Durable Object hibernation Cloudflare did not reliably expose the latest auto-response timestamp to the rehydrated OrgChannel. The persisted activity therefore appeared stale and the Worker closed a healthy control socket after roughly 45–50 seconds. That produced intermittent minute-scale vault loading and raw-read failures.

The binary pulse reaches the existing authenticated OrgChannel handler and refreshes durable activity. It is bounded to every 30 seconds rather than every heartbeat to reduce recurring Durable Object wakeups and state writes while remaining inside the current 45-second stale threshold.

## Impact

Hosted and self-hosted relay controls should remain connected across OrgChannel hibernation instead of entering a false reconnect loop. No vault data, schema, migration, or authentication behavior changes.

## Validation

- `pnpm --filter @kb-1/tunnel-client exec vitest run src/heartbeat.test.ts` — 3 passed
- Root `pnpm check` from the Cloud superproject — all 18 projects passed typecheck, test, build, deploy-build, and lint gates
- Autoreview — clean, no actionable findings
