### PR TITLE
feat: harden Windows daemon lifecycle

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,3 +57,7 @@ jobs:
           pnpm typecheck
           pnpm build
           pnpm smoke:windows
+
+      - name: Verify Windows background task lifecycle
+        shell: powershell
+        run: .\scripts\windows-task-smoke.ps1

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ environment variables with `$env:NAME="value"` before the command, for example
 `$env:KB1_PORT="17382"; pnpm dev`.
 
 Windows 11 source development is smoke-tested in CI for daemon startup, note
-create/read, restart persistence, and process-tree shutdown. Native
-installer/service packaging and soft-delete/trash portability remain separate
+create/read/soft-delete, restart persistence, and process-tree shutdown. Native
+installer and Windows Service Control Manager packaging remain separate
 follow-up work.
 
 ## Quick Start From Source
@@ -122,6 +122,44 @@ curl http://127.0.0.1:7382/api/health
 
 Then open http://127.0.0.1:7382 in a browser. A fresh daemon home creates a
 starter `demo-vault` so the UI has content immediately.
+
+### Windows background startup
+
+After cloning the repository, Windows 11 users can build KB-1 Local and install
+it as a per-user Scheduled Task that starts at logon:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File `
+  .\skills\kb-1-daemon-setup\scripts\install_kb1_daemon_user_task.ps1
+```
+
+The task runs with limited current-user privileges, binds to `127.0.0.1`, keeps
+vault data under `$HOME\.kb1`, and leaves network exposure unchanged. Local
+policy may require launching PowerShell as administrator to register the task;
+the daemon itself still runs as the current user at the limited run level.
+Manage it with the same script and `-Action Status`, `Start`, `Stop`, or
+`Uninstall`. Private task configuration, logs, and managed runtimes live under
+`$env:LOCALAPPDATA\KB-1\tasks`; uninstalling the task preserves the repository,
+logs, and vault data. Stop, replacement, and uninstall authenticate to the exact
+supervised daemon, stop accepting new work, drain its connections, and persist
+open document sessions before the process exits. Use `-ForceStop` only to
+recover an unhealthy task when accepting possible loss of the latest in-memory
+edits; the fallback verifies the protected launch identity before terminating
+the complete daemon process tree.
+Task replacement is transactional: if the new daemon does not become healthy,
+the installer restores the prior task definition and configuration. Initial
+installation and upgrades build in an isolated, owner-only versioned runtime
+from the exact selected commit so a failed update cannot corrupt the
+last-known-good daemon or silently switch revisions. Dependencies use a runtime-
+local pnpm store, and reparse points may not escape that protected runtime.
+Upgrades preserve the installed source checkout, home, bind, and port unless
+the operator explicitly supplies a replacement value.
+Task secrets and managed runtimes use current-user-only Windows permissions;
+successful upgrades prune inactive versioned runtimes.
+
+This is a source-based per-user background task, not a signed native installer
+or Windows service. Its install/status/stop/restart/uninstall lifecycle is
+smoke-tested on Windows in CI.
 
 ## Connect an Agent
 

--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -11,6 +11,7 @@ import {
   type VaultChangeEvent,
   type VaultService
 } from '@kb-1/vault-service';
+import { timingSafeEqual } from 'node:crypto';
 import { createReadStream } from 'node:fs';
 import { resolve } from 'node:path';
 import { Readable } from 'node:stream';
@@ -43,6 +44,8 @@ interface CreateAppOptions {
   webProxyTarget?: string;
   actorDefault?: ActorDefault;
   relay?: RelayLifecycleController;
+  shutdown?: ShutdownController;
+  shutdownSignal?: AbortSignal;
 }
 
 export interface RelayLifecycleStatus {
@@ -56,6 +59,12 @@ export interface RelayLifecycleController {
   status(): RelayLifecycleStatus;
   connect(): RelayLifecycleStatus;
   disconnect(): RelayLifecycleStatus;
+}
+
+export interface ShutdownController {
+  token: string;
+  requested(): boolean;
+  request(): void;
 }
 
 /**
@@ -95,6 +104,17 @@ export function createApp(options: CreateAppOptions): Hono {
   const app = new Hono();
   const api = new Hono();
 
+  api.use('*', async (context, next) => {
+    if (options.shutdown?.requested()) {
+      return context.json({
+        ok: false,
+        error: 'shutting_down',
+        message: 'The daemon is shutting down and is not accepting new work.'
+      }, 503);
+    }
+    await next();
+  });
+
   api.get('/health', async (context) => {
     const status = await readDaemonStatus(options.statusFile);
 
@@ -103,6 +123,20 @@ export function createApp(options: CreateAppOptions): Hono {
       service: SERVICE_NAME,
       status
     });
+  });
+
+  api.post('/control/shutdown', (context) => {
+    const token = context.req.header('x-kb1-control-token');
+    if (!options.shutdown || !token || !tokensMatch(token, options.shutdown.token)) {
+      return context.json({
+        ok: false,
+        error: 'unauthorized',
+        message: 'A valid daemon control token is required.'
+      }, 401);
+    }
+
+    options.shutdown.request();
+    return context.json({ ok: true, shuttingDown: true }, 202);
   });
 
   api.get('/relay/status', (context) => {
@@ -141,6 +175,13 @@ export function createApp(options: CreateAppOptions): Hono {
       }
     });
     app.all('/mcp', async (context) => {
+      if (options.shutdown?.requested()) {
+        return context.json({
+          ok: false,
+          error: 'shutting_down',
+          message: 'The daemon is shutting down and is not accepting new work.'
+        }, 503);
+      }
       return mcpEndpoint.handleRequest(context.req.raw);
     });
 
@@ -227,9 +268,9 @@ export function createApp(options: CreateAppOptions): Hono {
       if (!registry.get(id)) {
         return mapServiceResult(context, { ok: false, error: 'not_found', message: `No vault with id "${id}".` });
       }
-      return registryEventStreamResponse(registry, id);
+      return registryEventStreamResponse(registry, id, options.shutdownSignal);
     });
-    registerVaultDataRoutes(api, scopedScope, actorDefault, '/vaults/:id');
+    registerVaultDataRoutes(api, scopedScope, actorDefault, '/vaults/:id', options.shutdownSignal);
   }
 
   app.route('/api', api);
@@ -260,6 +301,13 @@ export function createApp(options: CreateAppOptions): Hono {
   return app;
 }
 
+function tokensMatch(provided: string, expected: string): boolean {
+  const providedBytes = Buffer.from(provided);
+  const expectedBytes = Buffer.from(expected);
+  return providedBytes.length === expectedBytes.length
+    && timingSafeEqual(providedBytes, expectedBytes);
+}
+
 function relayStatus(relay: RelayLifecycleController | undefined): RelayLifecycleStatus {
   return relay?.status() ?? {
     configured: false,
@@ -279,7 +327,8 @@ function registerVaultDataRoutes(
   router: Hono,
   scope: VaultRouteScope,
   actorDefault: ActorDefault,
-  basePath = ''
+  basePath = '',
+  shutdownSignal?: AbortSignal
 ): void {
   router.post(`${basePath}/ops/flush`, async (context) => {
     const resolved = scope.resolve(context);
@@ -290,7 +339,7 @@ function registerVaultDataRoutes(
   router.get(`${basePath}/events`, (context) => {
     const resolved = scope.resolve(context);
     if (!resolved.ok) return mapServiceResult(context, resolved);
-    return eventStreamResponse(resolved.service);
+    return eventStreamResponse(resolved.service, shutdownSignal);
   });
 
   router.get(`${basePath}/vault`, async (context) => {
@@ -613,17 +662,30 @@ async function readMutationJson<T extends MutationRequestSetup>(
   return { ok: true, ...request, body: body.body };
 }
 
-function eventStreamResponse(vaultService: VaultService): Response {
+function eventStreamResponse(vaultService: VaultService, shutdownSignal?: AbortSignal): Response {
   const encoder = new TextEncoder();
   let unsubscribe: () => void = () => undefined;
+  let removeAbortListener: () => void = () => undefined;
+  let closed = false;
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
       unsubscribe = vaultService.onEvent((event) => {
         controller.enqueue(encoder.encode(formatServerSentEvent(event)));
       });
+      const abort = () => {
+        if (closed) return;
+        closed = true;
+        unsubscribe();
+        controller.close();
+      };
+      shutdownSignal?.addEventListener('abort', abort, { once: true });
+      removeAbortListener = () => shutdownSignal?.removeEventListener('abort', abort);
+      if (shutdownSignal?.aborted) abort();
     },
     cancel() {
+      closed = true;
+      removeAbortListener();
       unsubscribe();
     }
   });
@@ -637,9 +699,15 @@ function eventStreamResponse(vaultService: VaultService): Response {
   });
 }
 
-function registryEventStreamResponse(registry: VaultRegistry, vaultId: string): Response {
+function registryEventStreamResponse(
+  registry: VaultRegistry,
+  vaultId: string,
+  shutdownSignal?: AbortSignal
+): Response {
   const encoder = new TextEncoder();
   let unsubscribe: () => void = () => undefined;
+  let removeAbortListener: () => void = () => undefined;
+  let closed = false;
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
@@ -647,8 +715,19 @@ function registryEventStreamResponse(registry: VaultRegistry, vaultId: string): 
         if (event.vaultSlug !== vaultId) return;
         controller.enqueue(encoder.encode(formatServerSentEvent(event.event)));
       });
+      const abort = () => {
+        if (closed) return;
+        closed = true;
+        unsubscribe();
+        controller.close();
+      };
+      shutdownSignal?.addEventListener('abort', abort, { once: true });
+      removeAbortListener = () => shutdownSignal?.removeEventListener('abort', abort);
+      if (shutdownSignal?.aborted) abort();
     },
     cancel() {
+      closed = true;
+      removeAbortListener();
       unsubscribe();
     }
   });

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -36,6 +36,8 @@ export interface DaemonConfig {
   statusFile: string;
   startedAt: string;
   pid: number;
+  /** Optional launch nonce used by supervised runtimes to prove process ownership. */
+  instanceId?: string;
   deprecationWarnings: string[];
 }
 
@@ -161,6 +163,7 @@ export function createDaemonConfig(options: ResolveConfigOptions = {}): DaemonCo
   const daemonHome = join(kb1Home, 'daemon');
   const vaultsHome = join(kb1Home, VAULTS_DIRNAME);
   const vaultRoot = join(vaultsHome, DEFAULT_VAULT_SLUG);
+  const instanceId = optionalEnv(env.KB1_INSTANCE_ID);
 
   return {
     serviceName: SERVICE_NAME,
@@ -177,6 +180,7 @@ export function createDaemonConfig(options: ResolveConfigOptions = {}): DaemonCo
     statusFile: join(daemonHome, 'status.json'),
     startedAt: (options.now ?? new Date()).toISOString(),
     pid: options.pid ?? process.pid,
+    ...(instanceId ? { instanceId } : {}),
     deprecationWarnings: collectConfigDeprecationWarnings(env, homeDir)
   };
 }

--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -10,6 +10,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 
 import { DOCUMENT_SESSION_FAILURE_CLOSE_CODE } from '@kb-1/doc-session';
 import { isDaemonCliEntrypoint, startDaemon } from './main.js';
+import * as statusModule from './status.js';
 
 describe('daemon startup', () => {
   let kb1Home: string;
@@ -222,6 +223,97 @@ describe('daemon startup', () => {
     await expect(readFile(join(started.config.vaultRoot, 'typo', 'missing.md'), 'utf8')).resolves.toBe('created immediately\n');
 
     await started.close();
+  });
+
+  it('authenticates a supervised shutdown and exposes its launch nonce in health', async () => {
+    const port = await reservePort();
+    process.env = {
+      ...originalEnv,
+      KB1_HOME: kb1Home,
+      KB1_HOST: '127.0.0.1',
+      KB1_PORT: String(port),
+      KB1_CONTROL_TOKEN: 'supervisor-secret',
+      KB1_INSTANCE_ID: 'scheduled-task-run-123'
+    };
+
+    const started = await startDaemon();
+    const origin = `http://127.0.0.1:${port}`;
+    const health = await fetch(`${origin}/api/health`);
+    await expect(health.json()).resolves.toMatchObject({
+      ok: true,
+      status: {
+        pid: process.pid,
+        instanceId: 'scheduled-task-run-123'
+      }
+    });
+
+    const rejected = await fetch(`${origin}/api/control/shutdown`, {
+      method: 'POST',
+      headers: { 'x-kb1-control-token': 'not-the-secret' }
+    });
+    expect(rejected.status).toBe(401);
+    expect((await fetch(`${origin}/api/health`)).status).toBe(200);
+
+    const accepted = await fetch(`${origin}/api/control/shutdown`, {
+      method: 'POST',
+      headers: { 'x-kb1-control-token': 'supervisor-secret' }
+    });
+    expect(accepted.status).toBe(202);
+    await expect(accepted.json()).resolves.toEqual({ ok: true, shuttingDown: true });
+
+    await started.close();
+    await expect(fetch(`${origin}/api/health`)).rejects.toBeTruthy();
+  });
+
+  it('completes an authenticated shutdown requested while startup status is pending', async () => {
+    const port = await reservePort();
+    process.env = {
+      ...originalEnv,
+      KB1_HOME: kb1Home,
+      KB1_HOST: '127.0.0.1',
+      KB1_PORT: String(port),
+      KB1_CONTROL_TOKEN: 'startup-shutdown-secret'
+    };
+
+    let releaseStatusWrite: (() => void) | undefined;
+    const statusWriteGate = new Promise<void>((resolve) => {
+      releaseStatusWrite = resolve;
+    });
+    let markStatusWriteStarted: (() => void) | undefined;
+    const statusWriteStarted = new Promise<void>((resolve) => {
+      markStatusWriteStarted = resolve;
+    });
+    const writeDaemonStatus = statusModule.writeDaemonStatus;
+    const statusSpy = vi
+      .spyOn(statusModule, 'writeDaemonStatus')
+      .mockImplementation(async (config) => {
+        markStatusWriteStarted?.();
+        await statusWriteGate;
+        return writeDaemonStatus(config);
+      });
+
+    try {
+      const starting = startDaemon();
+      await statusWriteStarted;
+      const origin = `http://127.0.0.1:${port}`;
+      const accepted = await fetch(`${origin}/api/control/shutdown`, {
+        method: 'POST',
+        headers: { 'x-kb1-control-token': 'startup-shutdown-secret' }
+      });
+      expect(accepted.status).toBe(202);
+      await expect(accepted.json()).resolves.toEqual({
+        ok: true,
+        shuttingDown: true
+      });
+
+      releaseStatusWrite?.();
+      const started = await starting;
+      await started.close();
+      await expect(fetch(`${origin}/api/health`)).rejects.toBeTruthy();
+    } finally {
+      releaseStatusWrite?.();
+      statusSpy.mockRestore();
+    }
   });
 });
 

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -60,6 +60,8 @@ export type StartDaemonOptions = ResolveConfigOptions;
 
 export async function startDaemon(options: StartDaemonOptions = {}): Promise<StartedDaemon> {
   const config = createDaemonConfig(options);
+  const env = options.env ?? process.env;
+  const controlToken = env.KB1_CONTROL_TOKEN?.trim();
 
   for (const warning of config.deprecationWarnings) {
     console.warn(`[${config.serviceName}] ${warning}`);
@@ -98,6 +100,17 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Sta
   // Every data tool requires a vaultId; there is no default vault.
   const mcpEndpoint = createLocalMcpEndpoint(mcpVaultProvider(registry));
   const relay = createRelayLifecycleController(config, registry);
+  const shutdownSignal = new AbortController();
+  let closeDaemon: (() => Promise<void>) | undefined;
+  let shutdownRequested = false;
+  const completeShutdownRequest = () => {
+    const close = closeDaemon;
+    if (!close) return;
+    void close().catch((error: unknown) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+  };
 
   const app = createApp({
     statusFile: config.statusFile,
@@ -106,11 +119,24 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Sta
     webBuildDir: fileURLToPath(new URL('../../web/build', import.meta.url)),
     webProxyTarget: config.webProxyTarget,
     actorDefault: config.actorDefault,
-    relay
+    relay,
+    shutdownSignal: shutdownSignal.signal,
+    ...(controlToken ? {
+      shutdown: {
+        token: controlToken,
+        requested: () => shutdownRequested,
+        request() {
+          if (shutdownRequested) return;
+          shutdownRequested = true;
+          setTimeout(completeShutdownRequest, 0);
+        }
+      }
+    } : {})
   });
 
   return new Promise((resolve, reject) => {
     let settled = false;
+    let closePromise: Promise<void> | undefined;
     const fail = (error: Error) => {
       if (!settled) {
         settled = true;
@@ -137,18 +163,18 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Sta
             console.log(`KB1_WEB_PROXY_TARGET=${config.webProxyTarget}`);
           }
           console.log(`status=${config.statusFile}`);
-          relay?.connect();
+          if (!shutdownRequested) {
+            relay?.connect();
+          }
 
+          const close = closeDaemon;
+          if (!close) {
+            throw new Error('KB-1 close handler was not initialized.');
+          }
           resolve({
             config,
             status,
-            close: async () => {
-              relay?.disconnect();
-              await mcpEndpoint.close();
-              await closeWebSocketServer(webSocketServer, activeDocumentConnections);
-              await closeServer(server);
-              await registry.close();
-            }
+            close
           });
         } catch (error) {
           server.close();
@@ -157,7 +183,57 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Sta
       }
     );
 
+    closeDaemon = () => {
+      if (!closePromise) {
+        // Stop accepting HTTP mutations first. Closing MCP and WebSocket
+        // transports then drains active work before the registry persists
+        // and closes every document session.
+        const serverClosed = closeServer(server);
+        shutdownSignal.abort();
+        closePromise = (async () => {
+          const errors: unknown[] = [];
+          try {
+            relay?.disconnect();
+          } catch (error) {
+            errors.push(error);
+          }
+
+          const transportResults = await Promise.allSettled([
+            mcpEndpoint.close(),
+            closeWebSocketServer(webSocketServer, activeDocumentConnections),
+            serverClosed
+          ]);
+          for (const result of transportResults) {
+            if (result.status === 'rejected') {
+              errors.push(result.reason);
+            }
+          }
+
+          // Registry persistence is the last shutdown step, but it must still
+          // run if one of the transport drains failed. Otherwise a transport
+          // error can strand dirty document state in memory.
+          try {
+            await registry.close();
+          } catch (error) {
+            errors.push(error);
+          }
+
+          if (errors.length > 0) {
+            throw new AggregateError(errors, 'KB-1 daemon shutdown did not complete cleanly.');
+          }
+        })();
+      }
+      return closePromise;
+    };
+    if (shutdownRequested) {
+      setTimeout(completeShutdownRequest, 0);
+    }
+
     server.on('upgrade', (request, socket, head) => {
+      if (shutdownRequested) {
+        socket.destroy();
+        return;
+      }
       const pathname = request.url ? new URL(request.url, `http://${request.headers.host ?? 'localhost'}`).pathname : '';
       // Resolve the addressed vault's document manager from the scoped
       // `/api/vaults/:id/files/.../yjs` path. An unknown vault or invalid path

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -131,6 +131,62 @@ describe("daemon routing", () => {
     expect(statusFileContents).toMatchObject(body.status);
   });
 
+  it("requires the private control token before requesting daemon shutdown", async () => {
+    const { config, registry } = await setupScopedVault();
+    let requested = false;
+    const request = vi.fn(() => {
+      requested = true;
+    });
+    const app = createApp({
+      statusFile: config.statusFile,
+      registry,
+      shutdown: {
+        token: "test-control-token",
+        requested: () => requested,
+        request,
+      },
+    });
+
+    const missing = await app.request("/api/control/shutdown", {
+      method: "POST",
+    });
+    expect(missing.status).toBe(401);
+
+    const wrong = await app.request("/api/control/shutdown", {
+      method: "POST",
+      headers: { "x-kb1-control-token": "wrong-control-token" },
+    });
+    expect(wrong.status).toBe(401);
+    expect(request).not.toHaveBeenCalled();
+
+    const accepted = await app.request("/api/control/shutdown", {
+      method: "POST",
+      headers: { "x-kb1-control-token": "test-control-token" },
+    });
+    expect(accepted.status).toBe(202);
+    await expect(accepted.json()).resolves.toEqual({
+      ok: true,
+      shuttingDown: true,
+    });
+    expect(request).toHaveBeenCalledOnce();
+
+    const quiesced = await app.request("/api/health");
+    expect(quiesced.status).toBe(503);
+    await expect(quiesced.json()).resolves.toMatchObject({
+      ok: false,
+      error: "shutting_down",
+    });
+
+    const quiescedMcp = await app.request("/mcp", { method: "POST" });
+    expect(quiescedMcp.status).toBe(503);
+    await expect(quiescedMcp.json()).resolves.toMatchObject({
+      ok: false,
+      error: "shutting_down",
+    });
+
+    await registry.close();
+  });
+
   it("exposes daemon relay lifecycle controls when relay is configured", async () => {
     const relay = fakeRelayLifecycleController();
     const config = createDaemonConfig({
@@ -2175,6 +2231,28 @@ describe("daemon routing", () => {
       await stream.close();
       await server.close();
     }
+  });
+
+  it("closes long-lived event streams when daemon shutdown begins", async () => {
+    const { registry, config } = await setupScopedVault();
+    const shutdown = new AbortController();
+    const app = createApp({
+      statusFile: config.statusFile,
+      registry,
+      actorDefault: config.actorDefault,
+      shutdownSignal: shutdown.signal,
+    });
+
+    const response = await app.request(`/api/vaults/${VAULT}/events`);
+    expect(response.status).toBe(200);
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("Expected SSE response body");
+
+    shutdown.abort();
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
   });
 
   it("covers vault info and non-live folder route branches", async () => {

--- a/apps/daemon/src/status.ts
+++ b/apps/daemon/src/status.ts
@@ -10,6 +10,7 @@ export interface DaemonStatus {
   statusFile: string;
   pid: number;
   nodeVersion: string;
+  instanceId?: string;
 }
 
 export async function writeDaemonStatus(config: DaemonConfig): Promise<DaemonStatus> {
@@ -20,7 +21,8 @@ export async function writeDaemonStatus(config: DaemonConfig): Promise<DaemonSta
     daemonHome: config.daemonHome,
     statusFile: config.statusFile,
     pid: config.pid,
-    nodeVersion: process.version
+    nodeVersion: process.version,
+    ...(config.instanceId ? { instanceId: config.instanceId } : {})
   };
 
   await mkdir(config.daemonHome, { recursive: true });
@@ -53,5 +55,6 @@ function isDaemonStatus(value: unknown): value is DaemonStatus {
     && typeof status.daemonHome === 'string'
     && typeof status.statusFile === 'string'
     && typeof status.pid === 'number'
-    && typeof status.nodeVersion === 'string';
+    && typeof status.nodeVersion === 'string'
+    && (status.instanceId === undefined || typeof status.instanceId === 'string');
 }

--- a/docs/packaging/daemon.md
+++ b/docs/packaging/daemon.md
@@ -96,6 +96,64 @@ open http://127.0.0.1:8787/
 The daemon owns one port in this mode: `/api/*` is the Hono API and every
 non-API route is served from the built SvelteKit shell with an SPA fallback.
 
+## Windows per-user background task
+
+Windows 11 supports the same source-built daemon through a per-user Scheduled
+Task. From a cloned checkout:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File `
+  .\skills\kb-1-daemon-setup\scripts\install_kb1_daemon_user_task.ps1
+```
+
+The installer prepares the requested source revision, installs the lockfile,
+runs `pnpm check` (`-BuildOnly` runs `pnpm build` instead), registers `KB-1
+Local` to start at logon, starts it immediately, and verifies that `/api/health`
+belongs to the configured task process and home. The task runs as the current
+user with limited privileges and stays bound to loopback unless the operator
+explicitly passes `-ConfirmNonLoopbackBind`.
+
+Use `-Action Status`, `Start`, `Stop`, or `Uninstall` for lifecycle management.
+Stop, replacement, and uninstall use a private per-task control token and launch
+nonce to verify the exact supervised daemon. Graceful shutdown stops new HTTP
+mutations, drains active transports, and closes every vault session before the
+process exits. Lifecycle operations fail closed when that shutdown cannot be
+verified unless the operator explicitly supplies `-ForceStop`; that fallback
+matches the protected PID, Node path, and process start time before terminating
+the complete daemon process tree. Uninstalling preserves the repository, logs,
+and vault data. CI exercises the complete register/status/stop/restart/unregister
+lifecycle on a Windows runner. By default the installer uses the checkout
+containing the script; pass `-RepoDir` only to select a different clone.
+Private task configuration, logs, and managed runtimes are stored beneath
+`$env:LOCALAPPDATA\KB-1\tasks`, separately from vault data in `KB1_HOME`.
+Registration is transactional: a failed fresh install removes the broken task,
+while a failed replacement restores the prior task definition, configuration,
+and runnable code. Initial installation and upgrades clone and build the exact
+selected commit in an isolated, owner-only versioned runtime before the old task
+is stopped. Dependencies use a runtime-local pnpm store, and runtime reparse
+points may not escape the protected root. A clean branch that is only behind its configured
+upstream advances to that fetched upstream commit; detached checkouts, local
+commits, and diverged branches preserve their selected commit. Task
+upgrades also preserve the installed source checkout, `KB1_HOME`, bind, and
+port unless the operator explicitly supplies an override. Task
+configuration and managed runtimes are restricted to the current Windows user.
+Task-name and `KB1_HOME` mutexes serialize lifecycle operations, so differently
+named tasks cannot race past the one-task-per-home check.
+Before any repository tool or script runs, the installer verifies the checkout
+boundary and executable ownership/permissions; it also rejects persistent paths
+another untrusted local principal can replace (including through the checkout
+parent or selected PowerShell binary). Inactive versioned runtimes are pruned
+after a successful replacement. A same-named task without KB-1's current-user
+ownership signature is never replaced or removed.
+
+Windows policy can require an elevated PowerShell window for registration, but
+the registered task itself uses the current user's limited run level.
+
+This is intentionally described as a source-based background task. It is not a
+signed MSI/MSIX and does not register Node directly with Windows Service Control
+Manager. A true native service requires a service-aware wrapper, code signing,
+artifact provenance, upgrade/rollback behavior, and an owned release channel.
+
 ## Docker
 
 The Docker path supports direct image runs and includes a Compose-backed
@@ -194,7 +252,8 @@ The daemon package reserves the future CLI binary name:
 ```
 
 Publishing is deferred. The supported public setup path is `git clone` plus the
-setup skill while packaging is hardened. Packaging hardening should make
+setup skill, including its Windows per-user task path, while native packaging is
+hardened. Packaging hardening should make
 `@kb-1/daemon` publishable, add provenance/signing rules, define whether the
 open-source package publishes from this package directly or from a dedicated
 release wrapper, and choose the public binary/package names.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,9 @@
 # Release Process
 
 KB-1 Local is currently distributed from source and as a Docker build from this
-repository. The npm workspace packages are private and are not published.
+repository. Windows source installs may use the tested per-user Scheduled Task
+installer. The npm workspace packages are private and are not published, and
+there is no signed native Windows installer or SCM service release.
 
 ## Release Checklist
 
@@ -36,6 +38,12 @@ repository. The npm workspace packages are private and are not published.
    check fails. Set
    `KB1_RELEASE_SMOKE_IMAGE` to override the image tag or
    `KB1_RELEASE_SMOKE_PORT` when a fixed host port is needed.
+
+   The regular GitHub Actions check must also pass its Windows jobs. Those jobs
+   verify source startup, note create/read/soft-delete, restart persistence,
+   process-tree shutdown, and the per-user Scheduled Task lifecycle, including
+   isolation after a failed staged build and rollback after a failed
+   replacement.
 
 6. Run a dedicated secret scanner across the full Git history and review
    dependency alerts.

--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -5,7 +5,7 @@ import { dirname, join } from 'node:path';
 
 import * as Y from 'yjs';
 
-import { createFastDiffYTextDelta } from './session.js';
+import { createFastDiffYTextDelta, resolveWatchDirectory } from './session.js';
 import {
   OneFileDocumentSession,
   DocumentSessionManager,
@@ -24,6 +24,23 @@ describe('OneFileDocumentSession', () => {
 
   afterEach(async () => {
     await rm(kb1Home, { force: true, recursive: true });
+  });
+
+  it('canonicalizes Windows watcher directories before starting fs.watch', () => {
+    const shortPath = 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\kb1';
+    const longPath = 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\kb1';
+    const nativeRealpath = vi.fn(() => longPath);
+    const cache = new Map<string, string>();
+
+    expect(resolveWatchDirectory(shortPath, 'win32', nativeRealpath, cache)).toBe(longPath);
+    expect(nativeRealpath).toHaveBeenCalledOnce();
+    expect(nativeRealpath).toHaveBeenCalledWith(shortPath);
+
+    nativeRealpath.mockClear();
+    expect(resolveWatchDirectory(shortPath, 'win32', nativeRealpath, cache)).toBe(longPath);
+    expect(resolveWatchDirectory(longPath, 'win32', nativeRealpath, cache)).toBe(longPath);
+    expect(resolveWatchDirectory('/tmp/kb1', 'linux', nativeRealpath, cache)).toBe('/tmp/kb1');
+    expect(nativeRealpath).not.toHaveBeenCalled();
   });
 
   it('maps fast-diff output to a Y.Text delta that reproduces randomized disk content exactly', () => {

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { watch, type FSWatcher } from 'node:fs';
+import { realpathSync, watch, type FSWatcher } from 'node:fs';
 import { mkdir, open, readFile, rename, rm } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 
@@ -21,6 +21,32 @@ const DOCUMENT_SESSION_STATE_VERSION = 1;
 const EXTERNAL_CHANGE_ORIGIN = Symbol('kb1.external-change');
 const WATCH_DEBOUNCE_MS = 150;
 const WATCH_POLL_MS = 2000;
+const WINDOWS_WATCH_DIRECTORY_CACHE = new Map<string, string>();
+
+export function resolveWatchDirectory(
+  directory: string,
+  platform: NodeJS.Platform = process.platform,
+  nativeRealpath: (path: string) => string = realpathSync.native,
+  cache: Map<string, string> = WINDOWS_WATCH_DIRECTORY_CACHE
+): string {
+  // Windows can report the watched directory through its long path even when
+  // the caller supplied an equivalent 8.3 short path. Older libuv releases
+  // assert when those two spellings no longer share a textual prefix, so hand
+  // fs.watch() the canonical spelling up front.
+  if (platform !== 'win32') {
+    return directory;
+  }
+
+  const cached = cache.get(directory);
+  if (cached) {
+    return cached;
+  }
+
+  const resolved = nativeRealpath(directory);
+  cache.set(directory, resolved);
+  cache.set(resolved, resolved);
+  return resolved;
+}
 
 interface DocumentSessionStateFile {
   version: typeof DOCUMENT_SESSION_STATE_VERSION;
@@ -602,28 +628,32 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
     const directory = dirname(this.filePath);
     const filename = basename(this.filePath);
 
-    this.watcher = watch(directory, (eventType, changedFilename) => {
-      if (eventType !== 'change' && eventType !== 'rename') {
-        return;
-      }
-
-      if (changedFilename && changedFilename.toString() !== filename) {
-        return;
-      }
-
-      this.scheduleExternalCheck();
-    });
-
-    this.watcher.on('error', (error) => {
-      console.warn(`KB-1 file watcher failed for ${this.filePath}; fallback polling remains active.`, error);
-    });
-
     this.watchPollTimer = setInterval(() => {
       this.checkForExternalChange().catch((error: unknown) => {
         console.warn(`KB-1 fallback file poll failed for ${this.filePath}.`, error);
       });
     }, this.watchPollMs);
     this.watchPollTimer.unref?.();
+
+    try {
+      this.watcher = watch(resolveWatchDirectory(directory), (eventType, changedFilename) => {
+        if (eventType !== 'change' && eventType !== 'rename') {
+          return;
+        }
+
+        if (changedFilename && changedFilename.toString() !== filename) {
+          return;
+        }
+
+        this.scheduleExternalCheck();
+      });
+
+      this.watcher.on('error', (error) => {
+        console.warn(`KB-1 file watcher failed for ${this.filePath}; fallback polling remains active.`, error);
+      });
+    } catch (error) {
+      console.warn(`KB-1 file watcher could not start for ${this.filePath}; fallback polling remains active.`, error);
+    }
   }
 
   private stopWatching(): void {

--- a/packages/doc-session/src/websocket.test.ts
+++ b/packages/doc-session/src/websocket.test.ts
@@ -374,6 +374,10 @@ describe('Yjs WebSocket session', () => {
       encoding.writeVarUint8Array(encoder, Y.encodeStateAsUpdate(stalePeer));
     }));
     await session.flush();
+    await waitUntil(
+      () => staleSocket.closed.length > 0,
+      () => 'Timed out waiting for the divergent stale socket to close',
+    );
 
     expect(staleSocket.closed).toEqual([{
       code: DOCUMENT_SESSION_FAILURE_CLOSE_CODE,

--- a/packages/local-mcp/src/server.test.ts
+++ b/packages/local-mcp/src/server.test.ts
@@ -39,8 +39,134 @@ describe("local MCP server", () => {
       }),
     );
     expect(postResponse.status).toBe(400);
+    await expect(postResponse.json()).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      error: {
+        code: -32000,
+        message: "Bad Request: No valid MCP session id provided",
+      },
+      id: null,
+    });
 
     await endpoint.close();
+  });
+
+  it("waits for an accepted initialization request before closing sessions", async () => {
+    const endpoint = createLocalMcpEndpoint(emptyService());
+    const request = new Request("http://127.0.0.1/mcp", {
+      method: "POST",
+      headers: {
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "init-race-test", version: "1.0.0" },
+        },
+      }),
+    });
+    const cloneRequest = request.clone.bind(request);
+    let releaseParsing: (() => void) | undefined;
+    const parseGate = new Promise<void>((resolve) => {
+      releaseParsing = resolve;
+    });
+    let markParsingStarted: (() => void) | undefined;
+    const parsingStarted = new Promise<void>((resolve) => {
+      markParsingStarted = resolve;
+    });
+    vi.spyOn(request, "clone").mockImplementation(() => {
+      const clone = cloneRequest();
+      const parseJson = clone.json.bind(clone);
+      vi.spyOn(clone, "json").mockImplementation(async () => {
+        markParsingStarted?.();
+        await parseGate;
+        return parseJson();
+      });
+      return clone;
+    });
+
+    const initialization = endpoint.handleRequest(request);
+    await within(parsingStarted, "initialization parsing did not start");
+    let closeResolved = false;
+    const closing = endpoint.close().then(() => {
+      closeResolved = true;
+    });
+    await Promise.resolve();
+    expect(closeResolved).toBe(false);
+
+    releaseParsing?.();
+    const response = await within(
+      initialization,
+      "initialization did not finish",
+    );
+    expect(response.status).toBe(200);
+    await Promise.resolve();
+    expect(closeResolved).toBe(false);
+    const responseBody = await within(
+      response.text(),
+      "initialization response body did not finish",
+    );
+    expect(responseBody).toContain('"serverInfo"');
+    await within(closing, "endpoint close did not finish after initialization");
+  });
+
+  it("finishes draining when an admitted response body is cancelled", async () => {
+    const endpoint = createLocalMcpEndpoint(emptyService());
+    const response = await endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "cancel-test", version: "1.0.0" },
+          },
+        }),
+      }),
+    );
+    expect(response.status).toBe(200);
+
+    let closeResolved = false;
+    const closing = endpoint.close().then(() => {
+      closeResolved = true;
+    });
+    await Promise.resolve();
+    expect(closeResolved).toBe(false);
+
+    await response.body?.cancel("client disconnected");
+    await within(closing, "endpoint close did not finish after cancellation");
+  });
+
+  it("releases request tracking when dispatch rejects", async () => {
+    const endpoint = createLocalMcpEndpoint(emptyService());
+    const request = new Request("http://127.0.0.1/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 }),
+    });
+    vi.spyOn(request, "clone").mockImplementation(() => {
+      throw new Error("request body unavailable");
+    });
+
+    await expect(endpoint.handleRequest(request)).rejects.toThrow(
+      "request body unavailable",
+    );
+    await within(
+      endpoint.close(),
+      "endpoint close did not finish after dispatch rejection",
+    );
   });
 
   it("registers every tier-1 tool and forwards calls to the injected service with initialize attribution", async () => {
@@ -500,7 +626,169 @@ describe("local MCP server", () => {
     await transport.terminateSession();
     await endpoint.close();
   });
+
+  it("waits for an in-flight tool mutation before closing MCP transports", async () => {
+    let releaseMutation: (() => void) | undefined;
+    const mutationGate = new Promise<void>((resolve) => {
+      releaseMutation = resolve;
+    });
+    let markMutationStarted: (() => void) | undefined;
+    const mutationStarted = new Promise<void>((resolve) => {
+      markMutationStarted = resolve;
+    });
+    let markMutationFinished: (() => void) | undefined;
+    const mutationFinished = new Promise<void>((resolve) => {
+      markMutationFinished = resolve;
+    });
+    const service = {
+      ...emptyService(),
+      appendNote: async () => {
+        markMutationStarted?.();
+        await mutationGate;
+        markMutationFinished?.();
+        return { ok: true as const };
+      },
+    } satisfies LocalMcpVaultService;
+    const endpoint = createLocalMcpEndpoint(service);
+    const client = new Client({ name: "drain-test-client", version: "1.0.0" });
+    const transport = new StreamableHTTPClientTransport(
+      new URL("http://127.0.0.1/mcp"),
+      {
+        fetch: async (input, init) =>
+          endpoint.handleRequest(
+            input instanceof Request ? input : new Request(input, init),
+          ),
+      },
+    );
+
+    await client.connect(transport);
+    const mutation = toolJson(client, "append_note", {
+      vaultId: "default",
+      path: "note.md",
+      content: "pending",
+    });
+    await within(mutationStarted, "mutation did not start");
+
+    let closeResolved = false;
+    const closing = endpoint.close().then(() => {
+      closeResolved = true;
+    });
+    await Promise.resolve();
+    expect(closeResolved).toBe(false);
+
+    releaseMutation?.();
+    await within(mutationFinished, "mutation service did not finish");
+    await within(closing, "endpoint close did not finish");
+    await expect(within(mutation, "mutation did not finish")).resolves.toEqual({
+      ok: true,
+    });
+
+    const rejected = await endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp"),
+    );
+    expect(rejected.status).toBe(503);
+  });
+
+  it("drains an admitted request whose tool starts during shutdown", async () => {
+    let sessionId: string | null = null;
+    let markMutationStarted: (() => void) | undefined;
+    const mutationStarted = new Promise<void>((resolve) => {
+      markMutationStarted = resolve;
+    });
+    const service = {
+      ...emptyService(),
+      appendNote: async () => {
+        markMutationStarted?.();
+        return { ok: true as const };
+      },
+    } satisfies LocalMcpVaultService;
+    const endpoint = createLocalMcpEndpoint(service);
+    const client = new Client({
+      name: "admission-drain-test-client",
+      version: "1.0.0",
+    });
+    const transport = new StreamableHTTPClientTransport(
+      new URL("http://127.0.0.1/mcp"),
+      {
+        fetch: async (input, init) => {
+          const response = await endpoint.handleRequest(
+            input instanceof Request ? input : new Request(input, init),
+          );
+          sessionId ??= response.headers.get("mcp-session-id");
+          return response;
+        },
+      },
+    );
+    await client.connect(transport);
+    expect(sessionId).toBeTruthy();
+
+    let releaseBody: (() => void) | undefined;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        releaseBody = () => {
+          controller.enqueue(
+            new TextEncoder().encode(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: 2,
+                method: "tools/call",
+                params: {
+                  name: "append_note",
+                  arguments: {
+                    vaultId: "default",
+                    path: "note.md",
+                    content: "admitted",
+                  },
+                },
+              }),
+            ),
+          );
+          controller.close();
+        };
+      },
+    });
+    const admittedRequest = endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+          "mcp-session-id": sessionId!,
+        },
+        body,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" }),
+    );
+    const closing = endpoint.close();
+
+    releaseBody?.();
+    await within(mutationStarted, "admitted mutation did not start");
+    const response = await within(
+      admittedRequest,
+      "admitted request did not finish",
+    );
+    expect(response.status).toBe(200);
+    const responseBody = await within(
+      response.text(),
+      "admitted request response body did not finish",
+    );
+    expect(responseBody).toContain('"id":2');
+    expect(responseBody).toContain('"result"');
+    await within(closing, "endpoint close did not finish");
+  });
 });
+
+async function within<T>(promise: Promise<T>, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), 1_000);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
 
 async function toolJson(
   client: Client,

--- a/packages/local-mcp/src/server.ts
+++ b/packages/local-mcp/src/server.ts
@@ -37,7 +37,10 @@ interface LocalMcpEndpointOptions {
 
 interface LocalMcpServerOptions {
   actor?: LocalMcpActor;
+  trackOperation?: ToolOperationTracker;
 }
+
+type ToolOperationTracker = <T>(operation: () => Promise<T>) => Promise<T>;
 
 interface SessionRecord {
   server: McpServer;
@@ -51,6 +54,7 @@ interface SessionRecord {
  * surface is identical either way.
  */
 type LocalMcpVaultSource = LocalMcpVaultProvider | LocalMcpVaultService;
+const toolOperationTrackers = new WeakMap<McpServer, ToolOperationTracker>();
 
 export function createLocalMcpEndpoint(
   source: LocalMcpVaultSource,
@@ -58,62 +62,186 @@ export function createLocalMcpEndpoint(
 ): LocalMcpEndpoint {
   const provider = asProvider(source);
   const sessions = new Map<string, SessionRecord>();
-
-  return {
-    async handleRequest(request) {
-      const sessionId = request.headers.get("mcp-session-id") ?? undefined;
-      const existing = sessionId ? sessions.get(sessionId) : undefined;
-      if (existing) {
-        return existing.transport.handleRequest(request);
+  const activeHttpRequests = new Set<Promise<void>>();
+  const activeOperations = new Set<Promise<void>>();
+  let acceptingRequests = true;
+  let acceptingOperations = true;
+  let closePromise: Promise<void> | undefined;
+  const trackOperation: ToolOperationTracker = async (operation) => {
+    if (!acceptingOperations) {
+      throw new Error("MCP endpoint is shutting down");
+    }
+    let markFinished: (() => void) | undefined;
+    const finished = new Promise<void>((resolve) => {
+      markFinished = resolve;
+    });
+    activeOperations.add(finished);
+    try {
+      return await operation();
+    } finally {
+      // Let the MCP SDK finish formatting and enqueueing the tool response
+      // before close() tears down the transport and clears its response map.
+      setImmediate(() => {
+        activeOperations.delete(finished);
+        markFinished?.();
+      });
+    }
+  };
+  const trackHttpRequest = async (
+    request: Promise<Response>,
+  ): Promise<Response> => {
+    let markFinished: (() => void) | undefined;
+    const finished = new Promise<void>((resolve) => {
+      markFinished = resolve;
+    });
+    let isFinished = false;
+    const finish = () => {
+      if (isFinished) return;
+      isFinished = true;
+      activeHttpRequests.delete(finished);
+      markFinished?.();
+    };
+    activeHttpRequests.add(finished);
+    try {
+      const response = await request;
+      if (!response.body) {
+        finish();
+        return response;
       }
 
-      const parsedBody =
-        request.method === "POST"
-          ? await request
-              .clone()
-              .json()
-              .catch(() => undefined)
-          : undefined;
-      if (request.method !== "POST" || !isInitializeRequest(parsedBody)) {
-        return jsonRpcError(
-          "Bad Request: No valid MCP session id provided",
-          400,
-        );
-      }
-
-      const actor = options.actorFromRequest?.(request);
-      if (isServiceFailure(actor)) {
-        return jsonRpcError(`Bad Request: ${actor.message}`, 400);
-      }
-
-      let assignedSessionId: string | undefined;
-      const transport = new WebStandardStreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
-        onsessioninitialized: (nextSessionId) => {
-          assignedSessionId = nextSessionId;
+      // The MCP transport may resolve handleRequest() as soon as it creates a
+      // streaming response, before its JSON-RPC handler has enqueued the
+      // response body. Keep the request active until the server/client has
+      // actually consumed or cancelled that body so close() cannot tear down
+      // the transport between those two events.
+      const reader = response.body.getReader();
+      const body = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          try {
+            const chunk = await reader.read();
+            if (chunk.done) {
+              controller.close();
+              reader.releaseLock();
+              finish();
+              return;
+            }
+            controller.enqueue(chunk.value);
+          } catch (error) {
+            controller.error(error);
+            reader.releaseLock();
+            finish();
+          }
+        },
+        async cancel(reason) {
+          try {
+            await reader.cancel(reason);
+          } finally {
+            reader.releaseLock();
+            finish();
+          }
         },
       });
-      const server = createLocalMcpServer(provider, { actor });
+      return new Response(body, {
+        headers: response.headers,
+        status: response.status,
+        statusText: response.statusText,
+      });
+    } catch (error) {
+      finish();
+      throw error;
+    }
+  };
 
-      transport.onclose = () => {
-        const id = transport.sessionId ?? assignedSessionId;
-        if (id) sessions.delete(id);
-      };
-
-      await server.connect(transport);
-      const response = await transport.handleRequest(request, { parsedBody });
-      const id = transport.sessionId ?? assignedSessionId;
-      if (id) {
-        sessions.set(id, { server, transport });
+  return {
+    handleRequest(request) {
+      if (!acceptingRequests) {
+        return Promise.resolve(
+          jsonRpcError("Service Unavailable: MCP endpoint is shutting down", 503),
+        );
       }
-      return response;
+      const response = handleMcpRequest(
+        provider,
+        sessions,
+        options,
+        trackOperation,
+        request,
+      );
+      return request.method === "GET" ? response : trackHttpRequest(response);
     },
-    async close() {
-      const records = [...sessions.values()];
-      sessions.clear();
-      await Promise.all(records.map(({ server }) => server.close()));
+    close() {
+      if (!closePromise) {
+        acceptingRequests = false;
+        closePromise = (async () => {
+          // Requests admitted before the shutdown boundary may still be
+          // parsing their body or dispatching a tool. Let those requests
+          // finish admitting their operations before closing that second
+          // gate, then drain every operation before tearing down sessions.
+          await Promise.all([...activeHttpRequests]);
+          acceptingOperations = false;
+          await Promise.all([...activeOperations]);
+          const records = [...sessions.values()];
+          sessions.clear();
+          await Promise.all(records.map(({ server }) => server.close()));
+        })();
+      }
+      return closePromise;
     },
   };
+}
+
+async function handleMcpRequest(
+  provider: LocalMcpVaultProvider,
+  sessions: Map<string, SessionRecord>,
+  options: LocalMcpEndpointOptions,
+  trackOperation: ToolOperationTracker,
+  request: Request,
+): Promise<Response> {
+  const sessionId = request.headers.get("mcp-session-id") ?? undefined;
+  const existing = sessionId ? sessions.get(sessionId) : undefined;
+  if (existing) {
+    return existing.transport.handleRequest(request);
+  }
+
+  const parsedBody =
+    request.method === "POST"
+      ? await request
+          .clone()
+          .json()
+          .catch(() => undefined)
+      : undefined;
+  if (request.method !== "POST" || !isInitializeRequest(parsedBody)) {
+    return jsonRpcError(
+      "Bad Request: No valid MCP session id provided",
+      400,
+    );
+  }
+
+  const actor = options.actorFromRequest?.(request);
+  if (isServiceFailure(actor)) {
+    return jsonRpcError(`Bad Request: ${actor.message}`, 400);
+  }
+
+  let assignedSessionId: string | undefined;
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+    onsessioninitialized: (nextSessionId) => {
+      assignedSessionId = nextSessionId;
+    },
+  });
+  const server = createLocalMcpServer(provider, { actor, trackOperation });
+
+  transport.onclose = () => {
+    const id = transport.sessionId ?? assignedSessionId;
+    if (id) sessions.delete(id);
+  };
+
+  await server.connect(transport);
+  const response = await transport.handleRequest(request, { parsedBody });
+  const id = transport.sessionId ?? assignedSessionId;
+  if (id) {
+    sessions.set(id, { server, transport });
+  }
+  return response;
 }
 
 export function createLocalMcpServer(
@@ -127,6 +255,9 @@ export function createLocalMcpServer(
     name: "kb-1-local-daemon",
     version: "0.0.0",
   });
+  if (options.trackOperation) {
+    toolOperationTrackers.set(server, options.trackOperation);
+  }
 
   const actor = (): LocalMcpActor => {
     if (options.actor) return options.actor;
@@ -730,7 +861,9 @@ function registerTool<TInput extends object>(
   handler: (input: TInput) => Promise<unknown>,
 ): void {
   server.registerTool(name, config, async (input) => {
-    const result = await handler(input as TInput);
+    const operation = () => handler(input as TInput);
+    const tracker = toolOperationTrackers.get(server);
+    const result = await (tracker ? tracker(operation) : operation());
     if (isDirectToolResult(result)) {
       return result;
     }

--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -1656,10 +1656,42 @@ describe("vault-core filesystem operations", () => {
     });
     expect(deleted.ok).toBe(true);
     const trashPath = deleted.ok ? deleted.value.trashPath : undefined;
-    expect(trashPath).toMatch(/^\.kb1\/trash\/.+\/folder$/);
+    expect(trashPath).toMatch(
+      /^\.kb1\/trash\/\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z-[0-9a-f-]{36}\/folder$/,
+    );
+    const trashBatch = trashPath?.split("/")[2];
+    expect(trashBatch).not.toMatch(/[<>:"\\|?*]/);
     await expect(
       readFile(path.join(root, trashPath!, "file.md"), "utf8"),
     ).resolves.toBe("x");
+  });
+
+  it("keeps repeated soft deletes distinct even within the same millisecond", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-28T10:13:11.123Z"));
+    try {
+      await writeVaultFile(ctx, { path: "recreated.md", content: "first" });
+      const first = await deleteVaultFile(ctx, { path: "recreated.md" });
+      await writeVaultFile(ctx, { path: "recreated.md", content: "second" });
+      const second = await deleteVaultFile(ctx, { path: "recreated.md" });
+
+      expect(first.ok).toBe(true);
+      expect(second.ok).toBe(true);
+      const firstTrashPath = first.ok ? first.value.trashPath : undefined;
+      const secondTrashPath = second.ok ? second.value.trashPath : undefined;
+      expect(firstTrashPath).toMatch(
+        /^\.kb1\/trash\/2026-07-28T10-13-11\.123Z-[0-9a-f-]{36}\/recreated\.md$/,
+      );
+      expect(secondTrashPath).not.toBe(firstTrashPath);
+      await expect(
+        readFile(path.join(root, firstTrashPath!), "utf8"),
+      ).resolves.toBe("first");
+      await expect(
+        readFile(path.join(root, secondTrashPath!), "utf8"),
+      ).resolves.toBe("second");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("permanently deletes files when requested", async () => {

--- a/packages/vault-core/src/vault-ops.ts
+++ b/packages/vault-core/src/vault-ops.ts
@@ -199,10 +199,12 @@ function folderMetadataPath(root: string): string {
 }
 
 function trashRelativePath(originalPath: string): string {
+  const deletedAt = new Date().toISOString().replaceAll(":", "-");
+  const batchId = `${deletedAt}-${randomUUID()}`;
   return path.posix.join(
     ".kb1",
     "trash",
-    new Date().toISOString(),
+    batchId,
     originalPath,
   );
 }

--- a/scripts/windows-smoke.mjs
+++ b/scripts/windows-smoke.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -18,6 +18,7 @@ const port = await reservePort();
 const origin = `http://127.0.0.1:${port}`;
 const timeoutMs = Number(process.env.KB1_WINDOWS_SMOKE_TIMEOUT_MS || '90000');
 const expectedContent = `# Windows smoke\n\nPersistent note ${Date.now()}\n`;
+const trashedContent = `# Windows trash smoke\n\nSoft-deleted note ${Date.now()}\n`;
 let daemon;
 
 try {
@@ -34,6 +35,7 @@ try {
     throw new Error(`Windows smoke note create failed: HTTP ${created.status} ${await created.text()}`);
   }
   await verifyNote();
+  await verifySoftDelete();
 
   await stopDaemon(daemon);
   daemon = undefined;
@@ -44,7 +46,7 @@ try {
   await verifyNote();
 
   console.log('Windows source smoke passed.');
-  console.log('Verified daemon startup, note create/read, process-tree shutdown, and restart persistence.');
+  console.log('Verified daemon startup, note create/read/soft-delete, process-tree shutdown, and restart persistence.');
 } catch (error) {
   if (daemon?.logs) {
     console.error('\nDaemon output:');
@@ -130,6 +132,57 @@ async function verifyNote() {
     throw new Error(
       `Windows smoke note read failed: HTTP ${response.status} ${JSON.stringify(body)}`
     );
+  }
+}
+
+async function verifySoftDelete() {
+  const noteUrl = `${origin}/api/vaults/demo-vault/files/windows-trash-smoke.md`;
+  const created = await fetch(noteUrl, {
+    method: 'PUT',
+    headers: { 'content-type': 'text/plain' },
+    body: trashedContent,
+    signal: AbortSignal.timeout(timeoutMs)
+  });
+  if (created.status !== 201) {
+    throw new Error(`Windows trash smoke note create failed: HTTP ${created.status} ${await created.text()}`);
+  }
+
+  const deleted = await fetch(noteUrl, {
+    method: 'DELETE',
+    signal: AbortSignal.timeout(timeoutMs)
+  });
+  const body = await deleted.json();
+  if (!deleted.ok || body.ok !== true || typeof body.trashPath !== 'string') {
+    throw new Error(
+      `Windows trash smoke delete failed: HTTP ${deleted.status} ${JSON.stringify(body)}`
+    );
+  }
+
+  const trashSegments = body.trashPath.split('/');
+  const trashBatch = trashSegments[2];
+  if (
+    trashSegments[0] !== '.kb1'
+    || trashSegments[1] !== 'trash'
+    || trashSegments.at(-1) !== 'windows-trash-smoke.md'
+    || typeof trashBatch !== 'string'
+    || /[<>:"\\|?*]/.test(trashBatch)
+  ) {
+    throw new Error(`Windows trash smoke returned a non-portable path: ${body.trashPath}`);
+  }
+
+  const trashed = await readFile(
+    join(kb1Home, 'vaults', 'demo-vault', ...trashSegments),
+    'utf8'
+  );
+  if (trashed !== trashedContent) {
+    throw new Error(`Windows trash smoke content mismatch at ${body.trashPath}`);
+  }
+
+  const missing = await fetch(noteUrl, {
+    signal: AbortSignal.timeout(timeoutMs)
+  });
+  if (missing.status !== 404) {
+    throw new Error(`Windows trash smoke original remained readable: HTTP ${missing.status}`);
   }
 }
 

--- a/scripts/windows-task-smoke.ps1
+++ b/scripts/windows-task-smoke.ps1
@@ -21,7 +21,37 @@ if ([string]::IsNullOrWhiteSpace($systemDriveRoot)) {
   throw "A local Windows system drive is required for the Windows task smoke test."
 }
 $kb1Home = Join-Path $systemDriveRoot "kb1-windows-task~archive-$([Guid]::NewGuid().ToString('N'))"
+$trustedToolsRoot = Join-Path $systemDriveRoot "kb1-windows-tools-$([Guid]::NewGuid().ToString('N'))"
+$sourceNodeDirectory = Split-Path -Parent (
+  (Get-Command node.exe -ErrorAction Stop).Source
+)
+$originalPath = [string]$env:PATH
 $taskName = "KB-1 Windows Smoke $([Guid]::NewGuid().ToString('N'))"
+function Set-OwnerOnlyDirectoryAcl {
+  param([string]$Path)
+
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $acl = Get-Acl -LiteralPath $Path
+  $acl.SetAccessRuleProtection($true, $false)
+  foreach ($accessRule in @($acl.Access)) {
+    $null = $acl.RemoveAccessRuleSpecific($accessRule)
+  }
+  $acl.SetOwner($identity.User)
+  $acl.AddAccessRule(
+    [Security.AccessControl.FileSystemAccessRule]::new(
+      $identity.User,
+      [Security.AccessControl.FileSystemRights]::FullControl,
+      (
+        [Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+        [Security.AccessControl.InheritanceFlags]::ObjectInherit
+      ),
+      [Security.AccessControl.PropagationFlags]::None,
+      [Security.AccessControl.AccessControlType]::Allow
+    )
+  )
+  Set-Acl -LiteralPath $Path -AclObject $acl
+}
+
 function Get-StorageKey {
   param([string]$Value)
 
@@ -129,6 +159,12 @@ $commonArguments = @(
 )
 
 try {
+  New-Item -ItemType Directory -Path $trustedToolsRoot | Out-Null
+  Set-OwnerOnlyDirectoryAcl $trustedToolsRoot
+  Get-ChildItem -LiteralPath $sourceNodeDirectory -Force |
+    Copy-Item -Destination $trustedToolsRoot -Recurse -Force
+  $env:PATH = "$trustedToolsRoot;$originalPath"
+
   Invoke-Installer (@(
     "-Action", "Install",
     "-SkipRepoUpdate",
@@ -405,6 +441,12 @@ try {
   }
   Remove-Item `
     -LiteralPath $runtimeRoot `
+    -Recurse `
+    -Force `
+    -ErrorAction SilentlyContinue
+  $env:PATH = $originalPath
+  Remove-Item `
+    -LiteralPath $trustedToolsRoot `
     -Recurse `
     -Force `
     -ErrorAction SilentlyContinue

--- a/scripts/windows-task-smoke.ps1
+++ b/scripts/windows-task-smoke.ps1
@@ -279,15 +279,40 @@ function Invoke-Installer {
 }
 
 function Invoke-InstallerExpectedFailure {
-  param([string[]]$InstallerArguments)
+  param(
+    [string[]]$InstallerArguments,
+    [string[]]$ExpectedOutputSubstrings = @()
+  )
 
-  & $powerShell `
-    -NoProfile `
-    -NonInteractive `
-    -ExecutionPolicy Bypass `
-    -File $installer `
-    @InstallerArguments
-  if ($LASTEXITCODE -eq 0) {
+  if ($ExpectedOutputSubstrings.Count -eq 0) {
+    & $powerShell `
+      -NoProfile `
+      -NonInteractive `
+      -ExecutionPolicy Bypass `
+      -File $installer `
+      @InstallerArguments
+    $installerExitCode = $LASTEXITCODE
+  } else {
+    $installerOutput = @(
+      & $powerShell `
+        -NoProfile `
+        -NonInteractive `
+        -ExecutionPolicy Bypass `
+        -File $installer `
+        @InstallerArguments 2>&1
+    )
+    $installerExitCode = $LASTEXITCODE
+    foreach ($outputLine in $installerOutput) {
+      Write-Host ([string]$outputLine)
+    }
+    $combinedInstallerOutput = $installerOutput | Out-String
+    foreach ($expectedSubstring in $ExpectedOutputSubstrings) {
+      if (-not $combinedInstallerOutput.Contains($expectedSubstring)) {
+        throw "Expected installer failure output to contain: $expectedSubstring"
+      }
+    }
+  }
+  if ($installerExitCode -eq 0) {
     throw "Windows task installer unexpectedly succeeded."
   }
 }
@@ -532,13 +557,54 @@ try {
     }
   }
 
-  Invoke-InstallerExpectedFailure (@(
-    "-Action", "Install",
-    "-SkipRepoUpdate",
-    "-SkipDependencyInstall",
-    "-BuildOnly",
-    "-HealthTimeoutSeconds", "5"
-  ) + $commonArguments)
+  $failingBuildPath = Join-Path `
+    $trustedSourceRoot `
+    "apps\daemon\src\windows-smoke-build-failure.ts"
+  Set-Content `
+    -LiteralPath $failingBuildPath `
+    -Value "const windowsSmokeBuildFailure: string = 1; export {};"
+  & $sourceGitPath `
+    -C $trustedSourceRoot `
+    add `
+    -- `
+    "apps/daemon/src/windows-smoke-build-failure.ts"
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not stage the intentional Windows smoke build failure."
+  }
+  & $sourceGitPath `
+    -C $trustedSourceRoot `
+    -c "user.name=KB-1 Windows Smoke" `
+    -c "user.email=windows-smoke@kb-1.invalid" `
+    commit `
+    --no-gpg-sign `
+    --no-verify `
+    -m "test: force Windows smoke build failure"
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not commit the intentional Windows smoke build failure."
+  }
+  try {
+    Invoke-InstallerExpectedFailure `
+      -InstallerArguments (@(
+        "-Action", "Install",
+        "-SkipRepoUpdate",
+        "-BuildOnly",
+        "-HealthTimeoutSeconds", "5"
+      ) + $commonArguments) `
+      -ExpectedOutputSubstrings @(
+        "==> Building KB-1 Local",
+        "windows-smoke-build-failure.ts",
+        "TS2322"
+      )
+  } finally {
+    & $sourceGitPath `
+      -C $trustedSourceRoot `
+      reset `
+      --hard `
+      $sourceCommit
+    if ($LASTEXITCODE -ne 0) {
+      throw "Could not restore the Windows smoke source checkout."
+    }
+  }
 
   $healthyAfterBuildFailure = Invoke-DirectRestMethod `
     -Uri $healthUrl `

--- a/scripts/windows-task-smoke.ps1
+++ b/scripts/windows-task-smoke.ps1
@@ -1,0 +1,415 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+if ($env:OS -ne "Windows_NT") {
+  Write-Host "Windows task smoke skipped: this check runs only on Windows."
+  exit 0
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$installer = Join-Path $repoRoot "skills\kb-1-daemon-setup\scripts\install_kb1_daemon_user_task.ps1"
+$powerShell = (Get-Command powershell.exe -ErrorAction Stop).Source
+$kb1Home = Join-Path ([IO.Path]::GetTempPath()) "kb1-windows-task~archive-$([Guid]::NewGuid().ToString('N'))"
+$taskName = "KB-1 Windows Smoke $([Guid]::NewGuid().ToString('N'))"
+function Get-StorageKey {
+  param([string]$Value)
+
+  $sha256 = [Security.Cryptography.SHA256]::Create()
+  try {
+    $bytes = [Text.Encoding]::UTF8.GetBytes($Value)
+    $hash = [BitConverter]::ToString($sha256.ComputeHash($bytes))
+    return $hash.Replace("-", "").Substring(0, 16).ToLowerInvariant()
+  } finally {
+    $sha256.Dispose()
+  }
+}
+$taskKey = Get-StorageKey $taskName.ToUpperInvariant()
+$homeKey = Get-StorageKey (
+  [IO.Path]::GetFullPath($kb1Home).ToUpperInvariant()
+)
+$taskStateDirectory = Join-Path (
+  [Environment]::GetFolderPath(
+    [Environment+SpecialFolder]::LocalApplicationData
+  )
+) "KB-1\tasks"
+$configPath = Join-Path $taskStateDirectory "windows-task-$taskKey.json"
+$runtimeRoot = Join-Path `
+  $taskStateDirectory `
+  "windows-runtimes\$taskKey"
+
+$listener = [Net.Sockets.TcpListener]::new(
+  [Net.IPAddress]::IPv6Loopback,
+  0
+)
+$listener.Start()
+$port = ([Net.IPEndPoint]$listener.LocalEndpoint).Port
+$listener.Stop()
+$healthUrl = "http://[::1]:$port/api/health"
+
+function Invoke-Installer {
+  param([string[]]$InstallerArguments)
+
+  & $powerShell `
+    -NoProfile `
+    -NonInteractive `
+    -ExecutionPolicy Bypass `
+    -File $installer `
+    @InstallerArguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "Windows task installer failed with code $LASTEXITCODE."
+  }
+}
+
+function Invoke-InstallerExpectedFailure {
+  param([string[]]$InstallerArguments)
+
+  & $powerShell `
+    -NoProfile `
+    -NonInteractive `
+    -ExecutionPolicy Bypass `
+    -File $installer `
+    @InstallerArguments
+  if ($LASTEXITCODE -eq 0) {
+    throw "Windows task installer unexpectedly succeeded."
+  }
+}
+
+function Wait-UntilUnavailable {
+  $deadline = [DateTime]::UtcNow.AddSeconds(15)
+  do {
+    try {
+      Invoke-RestMethod -Uri $healthUrl -TimeoutSec 1 | Out-Null
+    } catch {
+      return
+    }
+    Start-Sleep -Milliseconds 250
+  } while ([DateTime]::UtcNow -lt $deadline)
+
+  throw "KB-1 remained reachable after the Scheduled Task stopped."
+}
+
+function New-OwnerOnlyGlobalMutex {
+  param([string]$Name)
+
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $security = [Security.AccessControl.MutexSecurity]::new()
+  $security.SetOwner($identity.User)
+  $security.SetAccessRuleProtection($true, $false)
+  $security.AddAccessRule(
+    [Security.AccessControl.MutexAccessRule]::new(
+      $identity.User,
+      [Security.AccessControl.MutexRights]::FullControl,
+      [Security.AccessControl.AccessControlType]::Allow
+    )
+  )
+  $createdNew = $false
+  return [Threading.Mutex]::new(
+    $false,
+    $Name,
+    [ref]$createdNew,
+    $security
+  )
+}
+
+$commonArguments = @(
+  "-RepoDir", $repoRoot,
+  "-KB1Home", $kb1Home,
+  "-BindHost", "[::1]",
+  "-Port", [string]$port,
+  "-TaskName", $taskName
+)
+
+try {
+  Invoke-Installer (@(
+    "-Action", "Install",
+    "-SkipRepoUpdate",
+    "-BuildOnly",
+    "-HealthTimeoutSeconds", "15"
+  ) + $commonArguments)
+
+  Invoke-Installer (@("-Action", "Status") + $commonArguments)
+
+  if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+    throw "Expected one owner-only Windows task config."
+  }
+  $currentSid = (
+    [Security.Principal.WindowsIdentity]::GetCurrent()
+  ).User.Value
+  $installedConfig = Get-Content -LiteralPath $configPath -Raw |
+    ConvertFrom-Json
+  $activeRuntime = [string]$installedConfig.repoDir
+  if (
+    -not $activeRuntime.StartsWith(
+      "$runtimeRoot\",
+      [StringComparison]::OrdinalIgnoreCase
+    )
+  ) {
+    throw "The Scheduled Task was not installed from its protected runtime root."
+  }
+  if ([string]$installedConfig.bindHost -ne "::1") {
+    throw "The installer did not normalize the bracketed IPv6 bind host."
+  }
+  $sharedChildPath = Join-Path $kb1Home "shared-child"
+  New-Item -ItemType Directory -Path $sharedChildPath | Out-Null
+  $sharedChildAcl = Get-Acl -LiteralPath $sharedChildPath
+  $sharedChildAcl.SetAccessRuleProtection($true, $false)
+  $sharedChildAcl.AddAccessRule(
+    [Security.AccessControl.FileSystemAccessRule]::new(
+      [Security.Principal.SecurityIdentifier]::new($currentSid),
+      [Security.AccessControl.FileSystemRights]::FullControl,
+      (
+        [Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+        [Security.AccessControl.InheritanceFlags]::ObjectInherit
+      ),
+      [Security.AccessControl.PropagationFlags]::None,
+      [Security.AccessControl.AccessControlType]::Allow
+    )
+  )
+  $sharedChildAcl.AddAccessRule(
+    [Security.AccessControl.FileSystemAccessRule]::new(
+      [Security.Principal.SecurityIdentifier]::new("S-1-5-32-545"),
+      [Security.AccessControl.FileSystemRights]::Modify,
+      (
+        [Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+        [Security.AccessControl.InheritanceFlags]::ObjectInherit
+      ),
+      [Security.AccessControl.PropagationFlags]::None,
+      [Security.AccessControl.AccessControlType]::Allow
+    )
+  )
+  Set-Acl -LiteralPath $sharedChildPath -AclObject $sharedChildAcl
+  try {
+    Invoke-InstallerExpectedFailure (
+      @("-Action", "Start") + $commonArguments
+    )
+  } finally {
+    Remove-Item -LiteralPath $sharedChildPath -Recurse -Force
+  }
+
+  $junctionTarget = Join-Path (
+    [IO.Path]::GetTempPath()
+  ) "kb1-windows-junction-target-$([Guid]::NewGuid().ToString('N'))"
+  $junctionPath = Join-Path $kb1Home "redirected-vault"
+  New-Item -ItemType Directory -Path $junctionTarget | Out-Null
+  & cmd.exe /d /c mklink /J $junctionPath $junctionTarget | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not create the KB1_HOME junction used by the smoke test."
+  }
+  try {
+    Invoke-Installer (@("-Action", "Status") + $commonArguments)
+    Invoke-Installer (@("-Action", "Stop") + $commonArguments)
+    Wait-UntilUnavailable
+    Invoke-InstallerExpectedFailure (@("-Action", "Start") + $commonArguments)
+  } finally {
+    & cmd.exe /d /c rmdir $junctionPath
+    Remove-Item -LiteralPath $junctionTarget -Recurse -Force
+  }
+  Invoke-Installer (@("-Action", "Start") + $commonArguments)
+  Invoke-Installer @(
+    "-Action", "Install",
+    "-TaskName", $taskName,
+    "-SkipRepoUpdate",
+    "-SkipDependencyInstall",
+    "-SkipBuild",
+    "-HealthTimeoutSeconds", "15"
+  )
+  $preservedConfig = Get-Content -LiteralPath $configPath -Raw |
+    ConvertFrom-Json
+  if (
+    [string]$preservedConfig.kb1Home -ne [string]$kb1Home -or
+    [string]$preservedConfig.bindHost -ne "::1" -or
+    [int]$preservedConfig.port -ne $port -or
+    -not [string]::Equals(
+      [IO.Path]::GetFullPath([string]$preservedConfig.sourceRepoDir),
+      [IO.Path]::GetFullPath($repoRoot),
+      [StringComparison]::OrdinalIgnoreCase
+    )
+  ) {
+    throw "A default upgrade did not preserve the installed custom settings."
+  }
+  $installedConfig = $preservedConfig
+  $installedConfig.bindHost = "::"
+  $installedConfig |
+    ConvertTo-Json |
+    Set-Content -LiteralPath $configPath -Encoding utf8
+  Invoke-Installer (@("-Action", "Status") + $commonArguments)
+  $installedConfig.bindHost = "::1"
+  $installedConfig |
+    ConvertTo-Json |
+    Set-Content -LiteralPath $configPath -Encoding utf8
+
+  $ownerKey = ([string]$currentSid).Replace("-", "")
+  $mutexName = "Global\KB1DaemonTask-$ownerKey-$taskKey"
+  $heldMutex = New-OwnerOnlyGlobalMutex $mutexName
+  try {
+    if (-not $heldMutex.WaitOne(0)) {
+      throw "Could not acquire the task lifecycle mutex for smoke coverage."
+    }
+    Invoke-InstallerExpectedFailure (
+      @("-Action", "Status") + $commonArguments
+    )
+  } finally {
+    $heldMutex.ReleaseMutex()
+    $heldMutex.Dispose()
+  }
+
+  $homeMutexName = "Global\KB1DaemonHome-$ownerKey-$homeKey"
+  $heldHomeMutex = New-OwnerOnlyGlobalMutex $homeMutexName
+  try {
+    if (-not $heldHomeMutex.WaitOne(0)) {
+      throw "Could not acquire the KB1_HOME lifecycle mutex for smoke coverage."
+    }
+    Invoke-InstallerExpectedFailure (
+      @("-Action", "Status") + $commonArguments
+    )
+  } finally {
+    $heldHomeMutex.ReleaseMutex()
+    $heldHomeMutex.Dispose()
+  }
+
+  foreach ($securedPath in @($taskStateDirectory, $configPath)) {
+    foreach ($accessRule in @((Get-Acl -LiteralPath $securedPath).Access)) {
+      if (
+        $accessRule.AccessControlType -ne
+          [Security.AccessControl.AccessControlType]::Allow
+      ) {
+        continue
+      }
+      $ruleSid = $accessRule.IdentityReference.Translate(
+        [Security.Principal.SecurityIdentifier]
+      ).Value
+      if ([string]$ruleSid -ne [string]$currentSid) {
+        throw "Task state path is writable by an unexpected principal: $ruleSid"
+      }
+    }
+  }
+
+  Invoke-InstallerExpectedFailure (@(
+    "-Action", "Install",
+    "-SkipRepoUpdate",
+    "-SkipDependencyInstall",
+    "-BuildOnly",
+    "-HealthTimeoutSeconds", "5"
+  ) + $commonArguments)
+
+  $healthyAfterBuildFailure = Invoke-RestMethod -Uri $healthUrl -TimeoutSec 5
+  if (
+    $healthyAfterBuildFailure.ok -ne $true -or
+    $healthyAfterBuildFailure.service -ne "kb1d"
+  ) {
+    throw "The prior Scheduled Task was disrupted by a failed staged build."
+  }
+  if (
+    -not (Test-Path -LiteralPath $activeRuntime -PathType Container) -or
+    @(
+      Get-ChildItem -LiteralPath $runtimeRoot -Directory
+    ).Count -ne 1
+  ) {
+    throw "A failed staged build changed or leaked the protected runtime set."
+  }
+
+  $blockedListener = [Net.Sockets.TcpListener]::new(
+    [Net.IPAddress]::IPv6Loopback,
+    0
+  )
+  $blockedListener.Start()
+  try {
+    $blockedPort = ([Net.IPEndPoint]$blockedListener.LocalEndpoint).Port
+    $replacementArguments = @($commonArguments)
+    $replacementArguments[7] = [string]$blockedPort
+    Invoke-InstallerExpectedFailure (@(
+      "-Action", "Install",
+      "-SkipRepoUpdate",
+      "-SkipDependencyInstall",
+      "-SkipBuild",
+      "-HealthTimeoutSeconds", "5"
+    ) + $replacementArguments)
+  } finally {
+    $blockedListener.Stop()
+  }
+
+  $restoredHealth = Invoke-RestMethod -Uri $healthUrl -TimeoutSec 5
+  if ($restoredHealth.ok -ne $true -or $restoredHealth.service -ne "kb1d") {
+    throw "The prior Scheduled Task was not restored after failed replacement."
+  }
+
+  $obsoleteRuntime = Join-Path `
+    $runtimeRoot `
+    ([Guid]::NewGuid().ToString("N"))
+  New-Item -ItemType Directory -Path $obsoleteRuntime -Force | Out-Null
+  Set-Content `
+    -LiteralPath (Join-Path $obsoleteRuntime "obsolete.txt") `
+    -Value "remove me"
+  Invoke-Installer (@(
+    "-Action", "Install",
+    "-SkipRepoUpdate",
+    "-SkipDependencyInstall",
+    "-SkipBuild",
+    "-HealthTimeoutSeconds", "15"
+  ) + $commonArguments)
+  if (Test-Path -LiteralPath $obsoleteRuntime) {
+    throw "A healthy replacement did not prune an inactive versioned runtime."
+  }
+
+  Invoke-Installer (@("-Action", "Stop") + $commonArguments)
+  $gracefulStopInfo = Get-ScheduledTaskInfo `
+    -TaskName $taskName `
+    -TaskPath "\"
+  if ([long]$gracefulStopInfo.LastTaskResult -ne 0) {
+    throw "The graceful stop did not record a successful task exit."
+  }
+  Wait-UntilUnavailable
+  Invoke-Installer (@("-Action", "Start") + $commonArguments)
+
+  $forceStopConfig = Get-Content -LiteralPath $configPath -Raw |
+    ConvertFrom-Json
+  $forceStopConfig.controlToken = [Guid]::NewGuid().ToString("N")
+  $forceStopConfig |
+    ConvertTo-Json |
+    Set-Content -LiteralPath $configPath -Encoding utf8
+  Invoke-Installer (@("-Action", "Stop", "-ForceStop") + $commonArguments)
+  Invoke-Installer (@("-Action", "Status") + $commonArguments)
+  Wait-UntilUnavailable
+  Invoke-Installer (@("-Action", "Start") + $commonArguments)
+
+  $health = Invoke-RestMethod -Uri $healthUrl -TimeoutSec 5
+  if ($health.ok -ne $true -or $health.service -ne "kb1d") {
+    throw "Unexpected health response after restarting the Scheduled Task."
+  }
+
+  Write-Host "Windows per-user task smoke passed."
+  Write-Host "Verified owner-only state, task/home lifecycle locks, install, isolated build failure, failed-replacement rollback, runtime pruning, verified graceful and process-tree force-stop, status, restart, health, and uninstall lifecycle."
+} finally {
+  try {
+    Invoke-Installer (@("-Action", "Uninstall", "-ForceStop") + $commonArguments)
+  } catch {
+    Write-Warning "Task cleanup failed: $($_.Exception.Message)"
+  }
+  Remove-Item -LiteralPath $kb1Home -Recurse -Force -ErrorAction SilentlyContinue
+  if (Test-Path -LiteralPath $taskStateDirectory -PathType Container) {
+    Get-ChildItem `
+      -LiteralPath $taskStateDirectory `
+      -Filter "windows-task-$taskKey*" `
+      -File `
+      -ErrorAction SilentlyContinue |
+      Remove-Item -Force -ErrorAction SilentlyContinue
+  }
+  Remove-Item `
+    -LiteralPath $runtimeRoot `
+    -Recurse `
+    -Force `
+    -ErrorAction SilentlyContinue
+}
+
+if (
+  $null -ne (Get-ScheduledTask `
+    -TaskName $taskName `
+    -TaskPath "\" `
+    -ErrorAction SilentlyContinue)
+) {
+  throw "Windows task smoke left Scheduled Task '$taskName' registered."
+}

--- a/scripts/windows-task-smoke.ps1
+++ b/scripts/windows-task-smoke.ps1
@@ -16,7 +16,11 @@ $powerShell = (Get-Command powershell.exe -ErrorAction Stop).Source
 $localAppData = [Environment]::GetFolderPath(
   [Environment+SpecialFolder]::LocalApplicationData
 )
-$kb1Home = Join-Path $localAppData "kb1-windows-task~archive-$([Guid]::NewGuid().ToString('N'))"
+$userProfile = [string]$env:USERPROFILE
+if ([string]::IsNullOrWhiteSpace($userProfile)) {
+  throw "USERPROFILE is required for the Windows task smoke test."
+}
+$kb1Home = Join-Path $userProfile "kb1-windows-task~archive-$([Guid]::NewGuid().ToString('N'))"
 $taskName = "KB-1 Windows Smoke $([Guid]::NewGuid().ToString('N'))"
 function Get-StorageKey {
   param([string]$Value)

--- a/scripts/windows-task-smoke.ps1
+++ b/scripts/windows-task-smoke.ps1
@@ -16,11 +16,11 @@ $powerShell = (Get-Command powershell.exe -ErrorAction Stop).Source
 $localAppData = [Environment]::GetFolderPath(
   [Environment+SpecialFolder]::LocalApplicationData
 )
-$userProfile = [string]$env:USERPROFILE
-if ([string]::IsNullOrWhiteSpace($userProfile)) {
-  throw "USERPROFILE is required for the Windows task smoke test."
+$systemDriveRoot = [IO.Path]::GetPathRoot([string]$env:SystemRoot)
+if ([string]::IsNullOrWhiteSpace($systemDriveRoot)) {
+  throw "A local Windows system drive is required for the Windows task smoke test."
 }
-$kb1Home = Join-Path $userProfile "kb1-windows-task~archive-$([Guid]::NewGuid().ToString('N'))"
+$kb1Home = Join-Path $systemDriveRoot "kb1-windows-task~archive-$([Guid]::NewGuid().ToString('N'))"
 $taskName = "KB-1 Windows Smoke $([Guid]::NewGuid().ToString('N'))"
 function Get-StorageKey {
   param([string]$Value)

--- a/scripts/windows-task-smoke.ps1
+++ b/scripts/windows-task-smoke.ps1
@@ -23,6 +23,7 @@ if ([string]::IsNullOrWhiteSpace($systemDriveRoot)) {
 $trustedWorkspaceRoot = Join-Path $systemDriveRoot "kb1-windows-smoke-$([Guid]::NewGuid().ToString('N'))"
 $kb1Home = Join-Path $trustedWorkspaceRoot "home~archive"
 $trustedToolsRoot = Join-Path $trustedWorkspaceRoot "tools"
+$trustedNodePath = Join-Path $trustedToolsRoot "node.exe"
 $trustedSourceRoot = Join-Path $trustedWorkspaceRoot "source"
 $sourceNodeDirectory = Split-Path -Parent (
   (Get-Command node.exe -ErrorAction Stop).Source
@@ -109,6 +110,10 @@ function Invoke-DirectRestMethod {
   param(
     [Parameter(Mandatory = $true)]
     [Uri]$Uri,
+    [Parameter(Mandatory = $true)]
+    [string]$NodePath,
+    [Parameter(Mandatory = $true)]
+    [string]$ErrorDirectory,
     [ValidateSet("Get", "Post")]
     [string]$Method = "Get",
     [hashtable]$Headers = @{},
@@ -116,49 +121,147 @@ function Invoke-DirectRestMethod {
     [int]$TimeoutSec = 30
   )
 
-  if (-not ("System.Net.Http.HttpClient" -as [type])) {
-    Add-Type -AssemblyName System.Net.Http
-  }
-
-  $handler = [Net.Http.HttpClientHandler]::new()
-  $handler.UseProxy = $false
-  $client = [Net.Http.HttpClient]::new($handler)
-  $client.Timeout = [TimeSpan]::FromSeconds($TimeoutSec)
-  $httpMethod = if ($Method -eq "Post") {
-    [Net.Http.HttpMethod]::Post
-  } else {
-    [Net.Http.HttpMethod]::Get
-  }
-  $request = [Net.Http.HttpRequestMessage]::new($httpMethod, $Uri)
-  # Windows PowerShell 5.1 can omit the required brackets when it derives the
-  # Host header for an IPv6 literal. Pin the RFC-form authority explicitly.
-  $request.Headers.Host = $Uri.Authority
-  foreach ($header in $Headers.GetEnumerator()) {
-    $request.Headers.TryAddWithoutValidation(
-      [string]$header.Key,
-      [string]$header.Value
-    ) | Out-Null
-  }
-
-  $response = $null
+  $requestScript = @'
+const [url, method, timeoutSeconds] = process.argv.slice(1);
+const { default: http } = await import("node:http");
+const { default: https } = await import("node:https");
+const headers = JSON.parse(process.env.KB1_DIRECT_REQUEST_HEADERS || "{}");
+const writeUtf8 = (value) => {
+  process.stdout.write(Buffer.from(value, "utf8").toString("base64"));
+};
+try {
+  const target = new URL(url);
+  const transport = target.protocol === "https:" ? https : http;
+  const controller = new AbortController();
+  const deadline = setTimeout(() => {
+    controller.abort(new Error(`Request timed out after ${timeoutSeconds}s`));
+  }, Number(timeoutSeconds) * 1000);
   try {
-    $response = $client.SendAsync($request).GetAwaiter().GetResult()
-    $body = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
-    if (-not $response.IsSuccessStatusCode) {
-      throw "HTTP $([int]$response.StatusCode) $($response.ReasonPhrase): $body"
+    const response = await new Promise((resolve, reject) => {
+      const request = transport.request(target, {
+        method: method.toUpperCase(),
+        headers,
+        signal: controller.signal
+      }, resolve);
+      request.on("error", reject);
+      request.end();
+    });
+    const chunks = [];
+    for await (const chunk of response) {
+      chunks.push(chunk);
     }
-    if ([string]::IsNullOrWhiteSpace($body)) {
-      return $null
+    const body = Buffer.concat(chunks);
+    if (
+      response.statusCode === undefined ||
+      response.statusCode < 200 ||
+      response.statusCode >= 300
+    ) {
+      writeUtf8(
+        `HTTP ${response.statusCode ?? "unknown"} ` +
+        `${response.statusMessage ?? ""}: ${body.toString("utf8")}`
+      );
+      process.exitCode = 1;
+    } else {
+      process.stdout.write(body.toString("base64"));
     }
-    return $body | ConvertFrom-Json
   } finally {
-    if ($null -ne $response) {
-      $response.Dispose()
-    }
-    $request.Dispose()
-    $client.Dispose()
-    $handler.Dispose()
+    clearTimeout(deadline);
   }
+} catch (error) {
+  writeUtf8(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}
+'@
+  $encodedRequestScript = [Convert]::ToBase64String(
+    [Text.Encoding]::UTF8.GetBytes($requestScript)
+  )
+  $bootstrapScript = "const[a,b]=process.argv.splice(1,2);await(import(a+b))"
+  $previousHeaders = $env:KB1_DIRECT_REQUEST_HEADERS
+  $previousNodeOptions = $env:NODE_OPTIONS
+  $previousNodePath = $env:NODE_PATH
+  $previousNodeProxy = $env:NODE_USE_ENV_PROXY
+  $previousNodeDebug = $env:NODE_DEBUG
+  $previousNodeDebugNative = $env:NODE_DEBUG_NATIVE
+  $previousExtraCaCertificates = $env:NODE_EXTRA_CA_CERTS
+  $stderrPath = Join-Path `
+    $ErrorDirectory `
+    "windows-request-$([Guid]::NewGuid().ToString('N')).stderr.log"
+  $output = @()
+  $exitCode = 1
+  try {
+    $env:KB1_DIRECT_REQUEST_HEADERS = ConvertTo-Json `
+      -InputObject $Headers `
+      -Compress
+    $env:NODE_OPTIONS = $null
+    $env:NODE_PATH = $null
+    $env:NODE_USE_ENV_PROXY = $null
+    $env:NODE_DEBUG = $null
+    $env:NODE_DEBUG_NATIVE = $null
+    $env:NODE_EXTRA_CA_CERTS = $null
+    $output = @(
+      & $NodePath `
+        --input-type=module `
+        -e $bootstrapScript `
+        -- `
+        "data:text/javascript;base64," `
+        $encodedRequestScript `
+        ([string]$Uri.AbsoluteUri) `
+        $Method `
+        ([string]$TimeoutSec) `
+        2> $stderrPath
+    )
+    $exitCode = $LASTEXITCODE
+  } finally {
+    foreach ($environmentValue in @(
+      @{ Name = "KB1_DIRECT_REQUEST_HEADERS"; Value = $previousHeaders },
+      @{ Name = "NODE_OPTIONS"; Value = $previousNodeOptions },
+      @{ Name = "NODE_PATH"; Value = $previousNodePath },
+      @{ Name = "NODE_USE_ENV_PROXY"; Value = $previousNodeProxy },
+      @{ Name = "NODE_DEBUG"; Value = $previousNodeDebug },
+      @{ Name = "NODE_DEBUG_NATIVE"; Value = $previousNodeDebugNative },
+      @{
+        Name = "NODE_EXTRA_CA_CERTS"
+        Value = $previousExtraCaCertificates
+      }
+    )) {
+      if ($null -eq $environmentValue.Value) {
+        Remove-Item `
+          -LiteralPath "Env:$($environmentValue.Name)" `
+          -ErrorAction SilentlyContinue
+      } else {
+        [Environment]::SetEnvironmentVariable(
+          [string]$environmentValue.Name,
+          [string]$environmentValue.Value
+        )
+      }
+    }
+    Remove-Item `
+      -LiteralPath $stderrPath `
+      -Force `
+      -ErrorAction SilentlyContinue
+  }
+
+  $encodedBody = ($output -join "").Trim()
+  $body = ""
+  if (-not [string]::IsNullOrWhiteSpace($encodedBody)) {
+    try {
+      $body = [Text.Encoding]::UTF8.GetString(
+        [Convert]::FromBase64String($encodedBody)
+      )
+    } catch {
+      throw "Direct Node request returned invalid encoded output."
+    }
+  }
+  if ($exitCode -ne 0) {
+    if ([string]::IsNullOrWhiteSpace($body)) {
+      throw "Direct Node request failed with exit code $exitCode."
+    }
+    throw $body
+  }
+  if ([string]::IsNullOrWhiteSpace($body)) {
+    return $null
+  }
+  return $body | ConvertFrom-Json
 }
 
 function Invoke-Installer {
@@ -193,7 +296,12 @@ function Wait-UntilUnavailable {
   $deadline = [DateTime]::UtcNow.AddSeconds(15)
   do {
     try {
-      Invoke-DirectRestMethod -Uri $healthUrl -TimeoutSec 1 | Out-Null
+      Invoke-DirectRestMethod `
+        -Uri $healthUrl `
+        -NodePath $trustedNodePath `
+        -ErrorDirectory $taskStateDirectory `
+        -TimeoutSec 1 |
+        Out-Null
     } catch {
       return
     }
@@ -432,7 +540,11 @@ try {
     "-HealthTimeoutSeconds", "5"
   ) + $commonArguments)
 
-  $healthyAfterBuildFailure = Invoke-DirectRestMethod -Uri $healthUrl -TimeoutSec 5
+  $healthyAfterBuildFailure = Invoke-DirectRestMethod `
+    -Uri $healthUrl `
+    -NodePath $trustedNodePath `
+    -ErrorDirectory $taskStateDirectory `
+    -TimeoutSec 5
   if (
     $healthyAfterBuildFailure.ok -ne $true -or
     $healthyAfterBuildFailure.service -ne "kb1d"
@@ -468,7 +580,11 @@ try {
     $blockedListener.Stop()
   }
 
-  $restoredHealth = Invoke-DirectRestMethod -Uri $healthUrl -TimeoutSec 5
+  $restoredHealth = Invoke-DirectRestMethod `
+    -Uri $healthUrl `
+    -NodePath $trustedNodePath `
+    -ErrorDirectory $taskStateDirectory `
+    -TimeoutSec 5
   if ($restoredHealth.ok -ne $true -or $restoredHealth.service -ne "kb1d") {
     throw "The prior Scheduled Task was not restored after failed replacement."
   }
@@ -512,7 +628,11 @@ try {
   Wait-UntilUnavailable
   Invoke-Installer (@("-Action", "Start") + $commonArguments)
 
-  $health = Invoke-DirectRestMethod -Uri $healthUrl -TimeoutSec 5
+  $health = Invoke-DirectRestMethod `
+    -Uri $healthUrl `
+    -NodePath $trustedNodePath `
+    -ErrorDirectory $taskStateDirectory `
+    -TimeoutSec 5
   if ($health.ok -ne $true -or $health.service -ne "kb1d") {
     throw "Unexpected health response after restarting the Scheduled Task."
   }

--- a/scripts/windows-task-smoke.ps1
+++ b/scripts/windows-task-smoke.ps1
@@ -293,15 +293,21 @@ function Invoke-InstallerExpectedFailure {
       @InstallerArguments
     $installerExitCode = $LASTEXITCODE
   } else {
-    $installerOutput = @(
-      & $powerShell `
-        -NoProfile `
-        -NonInteractive `
-        -ExecutionPolicy Bypass `
-        -File $installer `
-        @InstallerArguments 2>&1
-    )
-    $installerExitCode = $LASTEXITCODE
+    $previousErrorActionPreference = $ErrorActionPreference
+    try {
+      $ErrorActionPreference = "Continue"
+      $installerOutput = @(
+        & $powerShell `
+          -NoProfile `
+          -NonInteractive `
+          -ExecutionPolicy Bypass `
+          -File $installer `
+          @InstallerArguments 2>&1
+      )
+      $installerExitCode = $LASTEXITCODE
+    } finally {
+      $ErrorActionPreference = $previousErrorActionPreference
+    }
     foreach ($outputLine in $installerOutput) {
       Write-Host ([string]$outputLine)
     }

--- a/scripts/windows-task-smoke.ps1
+++ b/scripts/windows-task-smoke.ps1
@@ -105,6 +105,59 @@ $port = ([Net.IPEndPoint]$listener.LocalEndpoint).Port
 $listener.Stop()
 $healthUrl = "http://[::1]:$port/api/health"
 
+function Invoke-DirectRestMethod {
+  param(
+    [Parameter(Mandatory = $true)]
+    [Uri]$Uri,
+    [ValidateSet("Get", "Post")]
+    [string]$Method = "Get",
+    [hashtable]$Headers = @{},
+    [ValidateRange(1, 300)]
+    [int]$TimeoutSec = 30
+  )
+
+  if (-not ("System.Net.Http.HttpClient" -as [type])) {
+    Add-Type -AssemblyName System.Net.Http
+  }
+
+  $handler = [Net.Http.HttpClientHandler]::new()
+  $handler.UseProxy = $false
+  $client = [Net.Http.HttpClient]::new($handler)
+  $client.Timeout = [TimeSpan]::FromSeconds($TimeoutSec)
+  $httpMethod = if ($Method -eq "Post") {
+    [Net.Http.HttpMethod]::Post
+  } else {
+    [Net.Http.HttpMethod]::Get
+  }
+  $request = [Net.Http.HttpRequestMessage]::new($httpMethod, $Uri)
+  foreach ($header in $Headers.GetEnumerator()) {
+    $request.Headers.TryAddWithoutValidation(
+      [string]$header.Key,
+      [string]$header.Value
+    ) | Out-Null
+  }
+
+  $response = $null
+  try {
+    $response = $client.SendAsync($request).GetAwaiter().GetResult()
+    $body = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+    if (-not $response.IsSuccessStatusCode) {
+      throw "HTTP $([int]$response.StatusCode) $($response.ReasonPhrase): $body"
+    }
+    if ([string]::IsNullOrWhiteSpace($body)) {
+      return $null
+    }
+    return $body | ConvertFrom-Json
+  } finally {
+    if ($null -ne $response) {
+      $response.Dispose()
+    }
+    $request.Dispose()
+    $client.Dispose()
+    $handler.Dispose()
+  }
+}
+
 function Invoke-Installer {
   param([string[]]$InstallerArguments)
 
@@ -137,7 +190,7 @@ function Wait-UntilUnavailable {
   $deadline = [DateTime]::UtcNow.AddSeconds(15)
   do {
     try {
-      Invoke-RestMethod -Uri $healthUrl -TimeoutSec 1 | Out-Null
+      Invoke-DirectRestMethod -Uri $healthUrl -TimeoutSec 1 | Out-Null
     } catch {
       return
     }
@@ -376,7 +429,7 @@ try {
     "-HealthTimeoutSeconds", "5"
   ) + $commonArguments)
 
-  $healthyAfterBuildFailure = Invoke-RestMethod -Uri $healthUrl -TimeoutSec 5
+  $healthyAfterBuildFailure = Invoke-DirectRestMethod -Uri $healthUrl -TimeoutSec 5
   if (
     $healthyAfterBuildFailure.ok -ne $true -or
     $healthyAfterBuildFailure.service -ne "kb1d"
@@ -412,7 +465,7 @@ try {
     $blockedListener.Stop()
   }
 
-  $restoredHealth = Invoke-RestMethod -Uri $healthUrl -TimeoutSec 5
+  $restoredHealth = Invoke-DirectRestMethod -Uri $healthUrl -TimeoutSec 5
   if ($restoredHealth.ok -ne $true -or $restoredHealth.service -ne "kb1d") {
     throw "The prior Scheduled Task was not restored after failed replacement."
   }
@@ -456,7 +509,7 @@ try {
   Wait-UntilUnavailable
   Invoke-Installer (@("-Action", "Start") + $commonArguments)
 
-  $health = Invoke-RestMethod -Uri $healthUrl -TimeoutSec 5
+  $health = Invoke-DirectRestMethod -Uri $healthUrl -TimeoutSec 5
   if ($health.ok -ne $true -or $health.service -ne "kb1d") {
     throw "Unexpected health response after restarting the Scheduled Task."
   }

--- a/scripts/windows-task-smoke.ps1
+++ b/scripts/windows-task-smoke.ps1
@@ -130,6 +130,9 @@ function Invoke-DirectRestMethod {
     [Net.Http.HttpMethod]::Get
   }
   $request = [Net.Http.HttpRequestMessage]::new($httpMethod, $Uri)
+  # Windows PowerShell 5.1 can omit the required brackets when it derives the
+  # Host header for an IPv6 literal. Pin the RFC-form authority explicitly.
+  $request.Headers.Host = $Uri.Authority
   foreach ($header in $Headers.GetEnumerator()) {
     $request.Headers.TryAddWithoutValidation(
       [string]$header.Key,

--- a/scripts/windows-task-smoke.ps1
+++ b/scripts/windows-task-smoke.ps1
@@ -13,7 +13,10 @@ if ($env:OS -ne "Windows_NT") {
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $installer = Join-Path $repoRoot "skills\kb-1-daemon-setup\scripts\install_kb1_daemon_user_task.ps1"
 $powerShell = (Get-Command powershell.exe -ErrorAction Stop).Source
-$kb1Home = Join-Path ([IO.Path]::GetTempPath()) "kb1-windows-task~archive-$([Guid]::NewGuid().ToString('N'))"
+$localAppData = [Environment]::GetFolderPath(
+  [Environment+SpecialFolder]::LocalApplicationData
+)
+$kb1Home = Join-Path $localAppData "kb1-windows-task~archive-$([Guid]::NewGuid().ToString('N'))"
 $taskName = "KB-1 Windows Smoke $([Guid]::NewGuid().ToString('N'))"
 function Get-StorageKey {
   param([string]$Value)
@@ -32,9 +35,7 @@ $homeKey = Get-StorageKey (
   [IO.Path]::GetFullPath($kb1Home).ToUpperInvariant()
 )
 $taskStateDirectory = Join-Path (
-  [Environment]::GetFolderPath(
-    [Environment+SpecialFolder]::LocalApplicationData
-  )
+  $localAppData
 ) "KB-1\tasks"
 $configPath = Join-Path $taskStateDirectory "windows-task-$taskKey.json"
 $runtimeRoot = Join-Path `

--- a/scripts/windows-task-smoke.ps1
+++ b/scripts/windows-task-smoke.ps1
@@ -20,11 +20,31 @@ $systemDriveRoot = [IO.Path]::GetPathRoot([string]$env:SystemRoot)
 if ([string]::IsNullOrWhiteSpace($systemDriveRoot)) {
   throw "A local Windows system drive is required for the Windows task smoke test."
 }
-$kb1Home = Join-Path $systemDriveRoot "kb1-windows-task~archive-$([Guid]::NewGuid().ToString('N'))"
-$trustedToolsRoot = Join-Path $systemDriveRoot "kb1-windows-tools-$([Guid]::NewGuid().ToString('N'))"
+$trustedWorkspaceRoot = Join-Path $systemDriveRoot "kb1-windows-smoke-$([Guid]::NewGuid().ToString('N'))"
+$kb1Home = Join-Path $trustedWorkspaceRoot "home~archive"
+$trustedToolsRoot = Join-Path $trustedWorkspaceRoot "tools"
+$trustedSourceRoot = Join-Path $trustedWorkspaceRoot "source"
 $sourceNodeDirectory = Split-Path -Parent (
   (Get-Command node.exe -ErrorAction Stop).Source
 )
+$sourceGitPath = (Get-Command git.exe -ErrorAction Stop).Source
+$sourceStatus = & $sourceGitPath `
+  -C $repoRoot `
+  status `
+  --porcelain `
+  --untracked-files=all
+if ($LASTEXITCODE -ne 0) {
+  throw "Could not inspect the Windows smoke source checkout."
+}
+if (-not [string]::IsNullOrWhiteSpace([string]$sourceStatus)) {
+  throw "The Windows task smoke requires a clean source checkout."
+}
+$sourceCommit = (
+  & $sourceGitPath -C $repoRoot rev-parse HEAD
+).Trim()
+if ($LASTEXITCODE -ne 0) {
+  throw "Could not resolve the Windows smoke source commit."
+}
 $originalPath = [string]$env:PATH
 $taskName = "KB-1 Windows Smoke $([Guid]::NewGuid().ToString('N'))"
 function Set-OwnerOnlyDirectoryAcl {
@@ -151,7 +171,7 @@ function New-OwnerOnlyGlobalMutex {
 }
 
 $commonArguments = @(
-  "-RepoDir", $repoRoot,
+  "-RepoDir", $trustedSourceRoot,
   "-KB1Home", $kb1Home,
   "-BindHost", "[::1]",
   "-Port", [string]$port,
@@ -159,11 +179,30 @@ $commonArguments = @(
 )
 
 try {
+  New-Item -ItemType Directory -Path $trustedWorkspaceRoot | Out-Null
+  Set-OwnerOnlyDirectoryAcl $trustedWorkspaceRoot
   New-Item -ItemType Directory -Path $trustedToolsRoot | Out-Null
   Set-OwnerOnlyDirectoryAcl $trustedToolsRoot
   Get-ChildItem -LiteralPath $sourceNodeDirectory -Force |
     Copy-Item -Destination $trustedToolsRoot -Recurse -Force
   $env:PATH = "$trustedToolsRoot;$originalPath"
+  & $sourceGitPath `
+    clone `
+    --no-hardlinks `
+    --no-checkout `
+    $repoRoot `
+    $trustedSourceRoot
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not create the trusted Windows smoke source checkout."
+  }
+  & $sourceGitPath `
+    -C $trustedSourceRoot `
+    checkout `
+    --detach `
+    $sourceCommit
+  if ($LASTEXITCODE -ne 0) {
+    throw "Could not check out the Windows smoke source commit."
+  }
 
   Invoke-Installer (@(
     "-Action", "Install",
@@ -266,7 +305,7 @@ try {
     [int]$preservedConfig.port -ne $port -or
     -not [string]::Equals(
       [IO.Path]::GetFullPath([string]$preservedConfig.sourceRepoDir),
-      [IO.Path]::GetFullPath($repoRoot),
+      [IO.Path]::GetFullPath($trustedSourceRoot),
       [StringComparison]::OrdinalIgnoreCase
     )
   ) {
@@ -447,6 +486,11 @@ try {
   $env:PATH = $originalPath
   Remove-Item `
     -LiteralPath $trustedToolsRoot `
+    -Recurse `
+    -Force `
+    -ErrorAction SilentlyContinue
+  Remove-Item `
+    -LiteralPath $trustedWorkspaceRoot `
     -Recurse `
     -Force `
     -ErrorAction SilentlyContinue

--- a/skills/kb-1-daemon-setup/SKILL.md
+++ b/skills/kb-1-daemon-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kb-1-daemon-setup
-description: Install, run, repair, and verify the KB-1 local open-source daemon for local web/API/MCP use on Linux or macOS. Use when setting up kb-1-daemon, configuring MCP clients, copying a Markdown/Obsidian vault into KB1_HOME, or explicitly enabling private Tailscale access after the user approves exposure.
+description: Install, run, repair, and verify the KB-1 local open-source daemon for local web/API/MCP use on Linux, macOS, or Windows 11. Use when setting up kb-1-daemon, configuring MCP clients, copying a Markdown/Obsidian vault into KB1_HOME, or explicitly enabling private Tailscale access after the user approves exposure.
 ---
 
 # KB-1 Daemon Setup
@@ -18,7 +18,8 @@ Safe to automate after stating what will change:
 1. Clone or update `https://github.com/metatheoryinc/kb-1-daemon.git` into `$HOME/repos/kb-1-daemon` or a user-approved path.
 2. Install Node/pnpm dependencies.
 3. Run checks/builds.
-4. Install or update a user-level service on Linux systemd or macOS launchd.
+4. Install or update a user-level service on Linux systemd or macOS launchd,
+   or a per-user logon Scheduled Task on Windows 11.
 5. Start or restart the daemon and verify `/api/health`, `/api/vaults`, and `/mcp` reachability.
 6. Configure MCP clients when their CLI/config is available, after inspecting existing entries.
 7. Report Tailscale status without changing it.
@@ -65,6 +66,7 @@ Defaults:
 - Port: `7382`
 - Linux service: user systemd unit `kb1d.service`
 - macOS service: user LaunchAgent `dev.metatheory.kb1.kb1d`
+- Windows background task: per-user Scheduled Task `KB-1 Local`
 - MCP endpoint: `http://127.0.0.1:7382/mcp`
 
 For a default-path in-place upgrade, first boot copies existing `$HOME/.kb2`
@@ -169,6 +171,66 @@ For Linux services that should survive logout/reboot, ask the user before runnin
 sudo loginctl enable-linger "$USER"
 ```
 
+On Windows 11, run the PowerShell installer from the cloned repository:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File `
+  .\skills\kb-1-daemon-setup\scripts\install_kb1_daemon_user_task.ps1
+```
+
+It installs a per-user Scheduled Task that starts at logon and immediately
+starts it for the current session. The task runs with the current user's limited
+privileges, though local policy may require an elevated PowerShell window to
+register it. The installer does not change Tailscale or expose KB-1 beyond
+loopback. This is a source-based background task, not a signed native installer
+or Windows Service Control Manager service.
+
+Manage the Windows task with the same script:
+
+```powershell
+$installer = ".\skills\kb-1-daemon-setup\scripts\install_kb1_daemon_user_task.ps1"
+powershell -NoProfile -ExecutionPolicy Bypass -File $installer -Action Status
+powershell -NoProfile -ExecutionPolicy Bypass -File $installer -Action Stop
+powershell -NoProfile -ExecutionPolicy Bypass -File $installer -Action Start
+powershell -NoProfile -ExecutionPolicy Bypass -File $installer -Action Uninstall
+```
+
+`Uninstall` unregisters the task and removes its generated task configuration,
+but preserves the repository, task log, and all vault data. Private task
+configuration, logs, and managed runtimes live under
+`$env:LOCALAPPDATA\KB-1\tasks`, separately from `KB1_HOME`. Use
+`-BuildOnly` to build without the slower full check after a known-good checkout.
+The installer also accepts `-RepoDir`, `-KB1Home`, `-BindHost`, `-Port`, and
+`-TaskName`; without `-RepoDir`, it uses the checkout containing the installer.
+Stop, replacement, and uninstall verify the task's private launch identity,
+stop new HTTP mutations, drain active transports, and close every vault session
+before the process exits. If exact task health or graceful shutdown is
+unavailable, they fail closed; use `-ForceStop` only after the user accepts that
+the latest in-memory edits may be lost. The fallback matches the protected PID,
+Node path, and process start time before terminating the complete daemon process
+tree. A second task cannot manage the same `KB1_HOME`. If a fresh task fails its
+health check, the installer removes it; if a replacement fails, the previous
+task definition and configuration are restored and restarted when they were
+active before the attempt. Initial installation and upgrades clone and build an
+isolated, owner-only versioned runtime from the exact selected commit first,
+preserving the last-known-good runnable code. Dependencies use a runtime-local
+pnpm store, and reparse points may not escape the protected runtime. The three
+skip switches together may only reuse that already-installed protected runtime;
+they cannot register a first task directly from an arbitrary checkout. A clean
+branch that is only behind its upstream advances to that fetched upstream
+commit; detached checkouts, local commits, and diverged branches preserve their
+selected commit. Upgrades preserve the installed source checkout, `KB1_HOME`,
+bind, and port unless the operator explicitly supplies an override. Before any
+repository tool or script runs, the installer
+verifies the checkout boundary and executable ownership/permissions. It
+restricts task configuration and managed runtimes to the current Windows user,
+refuses task code or its persistent executable chain when owned or writable by
+another untrusted local principal, and prunes inactive versioned runtimes after
+a healthy replacement. Task-name and `KB1_HOME` mutexes serialize lifecycle
+operations so differently named tasks cannot race into the same vault home.
+The installer fails closed if a same-named root task does not carry KB-1's
+current-user ownership signature.
+
 ## Manual Foreground Run
 
 Use this path on unsupported systems, while debugging, or when the user does not want a service installed:
@@ -189,6 +251,15 @@ Then verify from another shell:
 ```bash
 curl -fsS http://127.0.0.1:7382/api/health
 curl -fsS http://127.0.0.1:7382/api/vaults
+```
+
+On Windows PowerShell, set the equivalent environment variables before
+starting the foreground process:
+
+```powershell
+$env:KB1_HOST = "127.0.0.1"
+$env:KB1_PORT = "7382"
+pnpm --filter @kb-1/daemon dev
 ```
 
 ## Existing Vault Or Obsidian Copy
@@ -359,6 +430,10 @@ legacy instance, set `KB1_SERVICE_NAME=kb2d.service` on Linux or
 `KB1_LAUNCHD_LABEL=dev.metatheory.kb1.kb2d` on macOS, together with that
 instance's matching `KB1_HOST` and `KB1_PORT`.
 
+On Windows, use the task installer with `-Action Status`; it verifies that the
+task is running and that the health endpoint matches the configured KB-1 home,
+status file, and Node process.
+
 MCP smoke once tools are loaded:
 
 1. `list_vaults`.
@@ -378,6 +453,10 @@ MCP smoke once tools are loaded:
 - Linux `systemctl --user` fails in a container: install/run on the host OS or use the foreground run path.
 - Linux service stops after logout: ask before enabling lingering with `sudo loginctl enable-linger "$USER"`.
 - macOS service does not start: inspect `~/Library/Logs/<launchd-label>.{out,err}.log` and `launchctl print "gui/$(id -u)/<launchd-label>"`; custom labels get their own log pair, and the defaults are `dev.metatheory.kb1.kb1d` (current) and `dev.metatheory.kb1.kb2d` (legacy).
+- Windows task does not start: run the installer with `-Action Status`, inspect
+  the task-specific `windows-task-*.log`, `*.stdout.log`, and `*.stderr.log`
+  files under `$env:LOCALAPPDATA\KB-1\tasks`, and confirm the configured
+  protected runtime still contains `apps\daemon\dist\main.js`.
 - Tailscale not installed or logged in: keep KB-1 local-only and give the user Tailscale setup steps.
 - Tailscale Serve already has unrelated routes: do not overwrite in auto mode; require explicit approval and a chosen port.
 - UI works but agents cannot edit: check the MCP URL, restart the client, and ensure every data tool call includes `vaultId`.

--- a/skills/kb-1-daemon-setup/scripts/install_kb1_daemon_user_task.ps1
+++ b/skills/kb-1-daemon-setup/scripts/install_kb1_daemon_user_task.ps1
@@ -1,0 +1,1948 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param(
+  [ValidateSet("Install", "Uninstall", "Start", "Stop", "Status")]
+  [string]$Action = "Install",
+
+  [string]$RepoUrl = "https://github.com/metatheoryinc/kb-1-daemon.git",
+
+  [string]$RepoDir = $(if ($env:KB1_REPO_DIR) {
+    $env:KB1_REPO_DIR
+  } else {
+    [IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\..\.."))
+  }),
+
+  [string]$KB1Home = $(if ($env:KB1_HOME) {
+    $env:KB1_HOME
+  } else {
+    Join-Path $HOME ".kb1"
+  }),
+
+  [string]$BindHost = $(if ($env:KB1_HOST) {
+    $env:KB1_HOST
+  } else {
+    "127.0.0.1"
+  }),
+
+  [ValidateRange(1, 65535)]
+  [int]$Port = $(if ($env:KB1_PORT) {
+    [int]$env:KB1_PORT
+  } else {
+    7382
+  }),
+
+  [string]$TaskName = $(if ($env:KB1_WINDOWS_TASK_NAME) {
+    $env:KB1_WINDOWS_TASK_NAME
+  } else {
+    "KB-1 Local"
+  }),
+
+  [switch]$BuildOnly,
+  [switch]$ConfirmNonLoopbackBind,
+  [switch]$ForceStop,
+  [switch]$SkipRepoUpdate,
+  [switch]$SkipDependencyInstall,
+  [switch]$SkipBuild,
+
+  [ValidateRange(1, 300)]
+  [int]$HealthTimeoutSeconds = 30
+)
+
+$script:ExplicitParameters = @{}
+foreach ($parameterName in $PSBoundParameters.Keys) {
+  $script:ExplicitParameters[$parameterName] = $true
+}
+foreach ($environmentOverride in @{
+  RepoDir = "KB1_REPO_DIR"
+  KB1Home = "KB1_HOME"
+  BindHost = "KB1_HOST"
+  Port = "KB1_PORT"
+}.GetEnumerator()) {
+  if (-not [string]::IsNullOrWhiteSpace(
+    [Environment]::GetEnvironmentVariable($environmentOverride.Value)
+  )) {
+    $script:ExplicitParameters[$environmentOverride.Key] = $true
+  }
+}
+$ErrorActionPreference = "Stop"
+$RepoDir = [IO.Path]::GetFullPath($RepoDir)
+$KB1Home = [IO.Path]::GetFullPath($KB1Home)
+if ($BindHost.StartsWith("[") -and $BindHost.EndsWith("]")) {
+  $BindHost = $BindHost.Substring(1, $BindHost.Length - 2)
+}
+$TaskPath = "\"
+
+function Get-StableStorageKey {
+  param([string]$Value)
+
+  $sha256 = [Security.Cryptography.SHA256]::Create()
+  try {
+    $bytes = [Text.Encoding]::UTF8.GetBytes($Value)
+    $hash = $sha256.ComputeHash($bytes)
+    return ([BitConverter]::ToString($hash).Replace("-", "").Substring(0, 16)).ToLowerInvariant()
+  } finally {
+    $sha256.Dispose()
+  }
+}
+
+function Get-TaskStorageKey {
+  return Get-StableStorageKey ([string]$script:TaskName).ToUpperInvariant()
+}
+
+function Get-HomeStorageKey {
+  $normalizedHome = [IO.Path]::GetFullPath($script:KB1Home).ToUpperInvariant()
+  return Get-StableStorageKey $normalizedHome
+}
+
+function Get-TaskStateRoot {
+  $localAppData = [Environment]::GetFolderPath(
+    [Environment+SpecialFolder]::LocalApplicationData
+  )
+  if ([string]::IsNullOrWhiteSpace($localAppData)) {
+    throw "Windows LocalAppData could not be resolved for the current user."
+  }
+  return Join-Path $localAppData "KB-1\tasks"
+}
+
+function Get-LifecycleUrlHost {
+  param([string]$ListenHost)
+
+  $probeHost = switch ($ListenHost) {
+    "0.0.0.0" { "127.0.0.1" }
+    "::" { "::1" }
+    default { $ListenHost }
+  }
+  if ($probeHost.Contains(":") -and -not $probeHost.StartsWith("[")) {
+    return "[$probeHost]"
+  }
+  return $probeHost
+}
+
+function Set-RuntimeUrls {
+  $healthHost = Get-LifecycleUrlHost $script:BindHost
+  $taskKey = Get-TaskStorageKey
+  $script:TaskStateRoot = Get-TaskStateRoot
+  $script:ConfigPath = Join-Path $script:TaskStateRoot "windows-task-$taskKey.json"
+  $script:BaseUrl = "http://${healthHost}:$($script:Port)"
+  $script:HealthUrl = "$($script:BaseUrl)/api/health"
+}
+
+Set-RuntimeUrls
+
+function Write-Step {
+  param([string]$Message)
+  Write-Host ""
+  Write-Host "==> $Message"
+}
+
+function Resolve-CommandPath {
+  param([string[]]$Names)
+
+  foreach ($name in $Names) {
+    $command = Get-Command $name -ErrorAction SilentlyContinue
+    if ($null -ne $command) {
+      return $command.Source
+    }
+  }
+  return $null
+}
+
+function Invoke-External {
+  param(
+    [string]$FilePath,
+    [string[]]$Arguments
+  )
+
+  & $FilePath @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "$FilePath exited with code $LASTEXITCODE."
+  }
+}
+
+function Invoke-ExternalOutput {
+  param(
+    [string]$FilePath,
+    [string[]]$Arguments
+  )
+
+  $output = & $FilePath @Arguments 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    throw "$FilePath exited with code $LASTEXITCODE. $($output -join [Environment]::NewLine)"
+  }
+  return ([string]($output -join [Environment]::NewLine)).Trim()
+}
+
+function Invoke-ExternalOutputOrNull {
+  param(
+    [string]$FilePath,
+    [string[]]$Arguments
+  )
+
+  $output = & $FilePath @Arguments 2>$null
+  if ($LASTEXITCODE -ne 0) {
+    return $null
+  }
+  return ([string]($output -join [Environment]::NewLine)).Trim()
+}
+
+function Test-LoopbackHost {
+  param([string]$Value)
+
+  if ($Value -in @("localhost", "::1", "[::1]")) {
+    return $true
+  }
+
+  $address = $null
+  if ([Net.IPAddress]::TryParse($Value, [ref]$address)) {
+    return [Net.IPAddress]::IsLoopback($address)
+  }
+  return $false
+}
+
+function Get-InstalledTask {
+  return Get-ScheduledTask `
+    -TaskName $TaskName `
+    -TaskPath $script:TaskPath `
+    -ErrorAction SilentlyContinue
+}
+
+function Find-TaskConfigPath {
+  param($Task)
+
+  if ($null -eq $Task) {
+    return $null
+  }
+  foreach ($action in @($Task.Actions)) {
+    $match = [regex]::Match(
+      [string]$action.Arguments,
+      '(?i)-ConfigPath\s+"([^"]+)"'
+    )
+    if ($match.Success) {
+      return $match.Groups[1].Value
+    }
+  }
+  return $null
+}
+
+function Find-TaskRunnerPath {
+  param($Task)
+
+  if ($null -eq $Task) {
+    return $null
+  }
+  foreach ($action in @($Task.Actions)) {
+    $match = [regex]::Match(
+      [string]$action.Arguments,
+      '(?i)-File\s+"([^"]+)"'
+    )
+    if ($match.Success) {
+      return $match.Groups[1].Value
+    }
+  }
+  return $null
+}
+
+function Test-CurrentUserTaskPrincipal {
+  param($Task)
+
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $userId = [string]$Task.Principal.UserId
+  return (
+    [string]::Equals(
+      $userId,
+      [string]$identity.User.Value,
+      [StringComparison]::OrdinalIgnoreCase
+    ) -or
+    [string]::Equals(
+      $userId,
+      [string]$identity.Name,
+      [StringComparison]::OrdinalIgnoreCase
+    )
+  )
+}
+
+function Test-KB1RunnerAction {
+  param(
+    $Task,
+    [string]$ConfigPath
+  )
+
+  $runnerSuffix = "\skills\kb-1-daemon-setup\scripts\run_kb1_daemon_user_task.ps1"
+  foreach ($action in @($Task.Actions)) {
+    if ([IO.Path]::GetFileName([string]$action.Execute) -ine "powershell.exe") {
+      continue
+    }
+    $runnerPath = Find-TaskRunnerPath ([pscustomobject]@{ Actions = @($action) })
+    if (
+      -not [string]::IsNullOrWhiteSpace([string]$runnerPath) -and
+      [string]$runnerPath.Replace("/", "\").EndsWith(
+        $runnerSuffix,
+        [StringComparison]::OrdinalIgnoreCase
+      ) -and
+      [string]::Equals(
+        (Find-TaskConfigPath ([pscustomobject]@{ Actions = @($action) })),
+        $ConfigPath,
+        [StringComparison]::OrdinalIgnoreCase
+      )
+    ) {
+      return $true
+    }
+  }
+  return $false
+}
+
+function Test-TrustedLocalConfigPath {
+  param(
+    [string]$Path,
+    [string]$RequiredParent
+  )
+
+  if (
+    [string]::IsNullOrWhiteSpace($Path) -or
+    $Path.StartsWith("\\") -or
+    $Path -notmatch '^[A-Za-z]:[\\/]'
+  ) {
+    return $false
+  }
+  try {
+    $fullPath = [IO.Path]::GetFullPath($Path)
+    if (-not [string]::IsNullOrWhiteSpace($RequiredParent)) {
+      $parentPrefix = [IO.Path]::GetFullPath($RequiredParent).TrimEnd("\") + "\"
+      if (-not $fullPath.StartsWith(
+        $parentPrefix,
+        [StringComparison]::OrdinalIgnoreCase
+      )) {
+        return $false
+      }
+    }
+    return $true
+  } catch {
+    return $false
+  }
+}
+
+function Assert-OwnedTask {
+  param($Task)
+
+  if (
+    [string]$Task.TaskPath -ne $script:TaskPath -or
+    -not (Test-CurrentUserTaskPrincipal $Task)
+  ) {
+    throw "Refusing to modify Scheduled Task '$TaskName': its principal is not owned by KB-1."
+  }
+
+  $configPath = Find-TaskConfigPath $Task
+  if (
+    -not (Test-TrustedLocalConfigPath $configPath $null) -or
+    -not (Test-KB1RunnerAction $Task $configPath) -or
+    -not (Test-Path -LiteralPath $configPath -PathType Leaf)
+  ) {
+    throw "Refusing to modify Scheduled Task '$TaskName': it is not an owned KB-1 task."
+  }
+
+  Assert-NoUntrustedWriteAccess -Paths @(
+    $configPath,
+    (Split-Path -Parent $configPath)
+  )
+
+  try {
+    $config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json
+  } catch {
+    throw "Refusing to modify Scheduled Task '$TaskName': its KB-1 configuration is invalid."
+  }
+
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $ownedConfigDirectory = Get-TaskStateRoot
+  if (
+    [string]$config.kind -ne "kb1-windows-user-task" -or
+    [string]$config.taskName -ne $TaskName -or
+    [string]$config.ownerSid -ne [string]$identity.User.Value -or
+    -not (Test-EquivalentPath ([string]$config.taskStateRoot) $ownedConfigDirectory) -or
+    -not (Test-TrustedLocalConfigPath $configPath $ownedConfigDirectory)
+  ) {
+    throw "Refusing to modify Scheduled Task '$TaskName': its ownership signature does not match."
+  }
+
+  return $configPath
+}
+
+function Use-InstalledTaskConfig {
+  $task = Get-InstalledTask
+  if ($null -eq $task) {
+    return
+  }
+  $installedConfigPath = Assert-OwnedTask $task
+
+  $installedConfig = Get-Content -LiteralPath $installedConfigPath -Raw |
+    ConvertFrom-Json
+  $script:RepoDir = [IO.Path]::GetFullPath([string]$installedConfig.repoDir)
+  $script:KB1Home = [IO.Path]::GetFullPath([string]$installedConfig.kb1Home)
+  $script:BindHost = [string]$installedConfig.bindHost
+  $script:Port = [int]$installedConfig.port
+  Set-RuntimeUrls
+  $script:ConfigPath = $installedConfigPath
+}
+
+function Use-InstalledTaskUpgradeDefaults {
+  $task = Get-InstalledTask
+  if ($null -eq $task) {
+    return
+  }
+  $installedConfigPath = Assert-OwnedTask $task
+  $installedConfig = Get-Content -LiteralPath $installedConfigPath -Raw |
+    ConvertFrom-Json
+
+  if (-not $script:ExplicitParameters.ContainsKey("RepoUrl")) {
+    $installedRepoUrl = [string]$installedConfig.sourceRepoUrl
+    if (-not [string]::IsNullOrWhiteSpace($installedRepoUrl)) {
+      $script:RepoUrl = $installedRepoUrl
+    }
+  }
+  if (-not $script:ExplicitParameters.ContainsKey("RepoDir")) {
+    $installedSourceRepoDir = [string]$installedConfig.sourceRepoDir
+    if (-not [string]::IsNullOrWhiteSpace($installedSourceRepoDir)) {
+      $script:RepoDir = [IO.Path]::GetFullPath($installedSourceRepoDir)
+    }
+  }
+  if (-not $script:ExplicitParameters.ContainsKey("KB1Home")) {
+    $script:KB1Home = [IO.Path]::GetFullPath(
+      [string]$installedConfig.kb1Home
+    )
+  }
+  if (-not $script:ExplicitParameters.ContainsKey("BindHost")) {
+    $script:BindHost = [string]$installedConfig.bindHost
+  }
+  if (-not $script:ExplicitParameters.ContainsKey("Port")) {
+    $script:Port = [int]$installedConfig.port
+  }
+  Set-RuntimeUrls
+  $script:ConfigPath = $installedConfigPath
+}
+
+function Wait-TaskStopped {
+  param([switch]$RequireSuccessfulExit)
+
+  $deadline = [DateTime]::UtcNow.AddSeconds(45)
+  do {
+    $task = Get-InstalledTask
+    if ($null -eq $task) {
+      if ($RequireSuccessfulExit) {
+        throw "Scheduled Task '$TaskName' disappeared while waiting for a verified graceful shutdown."
+      }
+      return
+    }
+    if ($task.State -in @("Ready", "Disabled")) {
+      if ($RequireSuccessfulExit) {
+        $taskInfo = Get-ScheduledTaskInfo `
+          -TaskName $TaskName `
+          -TaskPath $script:TaskPath
+        if ([long]$taskInfo.LastTaskResult -ne 0) {
+          throw @"
+Scheduled Task '$TaskName' exited with code $($taskInfo.LastTaskResult) instead
+of completing a verified graceful shutdown. The task may be scheduled to
+restart. Repair the shutdown failure, or retry with -ForceStop only when you
+accept that the latest in-memory edits may be lost.
+"@
+        }
+      }
+      return
+    }
+    if ($task.State -eq "Unknown") {
+      throw "Scheduled Task '$TaskName' entered an unknown state while stopping."
+    }
+    Start-Sleep -Milliseconds 250
+  } while ([DateTime]::UtcNow -lt $deadline)
+
+  throw "Scheduled Task '$TaskName' did not stop within 45 seconds."
+}
+
+function Get-SupervisedDaemonIdentity {
+  param([string]$TaskConfigPath)
+
+  $taskConfig = Get-Content -LiteralPath $TaskConfigPath -Raw |
+    ConvertFrom-Json
+  $runtimeStatePath = [string]$taskConfig.runtimeStatePath
+  if (
+    [string]::IsNullOrWhiteSpace($runtimeStatePath) -or
+    -not (Test-Path -LiteralPath $runtimeStatePath -PathType Leaf)
+  ) {
+    return $null
+  }
+  Assert-NoUntrustedWriteAccess -Paths @(
+    $runtimeStatePath,
+    (Split-Path -Parent $runtimeStatePath)
+  )
+  $runtimeState = Get-Content -LiteralPath $runtimeStatePath -Raw |
+    ConvertFrom-Json
+  if (
+    [int]$runtimeState.daemonPid -le 0 -or
+    [string]::IsNullOrWhiteSpace(
+      [string]$runtimeState.daemonStartTimeFileTimeUtc
+    )
+  ) {
+    throw "The supervised daemon runtime state is incomplete."
+  }
+  return [pscustomobject]@{
+    daemonPid = [int]$runtimeState.daemonPid
+    daemonStartTimeFileTimeUtc = [long](
+      [string]$runtimeState.daemonStartTimeFileTimeUtc
+    )
+    nodePath = [string]$taskConfig.nodePath
+    runtimeStatePath = $runtimeStatePath
+  }
+}
+
+function Get-MatchingSupervisedDaemonProcess {
+  param($Identity)
+
+  $daemonProcess = Get-Process `
+    -Id ([int]$Identity.daemonPid) `
+    -ErrorAction SilentlyContinue
+  if ($null -eq $daemonProcess) {
+    return $null
+  }
+  try {
+    if (
+      -not (Test-EquivalentPath $daemonProcess.Path ([string]$Identity.nodePath)) -or
+      [long]$daemonProcess.StartTime.ToFileTimeUtc() -ne
+        [long]$Identity.daemonStartTimeFileTimeUtc
+    ) {
+      return $null
+    }
+  } catch {
+    return $null
+  }
+  return $daemonProcess
+}
+
+function Stop-SupervisedDaemonProcessTree {
+  param($Identity)
+
+  $daemonProcess = Get-MatchingSupervisedDaemonProcess $Identity
+  if ($null -eq $daemonProcess) {
+    Remove-Item `
+      -LiteralPath ([string]$Identity.runtimeStatePath) `
+      -Force `
+      -ErrorAction SilentlyContinue
+    return
+  }
+
+  $taskKillPath = Join-Path $env:SystemRoot "System32\taskkill.exe"
+  if (-not (Test-Path -LiteralPath $taskKillPath -PathType Leaf)) {
+    throw "Windows taskkill.exe is required for verified process-tree shutdown."
+  }
+  Assert-NoUntrustedWriteAccess -Paths @(
+    $taskKillPath,
+    (Split-Path -Parent $taskKillPath)
+  )
+
+  & $taskKillPath /PID ([string]$daemonProcess.Id) /T /F | Out-Null
+  $taskKillExitCode = $LASTEXITCODE
+  $deadline = [DateTime]::UtcNow.AddSeconds(15)
+  do {
+    if ($null -eq (Get-MatchingSupervisedDaemonProcess $Identity)) {
+      Remove-Item `
+        -LiteralPath ([string]$Identity.runtimeStatePath) `
+        -Force `
+        -ErrorAction SilentlyContinue
+      return
+    }
+    Start-Sleep -Milliseconds 250
+  } while ([DateTime]::UtcNow -lt $deadline)
+
+  throw "taskkill.exe exited with code $taskKillExitCode, and the supervised daemon process tree is still running."
+}
+
+function Stop-KB1TaskHard {
+  param(
+    [string]$TaskConfigPath,
+    [switch]$StopTaskAction
+  )
+
+  $identity = Get-SupervisedDaemonIdentity $TaskConfigPath
+  if ($StopTaskAction) {
+    Stop-ScheduledTask -TaskName $TaskName -TaskPath $script:TaskPath
+    Wait-TaskStopped
+    if ($null -eq $identity) {
+      return
+    }
+  } elseif ($null -eq $identity) {
+    throw "Cannot hard-stop the daemon safely because its runtime identity is unavailable."
+  }
+  Stop-SupervisedDaemonProcessTree $identity
+}
+
+function Stop-KB1Task {
+  $task = Get-InstalledTask
+  if ($null -eq $task) {
+    throw "Scheduled Task '$TaskName' is not installed."
+  }
+  if ($task.State -eq "Unknown") {
+    throw "Refusing to report a successful stop because Scheduled Task '$TaskName' has an unknown state."
+  }
+  $installedConfigPath = Assert-OwnedTask $task
+  if ($task.State -eq "Queued") {
+    Stop-ScheduledTask -TaskName $TaskName -TaskPath $script:TaskPath
+    Wait-TaskStopped
+  }
+  if ($task.State -eq "Running") {
+    try {
+      $null = Assert-HealthyTask `
+        -TimeoutSeconds 3 `
+        -TaskConfigPath $installedConfigPath
+      $taskConfig = Get-Content -LiteralPath $installedConfigPath -Raw |
+        ConvertFrom-Json
+      $urlHost = Get-LifecycleUrlHost ([string]$taskConfig.bindHost)
+      $shutdown = Invoke-RestMethod `
+        -Uri "http://${urlHost}:$($taskConfig.port)/api/control/shutdown" `
+        -Method Post `
+        -Headers @{ "x-kb1-control-token" = [string]$taskConfig.controlToken } `
+        -TimeoutSec 3
+      if ($shutdown.ok -ne $true -or $shutdown.shuttingDown -ne $true) {
+        throw "The daemon did not accept the graceful shutdown request."
+      }
+      Wait-TaskStopped -RequireSuccessfulExit
+    } catch {
+      if (-not $ForceStop) {
+        throw @"
+Could not verify and gracefully stop '$TaskName': $($_.Exception.Message)
+
+Repair local task health, then retry. Use -ForceStop only when you accept that
+the latest in-memory edits may be lost.
+"@
+      }
+      Write-Warning "Hard-stopping without verified graceful shutdown because -ForceStop was supplied."
+      Stop-KB1TaskHard `
+        -TaskConfigPath $installedConfigPath `
+        -StopTaskAction
+    }
+    return
+  }
+
+  $identity = Get-SupervisedDaemonIdentity $installedConfigPath
+  if ($null -ne $identity) {
+    if ($null -eq (Get-MatchingSupervisedDaemonProcess $identity)) {
+      Remove-Item `
+        -LiteralPath ([string]$identity.runtimeStatePath) `
+        -Force `
+        -ErrorAction SilentlyContinue
+      return
+    }
+    if (-not $ForceStop) {
+      throw @"
+Scheduled Task '$TaskName' is stopped, but its supervised daemon process may
+still be running. Rerun with -ForceStop to terminate the verified process tree.
+"@
+    }
+    Write-Warning "Terminating a verified orphan daemon process tree because -ForceStop was supplied."
+    Stop-KB1TaskHard -TaskConfigPath $installedConfigPath
+  }
+}
+
+function Test-EquivalentPath {
+  param(
+    [string]$Left,
+    [string]$Right
+  )
+
+  $leftFull = [IO.Path]::GetFullPath($Left).TrimEnd("\")
+  $rightFull = [IO.Path]::GetFullPath($Right).TrimEnd("\")
+  return [string]::Equals(
+    $leftFull,
+    $rightFull,
+    [StringComparison]::OrdinalIgnoreCase
+  )
+}
+
+function Test-PathAtOrWithin {
+  param(
+    [string]$Candidate,
+    [string]$Root
+  )
+
+  $candidateFull = [IO.Path]::GetFullPath($Candidate).TrimEnd("\")
+  $rootFull = [IO.Path]::GetFullPath($Root).TrimEnd("\")
+  return (
+    [string]::Equals(
+      $candidateFull,
+      $rootFull,
+      [StringComparison]::OrdinalIgnoreCase
+    ) -or
+    $candidateFull.StartsWith(
+      "$rootFull\",
+      [StringComparison]::OrdinalIgnoreCase
+    )
+  )
+}
+
+function Assert-ContainedRuntimeReparseTargets {
+  param(
+    [string]$RuntimeDirectory,
+    [string]$TrustedRoot
+  )
+
+  if (-not (Test-PathAtOrWithin $RuntimeDirectory $TrustedRoot)) {
+    throw "The scheduled runtime is outside the protected per-user runtime root."
+  }
+  foreach ($item in @(
+    Get-ChildItem -LiteralPath $RuntimeDirectory -Recurse -Force
+  )) {
+    if (
+      ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -eq 0
+    ) {
+      continue
+    }
+    $targets = @($item.Target)
+    if ($targets.Count -eq 0) {
+      throw "Could not resolve runtime reparse-point target: $($item.FullName)"
+    }
+    foreach ($target in $targets) {
+      if ([string]::IsNullOrWhiteSpace([string]$target)) {
+        throw "Could not resolve runtime reparse-point target: $($item.FullName)"
+      }
+      $targetPath = if ([IO.Path]::IsPathRooted([string]$target)) {
+        [IO.Path]::GetFullPath([string]$target)
+      } else {
+        [IO.Path]::GetFullPath(
+          (Join-Path (Split-Path -Parent $item.FullName) ([string]$target))
+        )
+      }
+      if (-not (Test-PathAtOrWithin $targetPath $TrustedRoot)) {
+        throw @"
+Refusing to schedule code through a reparse point outside the protected runtime:
+$($item.FullName) -> $targetPath
+"@
+      }
+    }
+  }
+}
+
+function Assert-HealthyTask {
+  param(
+    [int]$TimeoutSeconds = 30,
+    [string]$TaskConfigPath = $script:ConfigPath
+  )
+
+  $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+  $lastError = $null
+  $taskConfig = Get-Content -LiteralPath $TaskConfigPath -Raw |
+    ConvertFrom-Json
+  $urlHost = Get-LifecycleUrlHost ([string]$taskConfig.bindHost)
+  $healthUrl = "http://${urlHost}:$($taskConfig.port)/api/health"
+  do {
+    try {
+      $task = Get-InstalledTask
+      if ($null -eq $task -or $task.State -ne "Running") {
+        throw "Scheduled Task '$TaskName' is not running."
+      }
+
+      $health = Invoke-RestMethod -Uri $healthUrl -TimeoutSec 2
+      $expectedStatusFile = Join-Path ([string]$taskConfig.kb1Home) "daemon\status.json"
+      $runtimeState = Get-Content `
+        -LiteralPath ([string]$taskConfig.runtimeStatePath) `
+        -Raw |
+        ConvertFrom-Json
+      if (
+        $health.ok -ne $true -or
+        $health.service -ne "kb1d" -or
+        $health.status.serviceName -ne "kb1d" -or
+        -not (Test-EquivalentPath ([string]$health.status.kb1Home) ([string]$taskConfig.kb1Home)) -or
+        -not (Test-EquivalentPath ([string]$health.status.statusFile) $expectedStatusFile) -or
+        ([int]$health.status.pid) -ne ([int]$runtimeState.daemonPid) -or
+        ([string]$health.status.instanceId) -ne ([string]$runtimeState.instanceId)
+      ) {
+        throw "The health endpoint does not match the installed KB-1 task."
+      }
+
+      $daemonProcess = Get-Process -Id ([int]$health.status.pid) -ErrorAction Stop
+      if (
+        -not (Test-EquivalentPath $daemonProcess.Path ([string]$taskConfig.nodePath)) -or
+        [long]($daemonProcess.StartTime.ToFileTimeUtc()) -ne
+          [long]([string]$runtimeState.daemonStartTimeFileTimeUtc)
+      ) {
+        throw "The healthy daemon PID is not the Node executable configured for the task."
+      }
+      return $health
+    } catch {
+      $lastError = $_.Exception.Message
+      Start-Sleep -Seconds 1
+    }
+  } while ([DateTime]::UtcNow -lt $deadline)
+
+  $logPath = [string]$taskConfig.logPath
+  if (Test-Path -LiteralPath $logPath) {
+    Write-Host ""
+    Write-Host "Recent task log:"
+    Get-Content -LiteralPath $logPath -Tail 80
+  }
+  foreach ($outputPath in @(
+    [string]$taskConfig.stdoutPath,
+    [string]$taskConfig.stderrPath
+  )) {
+    if (Test-Path -LiteralPath $outputPath) {
+      Write-Host ""
+      Write-Host "Recent output from ${outputPath}:"
+      Get-Content -LiteralPath $outputPath -Tail 80
+    }
+  }
+  throw "KB-1 task did not become healthy at $healthUrl. Last error: $lastError"
+}
+
+function Show-KB1Status {
+  $task = Get-InstalledTask
+  if ($null -eq $task) {
+    throw "Scheduled Task '$TaskName' is not installed."
+  }
+
+  Write-Host "Task:   $TaskName"
+  Write-Host "State:  $($task.State)"
+  Write-Host "Health: $script:HealthUrl"
+  Write-Host "Home:   $KB1Home"
+  if ($task.State -ne "Running") {
+    return
+  }
+  $health = Assert-HealthyTask -TimeoutSeconds 2
+  Write-Host "PID:    $($health.status.pid)"
+}
+
+function Assert-NoOtherTaskUsesHome {
+  $expectedConfigDirectory = Get-TaskStateRoot
+  $currentOwnerSid = (
+    [Security.Principal.WindowsIdentity]::GetCurrent()
+  ).User.Value
+  foreach ($candidate in @(Get-ScheduledTask -ErrorAction SilentlyContinue)) {
+    if (
+      [string]$candidate.TaskName -eq $TaskName -and
+      [string]$candidate.TaskPath -eq $script:TaskPath
+    ) {
+      continue
+    }
+    if (
+      -not (Test-CurrentUserTaskPrincipal $candidate)
+    ) {
+      continue
+    }
+    $candidateConfigPath = Find-TaskConfigPath $candidate
+    if (
+      -not (Test-TrustedLocalConfigPath $candidateConfigPath $expectedConfigDirectory) -or
+      -not (Test-KB1RunnerAction $candidate $candidateConfigPath) -or
+      -not (Test-Path -LiteralPath $candidateConfigPath -PathType Leaf)
+    ) {
+      continue
+    }
+    Assert-NoUntrustedWriteAccess -Paths @(
+      $candidateConfigPath,
+      (Split-Path -Parent $candidateConfigPath)
+    )
+    try {
+      $candidateConfig = Get-Content -LiteralPath $candidateConfigPath -Raw |
+        ConvertFrom-Json
+    } catch {
+      throw @"
+Refusing to install because current-user Scheduled Task
+'$($candidate.TaskName)' uses the KB-1 runner, but its configuration is
+unreadable. Repair or remove that task before installing another KB-1 task.
+"@
+    }
+    if (
+      [string]$candidateConfig.kind -ne "kb1-windows-user-task" -or
+      [string]$candidateConfig.taskName -ne [string]$candidate.TaskName -or
+      [string]$candidateConfig.ownerSid -ne [string]$currentOwnerSid -or
+      [string]::IsNullOrWhiteSpace([string]$candidateConfig.kb1Home) -or
+      -not (
+        Test-EquivalentPath `
+          ([string]$candidateConfig.taskStateRoot) `
+          $expectedConfigDirectory
+      )
+    ) {
+      throw @"
+Refusing to install because current-user Scheduled Task
+'$($candidate.TaskName)' uses the KB-1 runner, but its ownership configuration
+is invalid. Repair or remove that task before installing another KB-1 task.
+"@
+    }
+    if (Test-EquivalentPath ([string]$candidateConfig.kb1Home) $KB1Home) {
+      throw "Scheduled Task '$($candidate.TaskName)' already manages KB1_HOME=$KB1Home."
+    }
+  }
+}
+
+function Enter-TaskOperationLock {
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $ownerKey = ([string]$identity.User.Value).Replace("-", "")
+  $mutexName = "Global\KB1DaemonTask-$ownerKey-$(Get-TaskStorageKey)"
+  $mutex = New-OwnerOnlyGlobalMutex $mutexName
+  $acquired = $false
+  try {
+    try {
+      $acquired = $mutex.WaitOne(0)
+    } catch [Threading.AbandonedMutexException] {
+      $acquired = $true
+    }
+    if (-not $acquired) {
+      throw "Another lifecycle operation is already running for Scheduled Task '$TaskName'."
+    }
+    return $mutex
+  } catch {
+    $mutex.Dispose()
+    throw
+  }
+}
+
+function Enter-HomeOperationLock {
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $ownerKey = ([string]$identity.User.Value).Replace("-", "")
+  $mutexName = "Global\KB1DaemonHome-$ownerKey-$(Get-HomeStorageKey)"
+  $mutex = New-OwnerOnlyGlobalMutex $mutexName
+  $acquired = $false
+  try {
+    try {
+      $acquired = $mutex.WaitOne(0)
+    } catch [Threading.AbandonedMutexException] {
+      $acquired = $true
+    }
+    if (-not $acquired) {
+      throw "Another lifecycle operation is already running for KB1_HOME=$KB1Home."
+    }
+    return $mutex
+  } catch {
+    $mutex.Dispose()
+    throw
+  }
+}
+
+function Set-OwnerOnlyAcl {
+  param(
+    [string]$Path,
+    [switch]$Directory
+  )
+
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $acl = Get-Acl -LiteralPath $Path
+  $acl.SetAccessRuleProtection($true, $false)
+  foreach ($accessRule in @($acl.Access)) {
+    $null = $acl.RemoveAccessRuleSpecific($accessRule)
+  }
+  $acl.SetOwner($identity.User)
+  if ($Directory) {
+    $rule = [Security.AccessControl.FileSystemAccessRule]::new(
+      $identity.User,
+      [Security.AccessControl.FileSystemRights]::FullControl,
+      (
+        [Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+        [Security.AccessControl.InheritanceFlags]::ObjectInherit
+      ),
+      [Security.AccessControl.PropagationFlags]::None,
+      [Security.AccessControl.AccessControlType]::Allow
+    )
+  } else {
+    $rule = [Security.AccessControl.FileSystemAccessRule]::new(
+      $identity.User,
+      [Security.AccessControl.FileSystemRights]::FullControl,
+      [Security.AccessControl.AccessControlType]::Allow
+    )
+  }
+  $acl.AddAccessRule($rule)
+  Set-Acl -LiteralPath $Path -AclObject $acl
+}
+
+function New-OwnerOnlyGlobalMutex {
+  param([string]$Name)
+
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $security = [Security.AccessControl.MutexSecurity]::new()
+  $security.SetOwner($identity.User)
+  $security.SetAccessRuleProtection($true, $false)
+  $security.AddAccessRule(
+    [Security.AccessControl.MutexAccessRule]::new(
+      $identity.User,
+      [Security.AccessControl.MutexRights]::FullControl,
+      [Security.AccessControl.AccessControlType]::Allow
+    )
+  )
+  $createdNew = $false
+  try {
+    $mutex = [Threading.Mutex]::new(
+      $false,
+      $Name,
+      [ref]$createdNew,
+      $security
+    )
+  } catch {
+    throw "Could not create or open the cross-session lifecycle mutex '$Name'."
+  }
+
+  if (-not $createdNew) {
+    try {
+      $existingSecurity = $mutex.GetAccessControl()
+      $ownerSid = $existingSecurity.GetOwner(
+        [Security.Principal.SecurityIdentifier]
+      ).Value
+      if ($ownerSid -ne [string]$identity.User.Value) {
+        throw "The lifecycle mutex is owned by another principal."
+      }
+      foreach ($rule in @(
+        $existingSecurity.GetAccessRules(
+          $true,
+          $true,
+          [Security.Principal.SecurityIdentifier]
+        )
+      )) {
+        if (
+          $rule.AccessControlType -eq
+            [Security.AccessControl.AccessControlType]::Allow -and
+          [string]$rule.IdentityReference.Value -ne
+            [string]$identity.User.Value
+        ) {
+          throw "The lifecycle mutex grants access to another principal."
+        }
+      }
+    } catch {
+      $mutex.Dispose()
+      throw "Refusing to use an untrusted cross-session lifecycle mutex '$Name'."
+    }
+  }
+  return $mutex
+}
+
+function Assert-NoUntrustedWriteAccess {
+  param([string[]]$Paths)
+
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $trustedWriteSids = @(
+    [string]$identity.User.Value,
+    "S-1-5-18",
+    "S-1-5-32-544",
+    "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464"
+  )
+  $writeMask = (
+    [Security.AccessControl.FileSystemRights]::WriteData -bor
+    [Security.AccessControl.FileSystemRights]::AppendData -bor
+    [Security.AccessControl.FileSystemRights]::WriteExtendedAttributes -bor
+    [Security.AccessControl.FileSystemRights]::WriteAttributes -bor
+    [Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+    [Security.AccessControl.FileSystemRights]::Delete -bor
+    [Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+    [Security.AccessControl.FileSystemRights]::TakeOwnership
+  )
+
+  foreach ($path in $Paths) {
+    Assert-NoReparsePoints -Paths @($path)
+    $acl = Get-Acl -LiteralPath $path
+    try {
+      $ownerSid = $acl.GetOwner(
+        [Security.Principal.SecurityIdentifier]
+      ).Value
+    } catch {
+      throw "Could not validate filesystem ownership for $path."
+    }
+    if ($ownerSid -notin $trustedWriteSids) {
+      throw @"
+Refusing to register the task because an untrusted local principal owns:
+$path
+
+Move the checkout and KB1_HOME into a private directory owned by the current
+user, then retry.
+"@
+    }
+    foreach ($accessRule in @($acl.Access)) {
+      if (
+        $accessRule.AccessControlType -ne
+          [Security.AccessControl.AccessControlType]::Allow -or
+        (
+          $accessRule.PropagationFlags -band
+          [Security.AccessControl.PropagationFlags]::InheritOnly
+        ) -ne 0 -or
+        ($accessRule.FileSystemRights -band $writeMask) -eq 0
+      ) {
+        continue
+      }
+      try {
+        $ruleSid = $accessRule.IdentityReference.Translate(
+          [Security.Principal.SecurityIdentifier]
+        ).Value
+      } catch {
+        throw "Could not validate filesystem permissions for $path."
+      }
+      if ($ruleSid -notin $trustedWriteSids) {
+        throw @"
+Refusing to register the task because another local principal can modify:
+$path
+
+Move the checkout and KB1_HOME into a private directory owned by the current
+user, then retry.
+"@
+      }
+    }
+  }
+}
+
+function Assert-NoReparsePoints {
+  param([string[]]$Paths)
+
+  foreach ($path in $Paths) {
+    $item = Get-Item -LiteralPath $path -Force
+    if (
+      ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0
+    ) {
+      throw "Refusing to trust reparse-point path: $path"
+    }
+  }
+}
+
+function Get-LocalDirectoryChain {
+  param([string]$Path)
+
+  $fullPath = [IO.Path]::GetFullPath($Path)
+  $root = [IO.Path]::GetPathRoot($fullPath)
+  if (
+    [string]::IsNullOrWhiteSpace($root) -or
+    -not [regex]::IsMatch($root, '^[A-Za-z]:\\$')
+  ) {
+    throw "KB1_HOME must be an absolute path on a local Windows drive."
+  }
+  $relativePath = $fullPath.Substring($root.Length)
+  $components = @(
+    $relativePath -split '[\\/]' |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+
+  $chain = @($root)
+  $current = $root
+  foreach ($component in $components) {
+    $current = Join-Path $current $component
+    $chain += $current
+  }
+  return $chain
+}
+
+function Assert-NoUntrustedReplaceAccess {
+  param([string[]]$Paths)
+
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $trustedWriteSids = @(
+    [string]$identity.User.Value,
+    "S-1-5-18",
+    "S-1-5-32-544",
+    "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464"
+  )
+  $replaceMask = (
+    [Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+    [Security.AccessControl.FileSystemRights]::Delete -bor
+    [Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+    [Security.AccessControl.FileSystemRights]::TakeOwnership
+  )
+
+  foreach ($path in $Paths) {
+    Assert-NoReparsePoints -Paths @($path)
+    $acl = Get-Acl -LiteralPath $path
+    try {
+      $ownerSid = $acl.GetOwner(
+        [Security.Principal.SecurityIdentifier]
+      ).Value
+    } catch {
+      throw "Could not validate filesystem ownership for $path."
+    }
+    if ($ownerSid -notin $trustedWriteSids) {
+      throw "Refusing to trust KB1_HOME beneath a directory owned by an untrusted principal: $path"
+    }
+    foreach ($accessRule in @($acl.Access)) {
+      if (
+        $accessRule.AccessControlType -ne
+          [Security.AccessControl.AccessControlType]::Allow -or
+        (
+          $accessRule.PropagationFlags -band
+          [Security.AccessControl.PropagationFlags]::InheritOnly
+        ) -ne 0 -or
+        ($accessRule.FileSystemRights -band $replaceMask) -eq 0
+      ) {
+        continue
+      }
+      try {
+        $ruleSid = $accessRule.IdentityReference.Translate(
+          [Security.Principal.SecurityIdentifier]
+        ).Value
+      } catch {
+        throw "Could not validate filesystem permissions for $path."
+      }
+      if ($ruleSid -notin $trustedWriteSids) {
+        throw "Refusing to trust KB1_HOME beneath a replaceable directory: $path"
+      }
+    }
+  }
+}
+
+function Initialize-TrustedKB1Home {
+  param(
+    [string]$Path,
+    [switch]$Create
+  )
+
+  $chain = @(Get-LocalDirectoryChain $Path)
+  for ($index = 0; $index -lt $chain.Count; $index++) {
+    $candidate = [string]$chain[$index]
+    if (-not (Test-Path -LiteralPath $candidate)) {
+      if (-not $Create) {
+        throw "KB1_HOME does not exist: $Path"
+      }
+      New-Item -ItemType Directory -Path $candidate | Out-Null
+      Set-OwnerOnlyAcl -Path $candidate -Directory
+    }
+    if (-not (Test-Path -LiteralPath $candidate -PathType Container)) {
+      throw "KB1_HOME path component is not a directory: $candidate"
+    }
+    if ($index -eq ($chain.Count - 1)) {
+      Assert-NoUntrustedWriteAccess -Paths @($candidate)
+    } else {
+      Assert-NoUntrustedReplaceAccess -Paths @($candidate)
+    }
+  }
+
+  $pendingDirectories = [Collections.Generic.Queue[string]]::new()
+  $pendingDirectories.Enqueue([IO.Path]::GetFullPath($Path))
+  while ($pendingDirectories.Count -gt 0) {
+    $directory = $pendingDirectories.Dequeue()
+    foreach ($item in @(
+      Get-ChildItem -LiteralPath $directory -Force -ErrorAction Stop
+    )) {
+      if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "KB1_HOME contains a reparse point that could redirect vault access: $($item.FullName)"
+      }
+      if ($item.PSIsContainer) {
+        Assert-NoUntrustedWriteAccess -Paths @($item.FullName)
+        $pendingDirectories.Enqueue([string]$item.FullName)
+      }
+    }
+  }
+
+  return [IO.Path]::GetFullPath(
+    (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+  )
+}
+
+function Assert-TrustedPathChain {
+  param(
+    [string]$Path,
+    [switch]$Directory
+  )
+
+  $fullPath = [IO.Path]::GetFullPath($Path)
+  $trustedDirectory = if ($Directory) {
+    $fullPath
+  } else {
+    Split-Path -Parent $fullPath
+  }
+  $chain = @(Get-LocalDirectoryChain $trustedDirectory)
+  if ($chain.Count -gt 1) {
+    Assert-NoUntrustedReplaceAccess -Paths @(
+      $chain[0..($chain.Count - 2)]
+    )
+  }
+  Assert-NoUntrustedWriteAccess -Paths @($trustedDirectory)
+  if (-not $Directory) {
+    Assert-NoUntrustedWriteAccess -Paths @($fullPath)
+  }
+}
+
+function Assert-ExecutableTrust {
+  param([string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "Required executable is missing: $Path"
+  }
+  Assert-TrustedPathChain -Path $Path
+}
+
+function Assert-GitCheckoutTrust {
+  param([string]$Checkout)
+
+  $gitDirectory = Join-Path $Checkout ".git"
+  if (-not (Test-Path -LiteralPath $gitDirectory -PathType Container)) {
+    throw "$Checkout must be a standalone Git checkout with a .git directory."
+  }
+  Assert-TrustedPathChain -Path $Checkout -Directory
+  $paths = @(
+    $gitDirectory
+  )
+  foreach ($gitControlPath in @(
+    (Join-Path $gitDirectory "config"),
+    (Join-Path $gitDirectory "HEAD"),
+    (Join-Path $gitDirectory "index"),
+    (Join-Path $gitDirectory "hooks")
+  )) {
+    if (Test-Path -LiteralPath $gitControlPath) {
+      $paths += $gitControlPath
+    }
+  }
+  Assert-NoUntrustedWriteAccess -Paths @($paths | Select-Object -Unique)
+}
+
+function Remove-InactiveWindowsRuntimes {
+  param(
+    [string]$RuntimeRoot,
+    [string]$ActiveRuntime,
+    [switch]$WarnOnly
+  )
+
+  if (-not (Test-Path -LiteralPath $RuntimeRoot -PathType Container)) {
+    return
+  }
+  foreach ($candidate in @(Get-ChildItem -LiteralPath $RuntimeRoot -Directory)) {
+    $runtimeId = [Guid]::Empty
+    if (-not [Guid]::TryParseExact($candidate.Name, "N", [ref]$runtimeId)) {
+      continue
+    }
+    if (
+      -not [string]::IsNullOrWhiteSpace($ActiveRuntime) -and
+      (Test-EquivalentPath $candidate.FullName $ActiveRuntime)
+    ) {
+      continue
+    }
+    try {
+      Remove-Item -LiteralPath $candidate.FullName -Recurse -Force
+    } catch {
+      $message = "Could not remove inactive Windows runtime '$($candidate.FullName)': $($_.Exception.Message)"
+      if ($WarnOnly) {
+        Write-Warning $message
+      } else {
+        throw $message
+      }
+    }
+  }
+}
+
+function Install-KB1Task {
+  if (-not (Test-LoopbackHost $BindHost) -and -not $ConfirmNonLoopbackBind) {
+    throw @"
+Refusing to bind KB-1 to non-loopback host: $BindHost
+
+KB-1 Local has no application authentication. Keep the daemon on 127.0.0.1.
+If you intentionally accept direct network exposure, rerun with
+-ConfirmNonLoopbackBind.
+"@
+  }
+
+  $gitPath = Resolve-CommandPath @("git.exe", "git")
+  $nodePath = Resolve-CommandPath @("node.exe", "node")
+  if ($null -eq $gitPath) {
+    throw "Missing Git. Install Git for Windows before installing KB-1 Local."
+  }
+  if ($null -eq $nodePath) {
+    throw "Missing Node.js. Install a supported Node release (20.19.x, 22.12+, or 24+)."
+  }
+  Assert-ExecutableTrust $gitPath
+  Assert-ExecutableTrust $nodePath
+
+  $taskStateDirectory = Get-TaskStateRoot
+  $appStateDirectory = Split-Path -Parent $taskStateDirectory
+  $localAppData = Split-Path -Parent $appStateDirectory
+  Assert-NoReparsePoints -Paths @($localAppData)
+  Assert-NoUntrustedWriteAccess -Paths @($localAppData)
+  if (Test-Path -LiteralPath $appStateDirectory) {
+    Assert-NoUntrustedWriteAccess -Paths @($appStateDirectory)
+  } else {
+    New-Item -ItemType Directory -Path $appStateDirectory | Out-Null
+  }
+  Set-OwnerOnlyAcl -Path $appStateDirectory -Directory
+  if (Test-Path -LiteralPath $taskStateDirectory) {
+    Assert-NoUntrustedWriteAccess -Paths @($taskStateDirectory)
+  } else {
+    New-Item -ItemType Directory -Path $taskStateDirectory | Out-Null
+  }
+  Set-OwnerOnlyAcl -Path $taskStateDirectory -Directory
+  Assert-NoUntrustedWriteAccess -Paths @(
+    $appStateDirectory,
+    $taskStateDirectory
+  )
+  $runtimeRoot = Join-Path `
+    $taskStateDirectory `
+    "windows-runtimes\$(Get-TaskStorageKey)"
+
+  $existingTask = Get-InstalledTask
+  $existingConfigPath = $null
+  $existingTaskConfig = $null
+  if ($null -ne $existingTask) {
+    $existingConfigPath = Assert-OwnedTask $existingTask
+    $existingTaskConfig = Get-Content -LiteralPath $existingConfigPath -Raw |
+      ConvertFrom-Json
+  }
+  Assert-NoOtherTaskUsesHome
+  Remove-InactiveWindowsRuntimes `
+    -RuntimeRoot $runtimeRoot `
+    -ActiveRuntime ([string]$existingTaskConfig.repoDir)
+
+  $requestedRepoDir = $RepoDir
+  $stagedRuntimeDir = $null
+  $usingStagedRuntime = $false
+  $wouldMutateRuntime = (
+    -not $SkipRepoUpdate -or
+    -not $SkipDependencyInstall -or
+    -not $SkipBuild
+  )
+  if (-not $wouldMutateRuntime -and $null -eq $existingTaskConfig) {
+    throw @"
+The three skip switches can reuse an existing protected KB-1 runtime, but they
+cannot register a first task directly from an arbitrary checkout.
+
+Rerun without -SkipDependencyInstall and -SkipBuild so the installer can create
+an isolated per-user runtime.
+"@
+  }
+  if ($wouldMutateRuntime) {
+    $stagedRuntimeDir = Join-Path $runtimeRoot ([Guid]::NewGuid().ToString("N"))
+    $usingStagedRuntime = $true
+  } else {
+    $RepoDir = [IO.Path]::GetFullPath([string]$existingTaskConfig.repoDir)
+    if (-not (Test-PathAtOrWithin $RepoDir $runtimeRoot)) {
+      throw @"
+The existing Scheduled Task predates protected runtime staging and cannot be
+reused with all three skip switches.
+
+Rerun a normal Install to replace it with an isolated per-user runtime.
+"@
+    }
+  }
+
+  try {
+    if ($usingStagedRuntime) {
+      $repoParent = Split-Path -Parent $requestedRepoDir
+      New-Item -ItemType Directory -Path $repoParent -Force | Out-Null
+      Assert-NoUntrustedWriteAccess -Paths @($repoParent)
+      if (-not (Test-Path -LiteralPath $requestedRepoDir)) {
+        Write-Step "Cloning source checkout at $requestedRepoDir"
+        Invoke-External $gitPath @("clone", $RepoUrl, $requestedRepoDir)
+      } elseif (
+        -not (Test-Path -LiteralPath (Join-Path $requestedRepoDir ".git") -PathType Container)
+      ) {
+        throw "$requestedRepoDir exists but is not a standalone Git repository."
+      }
+      Assert-GitCheckoutTrust $requestedRepoDir
+
+      Write-Step "Preparing isolated replacement runtime at $stagedRuntimeDir"
+      New-Item `
+        -ItemType Directory `
+        -Path (Split-Path -Parent $stagedRuntimeDir) `
+        -Force |
+        Out-Null
+      Set-OwnerOnlyAcl -Path $runtimeRoot -Directory
+
+      $dirtyCheckout = Invoke-ExternalOutput `
+        -FilePath $gitPath `
+        -Arguments @(
+          "-C",
+          $requestedRepoDir,
+          "status",
+          "--porcelain",
+          "--untracked-files=all"
+        )
+      if (-not [string]::IsNullOrWhiteSpace($dirtyCheckout)) {
+        throw @"
+Refusing to stage a replacement from a dirty checkout at $requestedRepoDir.
+
+Commit or stash the local changes, or rerun with all three skip switches only
+when intentionally reusing an already-built runtime.
+"@
+      }
+
+      $selectedCommit = Invoke-ExternalOutput `
+        -FilePath $gitPath `
+        -Arguments @("-C", $requestedRepoDir, "rev-parse", "HEAD")
+      if (-not $SkipRepoUpdate) {
+        Invoke-External $gitPath @("-C", $requestedRepoDir, "fetch", "--prune")
+        $currentBranch = Invoke-ExternalOutput `
+          -FilePath $gitPath `
+          -Arguments @("-C", $requestedRepoDir, "branch", "--show-current")
+        $upstream = Invoke-ExternalOutputOrNull `
+          -FilePath $gitPath `
+          -Arguments @(
+            "-C",
+            $requestedRepoDir,
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}"
+          )
+        if (
+          -not [string]::IsNullOrWhiteSpace($currentBranch) -and
+          -not [string]::IsNullOrWhiteSpace($upstream)
+        ) {
+          $aheadBehind = Invoke-ExternalOutput `
+            -FilePath $gitPath `
+            -Arguments @(
+              "-C",
+              $requestedRepoDir,
+              "rev-list",
+              "--left-right",
+              "--count",
+              "HEAD...$upstream"
+            )
+          $counts = @($aheadBehind -split "\s+")
+          if ([int]$counts[0] -eq 0 -and [int]$counts[1] -gt 0) {
+            $selectedCommit = Invoke-ExternalOutput `
+              -FilePath $gitPath `
+              -Arguments @("-C", $requestedRepoDir, "rev-parse", $upstream)
+          }
+        }
+      }
+      Invoke-External $gitPath @(
+        "clone",
+        "--no-hardlinks",
+        "--no-checkout",
+        $requestedRepoDir,
+        $stagedRuntimeDir
+      )
+      Invoke-External $gitPath @(
+        "-C",
+        $stagedRuntimeDir,
+        "checkout",
+        "--detach",
+        $selectedCommit
+      )
+      $RepoDir = $stagedRuntimeDir
+    } else {
+      Write-Step "Reusing installed protected runtime at $RepoDir"
+    }
+
+    $RepoDir = (Resolve-Path -LiteralPath $RepoDir).Path
+    $entrypoint = Join-Path $RepoDir "apps\daemon\dist\main.js"
+    $runnerPath = Join-Path $RepoDir "skills\kb-1-daemon-setup\scripts\run_kb1_daemon_user_task.ps1"
+    Assert-GitCheckoutTrust $RepoDir
+
+    if (-not $SkipDependencyInstall -or -not $SkipBuild) {
+      Push-Location $RepoDir
+      try {
+        $pnpmPath = Resolve-CommandPath @("pnpm.cmd", "pnpm")
+        if ($null -eq $pnpmPath) {
+          $corepackPath = Resolve-CommandPath @("corepack.cmd", "corepack")
+          if ($null -eq $corepackPath) {
+            throw "pnpm is missing and Corepack is unavailable."
+          }
+          Assert-ExecutableTrust $corepackPath
+          Write-Step "Activating the repository package manager with Corepack"
+          Invoke-External $corepackPath @("enable")
+          Invoke-External $corepackPath @("install")
+          $pnpmPath = Resolve-CommandPath @("pnpm.cmd", "pnpm")
+          if ($null -eq $pnpmPath) {
+            throw "Corepack did not make pnpm available. Reopen PowerShell and retry."
+          }
+        }
+        Assert-ExecutableTrust $pnpmPath
+
+        if (-not $SkipDependencyInstall) {
+          Write-Step "Installing isolated runtime dependencies"
+          Invoke-External $pnpmPath @(
+            "install",
+            "--frozen-lockfile",
+            "--store-dir",
+            (Join-Path $RepoDir ".pnpm-store"),
+            "--package-import-method",
+            "copy"
+          )
+        }
+        if (-not $SkipBuild) {
+          if ($BuildOnly) {
+            Write-Step "Building KB-1 Local"
+            Invoke-External $pnpmPath @("build")
+          } else {
+            Write-Step "Running the full KB-1 check"
+            Invoke-External $pnpmPath @("check")
+          }
+        }
+      } finally {
+        Pop-Location
+      }
+    }
+
+    foreach ($requiredFile in @($entrypoint, $runnerPath)) {
+      if (-not (Test-Path -LiteralPath $requiredFile -PathType Leaf)) {
+        throw "Required runtime file is missing: $requiredFile"
+      }
+    }
+    if (-not (Test-PathAtOrWithin $RepoDir $runtimeRoot)) {
+      throw "Refusing to register a Scheduled Task outside the protected runtime root."
+    }
+    Assert-ContainedRuntimeReparseTargets `
+      -RuntimeDirectory $RepoDir `
+      -TrustedRoot $runtimeRoot
+
+    $codeAclPaths = @(
+      $nodePath,
+      (Split-Path -Parent $nodePath),
+      (Split-Path -Parent $RepoDir),
+      $RepoDir,
+      $entrypoint,
+      $runnerPath
+    )
+    $repoAclRoot = [IO.Path]::GetFullPath($RepoDir).TrimEnd("\")
+    foreach ($codeFile in @($entrypoint, $runnerPath)) {
+      $parentPath = Split-Path -Parent $codeFile
+      while (
+        [string]::Equals(
+          $parentPath,
+          $repoAclRoot,
+          [StringComparison]::OrdinalIgnoreCase
+        ) -or
+        $parentPath.StartsWith(
+          "$repoAclRoot\",
+          [StringComparison]::OrdinalIgnoreCase
+        )
+      ) {
+        $codeAclPaths += $parentPath
+        if ([string]::Equals(
+          $parentPath,
+          $repoAclRoot,
+          [StringComparison]::OrdinalIgnoreCase
+        )) {
+          break
+        }
+        $parentPath = Split-Path -Parent $parentPath
+      }
+    }
+    Assert-NoUntrustedWriteAccess -Paths @(
+      $codeAclPaths | Select-Object -Unique
+    )
+  } catch {
+    if (
+      $usingStagedRuntime -and
+      -not [string]::IsNullOrWhiteSpace($stagedRuntimeDir)
+    ) {
+      Remove-Item `
+        -LiteralPath $stagedRuntimeDir `
+        -Recurse `
+        -Force `
+        -ErrorAction SilentlyContinue
+    }
+    throw
+  }
+
+  try {
+    $taskKey = Get-TaskStorageKey
+    $windowsIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $identityName = $windowsIdentity.Name
+    $taskConfig = [ordered]@{
+      version = 5
+      kind = "kb1-windows-user-task"
+      taskName = $TaskName
+      ownerSid = $windowsIdentity.User.Value
+      nodePath = $nodePath
+      sourceRepoUrl = $RepoUrl
+      sourceRepoDir = $requestedRepoDir
+      repoDir = $RepoDir
+      entrypoint = $entrypoint
+      taskStateRoot = $taskStateDirectory
+      kb1Home = $KB1Home
+      bindHost = $BindHost
+      port = $Port
+      logPath = Join-Path $taskStateDirectory "windows-task-$taskKey.log"
+      stdoutPath = Join-Path $taskStateDirectory "windows-task-$taskKey.stdout.log"
+      stderrPath = Join-Path $taskStateDirectory "windows-task-$taskKey.stderr.log"
+      runtimeStatePath = Join-Path $taskStateDirectory "windows-task-$taskKey.runtime.json"
+      controlToken = [Guid]::NewGuid().ToString("N")
+    }
+
+    $powerShellPath = Resolve-CommandPath @("powershell.exe")
+    if ($null -eq $powerShellPath) {
+      throw "Windows PowerShell 5.1 is required to register the background task."
+    }
+    Assert-ExecutableTrust $powerShellPath
+    $taskArguments = '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{0}" -ConfigPath "{1}"' -f (
+      $runnerPath.Replace('"', '\"')
+    ), (
+      $script:ConfigPath.Replace('"', '\"')
+    )
+    $taskAction = New-ScheduledTaskAction `
+      -Execute $powerShellPath `
+      -Argument $taskArguments `
+      -WorkingDirectory $RepoDir
+    $principal = New-ScheduledTaskPrincipal `
+      -UserId $identityName `
+      -LogonType Interactive `
+      -RunLevel Limited
+    $trigger = New-ScheduledTaskTrigger -AtLogOn -User $identityName
+    $settings = New-ScheduledTaskSettingsSet `
+      -AllowStartIfOnBatteries `
+      -DontStopIfGoingOnBatteries `
+      -ExecutionTimeLimit ([TimeSpan]::Zero) `
+      -MultipleInstances IgnoreNew `
+      -RestartCount 3 `
+      -RestartInterval (New-TimeSpan -Minutes 1) `
+      -StartWhenAvailable
+
+    $previousTaskXml = $null
+    $previousConfigPath = $null
+    $previousConfigBytes = $null
+    $previousWasActive = $false
+    if ($null -ne $existingTask) {
+      $previousConfigPath = Assert-OwnedTask $existingTask
+      $previousTaskXml = Export-ScheduledTask `
+        -TaskName $TaskName `
+        -TaskPath $script:TaskPath
+      $previousConfigBytes = [IO.File]::ReadAllBytes($previousConfigPath)
+      $previousWasActive = $existingTask.State -in @("Running", "Queued")
+    }
+  } catch {
+    if (
+      $usingStagedRuntime -and
+      -not [string]::IsNullOrWhiteSpace($stagedRuntimeDir)
+    ) {
+      Remove-Item `
+        -LiteralPath $stagedRuntimeDir `
+        -Recurse `
+        -Force `
+        -ErrorAction SilentlyContinue
+    }
+    throw
+  }
+
+  $registrationAttempted = $false
+  $replacementConfigAttempted = $false
+  $previousStopped = $false
+  try {
+    if ($null -ne $existingTask) {
+      $taskBeforeStop = Get-InstalledTask
+      if ($null -eq $taskBeforeStop) {
+        throw "Scheduled Task '$TaskName' disappeared before replacement."
+      }
+      $previousWasActive = (
+        $previousWasActive -or
+        $taskBeforeStop.State -in @("Running", "Queued")
+      )
+      if (-not $previousWasActive) {
+        $previousIdentity = Get-SupervisedDaemonIdentity $previousConfigPath
+        $previousWasActive = (
+          $null -ne $previousIdentity -and
+          $null -ne (Get-MatchingSupervisedDaemonProcess $previousIdentity)
+        )
+      }
+
+      # Even a Ready or Disabled task can have a live orphaned child. Stop
+      # (or fail closed on) that verified process before replacing the config
+      # and its only persisted PID/start-time identity.
+      $previousStopped = $previousWasActive
+      Stop-KB1Task
+    }
+
+    Write-Step "Writing task configuration"
+    $replacementConfigAttempted = $true
+    Remove-Item `
+      -LiteralPath $taskConfig.runtimeStatePath `
+      -Force `
+      -ErrorAction SilentlyContinue
+    $taskConfig |
+      ConvertTo-Json |
+      Set-Content -LiteralPath $script:ConfigPath -Encoding utf8
+    Set-OwnerOnlyAcl -Path $script:ConfigPath
+
+    Write-Step "Registering per-user Scheduled Task '$TaskName'"
+    $registrationAttempted = $true
+    Register-ScheduledTask `
+      -TaskName $TaskName `
+      -TaskPath $script:TaskPath `
+      -Action $taskAction `
+      -Trigger $trigger `
+      -Principal $principal `
+      -Settings $settings `
+      -Description "KB-1 Local per-user background task" `
+      -Force | Out-Null
+
+    Start-ScheduledTask -TaskName $TaskName -TaskPath $script:TaskPath
+    Write-Step "Waiting for KB-1 Local health"
+    $health = Assert-HealthyTask -TimeoutSeconds $HealthTimeoutSeconds
+    $health | ConvertTo-Json -Depth 8
+  } catch {
+    $installError = $_.Exception
+    $rollbackError = $null
+    $shouldRestorePrevious = (
+      $null -ne $previousTaskXml -and
+      ($previousStopped -or $replacementConfigAttempted -or $registrationAttempted)
+    )
+
+    if ($registrationAttempted) {
+      $failedTask = Get-InstalledTask
+      if ($null -ne $failedTask) {
+        try {
+          Stop-KB1Task
+        } catch {
+          Stop-KB1TaskHard `
+            -TaskConfigPath $script:ConfigPath `
+            -StopTaskAction:($failedTask.State -in @("Running", "Queued"))
+        }
+      }
+      Unregister-ScheduledTask `
+        -TaskName $TaskName `
+        -TaskPath $script:TaskPath `
+        -Confirm:$false `
+        -ErrorAction SilentlyContinue
+    }
+
+    if ($replacementConfigAttempted) {
+      Remove-Item `
+        -LiteralPath ([string]$taskConfig.runtimeStatePath) `
+        -Force `
+        -ErrorAction SilentlyContinue
+      Remove-Item `
+        -LiteralPath $script:ConfigPath `
+        -Force `
+        -ErrorAction SilentlyContinue
+    }
+
+    if ($shouldRestorePrevious) {
+      try {
+        if (
+          $null -ne $previousConfigBytes -and
+          -not [string]::IsNullOrWhiteSpace([string]$previousConfigPath)
+        ) {
+          New-Item `
+            -ItemType Directory `
+            -Path (Split-Path -Parent $previousConfigPath) `
+            -Force |
+            Out-Null
+          [IO.File]::WriteAllBytes($previousConfigPath, $previousConfigBytes)
+          Set-OwnerOnlyAcl -Path $previousConfigPath
+        }
+        Register-ScheduledTask `
+          -TaskName $TaskName `
+          -TaskPath $script:TaskPath `
+          -Xml $previousTaskXml `
+          -Force |
+          Out-Null
+        if ($previousWasActive) {
+          Start-ScheduledTask -TaskName $TaskName -TaskPath $script:TaskPath
+          $null = Assert-HealthyTask `
+            -TimeoutSeconds $HealthTimeoutSeconds `
+            -TaskConfigPath $previousConfigPath
+        }
+      } catch {
+        $rollbackError = $_.Exception
+      }
+    }
+
+    if (
+      $null -eq $rollbackError -and
+      $usingStagedRuntime -and
+      -not [string]::IsNullOrWhiteSpace($stagedRuntimeDir)
+    ) {
+      Remove-Item `
+        -LiteralPath $stagedRuntimeDir `
+        -Recurse `
+        -Force `
+        -ErrorAction SilentlyContinue
+    }
+
+    if ($null -ne $rollbackError) {
+      throw @"
+KB-1 task installation failed: $($installError.Message)
+
+Restoring the previous Scheduled Task also failed: $($rollbackError.Message)
+"@
+    }
+    throw $installError
+  }
+
+  if (
+    -not [string]::IsNullOrWhiteSpace([string]$previousConfigPath) -and
+    -not [string]::Equals(
+      [IO.Path]::GetFullPath($previousConfigPath),
+      [IO.Path]::GetFullPath($script:ConfigPath),
+      [StringComparison]::OrdinalIgnoreCase
+    )
+  ) {
+    Remove-Item `
+      -LiteralPath $previousConfigPath `
+      -Force `
+      -ErrorAction SilentlyContinue
+  }
+
+  Remove-InactiveWindowsRuntimes `
+    -RuntimeRoot $runtimeRoot `
+    -ActiveRuntime $RepoDir `
+    -WarnOnly
+
+  Write-Step "Installation complete"
+  Write-Host "Local app/API: $($script:BaseUrl)"
+  Write-Host "Local MCP:     $($script:BaseUrl)/mcp"
+  Write-Host "Task:          $TaskName"
+  Write-Host "Log:           $($taskConfig.logPath)"
+}
+
+function Invoke-Main {
+  if ($env:OS -ne "Windows_NT") {
+    throw "This installer is supported only on Windows."
+  }
+  $taskLock = Enter-TaskOperationLock
+  $homeLock = $null
+  try {
+    if ($Action -eq "Install") {
+      Use-InstalledTaskUpgradeDefaults
+    } else {
+      Use-InstalledTaskConfig
+    }
+    if ($Action -in @("Install", "Start")) {
+      $script:KB1Home = Initialize-TrustedKB1Home `
+        -Path $script:KB1Home `
+        -Create
+      Set-RuntimeUrls
+    }
+    $homeLock = Enter-HomeOperationLock
+
+    switch ($Action) {
+      "Install" {
+        Install-KB1Task
+      }
+      "Uninstall" {
+        Write-Step "Removing Scheduled Task '$TaskName'"
+        $task = Get-InstalledTask
+        if ($null -ne $task) {
+          Stop-KB1Task
+          Unregister-ScheduledTask `
+            -TaskName $TaskName `
+            -TaskPath $script:TaskPath `
+            -Confirm:$false
+        }
+        if (Test-Path -LiteralPath $script:ConfigPath -PathType Leaf) {
+          $removedConfig = Get-Content -LiteralPath $script:ConfigPath -Raw |
+            ConvertFrom-Json
+          if (-not [string]::IsNullOrWhiteSpace([string]$removedConfig.runtimeStatePath)) {
+            Remove-Item `
+              -LiteralPath ([string]$removedConfig.runtimeStatePath) `
+              -Force `
+              -ErrorAction SilentlyContinue
+          }
+        }
+        Remove-Item -LiteralPath $script:ConfigPath -Force -ErrorAction SilentlyContinue
+        Write-Host "The repository, logs, and vault data were preserved."
+      }
+      "Start" {
+        $task = Get-InstalledTask
+        if ($null -eq $task) {
+          throw "Scheduled Task '$TaskName' is not installed."
+        }
+        Start-ScheduledTask -TaskName $TaskName -TaskPath $script:TaskPath
+        Assert-HealthyTask | Out-Null
+        Write-Host "KB-1 Local is healthy at $script:HealthUrl"
+      }
+      "Stop" {
+        Stop-KB1Task
+        Write-Host "KB-1 Local task stopped."
+      }
+      "Status" {
+        Show-KB1Status
+      }
+    }
+  } finally {
+    if ($null -ne $homeLock) {
+      $homeLock.ReleaseMutex()
+      $homeLock.Dispose()
+    }
+    $taskLock.ReleaseMutex()
+    $taskLock.Dispose()
+  }
+}
+
+try {
+  Invoke-Main
+} catch {
+  Write-Error $_
+  exit 1
+}

--- a/skills/kb-1-daemon-setup/scripts/install_kb1_daemon_user_task.ps1
+++ b/skills/kb-1-daemon-setup/scripts/install_kb1_daemon_user_task.ps1
@@ -405,8 +405,8 @@ function Test-CurrentUserTaskPrincipal {
   param($Task)
 
   $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
-  $userId = [string]$Task.Principal.UserId
-  return (
+  $userId = ([string]$Task.Principal.UserId).Trim()
+  if (
     [string]::Equals(
       $userId,
       [string]$identity.User.Value,
@@ -417,7 +417,24 @@ function Test-CurrentUserTaskPrincipal {
       [string]$identity.Name,
       [StringComparison]::OrdinalIgnoreCase
     )
-  )
+  ) {
+    return $true
+  }
+
+  try {
+    $principalSid = (
+      [Security.Principal.NTAccount]::new($userId)
+    ).Translate(
+      [Security.Principal.SecurityIdentifier]
+    )
+    return [string]::Equals(
+      [string]$principalSid.Value,
+      [string]$identity.User.Value,
+      [StringComparison]::OrdinalIgnoreCase
+    )
+  } catch {
+    return $false
+  }
 }
 
 function Test-KB1RunnerAction {

--- a/skills/kb-1-daemon-setup/scripts/install_kb1_daemon_user_task.ps1
+++ b/skills/kb-1-daemon-setup/scripts/install_kb1_daemon_user_task.ps1
@@ -123,6 +123,10 @@ function Invoke-DirectRestMethod {
   param(
     [Parameter(Mandatory = $true)]
     [Uri]$Uri,
+    [Parameter(Mandatory = $true)]
+    [string]$NodePath,
+    [Parameter(Mandatory = $true)]
+    [string]$ErrorDirectory,
     [ValidateSet("Get", "Post")]
     [string]$Method = "Get",
     [hashtable]$Headers = @{},
@@ -130,49 +134,147 @@ function Invoke-DirectRestMethod {
     [int]$TimeoutSec = 30
   )
 
-  if (-not ("System.Net.Http.HttpClient" -as [type])) {
-    Add-Type -AssemblyName System.Net.Http
-  }
-
-  $handler = [Net.Http.HttpClientHandler]::new()
-  $handler.UseProxy = $false
-  $client = [Net.Http.HttpClient]::new($handler)
-  $client.Timeout = [TimeSpan]::FromSeconds($TimeoutSec)
-  $httpMethod = if ($Method -eq "Post") {
-    [Net.Http.HttpMethod]::Post
-  } else {
-    [Net.Http.HttpMethod]::Get
-  }
-  $request = [Net.Http.HttpRequestMessage]::new($httpMethod, $Uri)
-  # Windows PowerShell 5.1 can omit the required brackets when it derives the
-  # Host header for an IPv6 literal. Pin the RFC-form authority explicitly.
-  $request.Headers.Host = $Uri.Authority
-  foreach ($header in $Headers.GetEnumerator()) {
-    $request.Headers.TryAddWithoutValidation(
-      [string]$header.Key,
-      [string]$header.Value
-    ) | Out-Null
-  }
-
-  $response = $null
+  $requestScript = @'
+const [url, method, timeoutSeconds] = process.argv.slice(1);
+const { default: http } = await import("node:http");
+const { default: https } = await import("node:https");
+const headers = JSON.parse(process.env.KB1_DIRECT_REQUEST_HEADERS || "{}");
+const writeUtf8 = (value) => {
+  process.stdout.write(Buffer.from(value, "utf8").toString("base64"));
+};
+try {
+  const target = new URL(url);
+  const transport = target.protocol === "https:" ? https : http;
+  const controller = new AbortController();
+  const deadline = setTimeout(() => {
+    controller.abort(new Error(`Request timed out after ${timeoutSeconds}s`));
+  }, Number(timeoutSeconds) * 1000);
   try {
-    $response = $client.SendAsync($request).GetAwaiter().GetResult()
-    $body = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
-    if (-not $response.IsSuccessStatusCode) {
-      throw "HTTP $([int]$response.StatusCode) $($response.ReasonPhrase): $body"
+    const response = await new Promise((resolve, reject) => {
+      const request = transport.request(target, {
+        method: method.toUpperCase(),
+        headers,
+        signal: controller.signal
+      }, resolve);
+      request.on("error", reject);
+      request.end();
+    });
+    const chunks = [];
+    for await (const chunk of response) {
+      chunks.push(chunk);
     }
-    if ([string]::IsNullOrWhiteSpace($body)) {
-      return $null
+    const body = Buffer.concat(chunks);
+    if (
+      response.statusCode === undefined ||
+      response.statusCode < 200 ||
+      response.statusCode >= 300
+    ) {
+      writeUtf8(
+        `HTTP ${response.statusCode ?? "unknown"} ` +
+        `${response.statusMessage ?? ""}: ${body.toString("utf8")}`
+      );
+      process.exitCode = 1;
+    } else {
+      process.stdout.write(body.toString("base64"));
     }
-    return $body | ConvertFrom-Json
   } finally {
-    if ($null -ne $response) {
-      $response.Dispose()
-    }
-    $request.Dispose()
-    $client.Dispose()
-    $handler.Dispose()
+    clearTimeout(deadline);
   }
+} catch (error) {
+  writeUtf8(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}
+'@
+  $encodedRequestScript = [Convert]::ToBase64String(
+    [Text.Encoding]::UTF8.GetBytes($requestScript)
+  )
+  $bootstrapScript = "const[a,b]=process.argv.splice(1,2);await(import(a+b))"
+  $previousHeaders = $env:KB1_DIRECT_REQUEST_HEADERS
+  $previousNodeOptions = $env:NODE_OPTIONS
+  $previousNodePath = $env:NODE_PATH
+  $previousNodeProxy = $env:NODE_USE_ENV_PROXY
+  $previousNodeDebug = $env:NODE_DEBUG
+  $previousNodeDebugNative = $env:NODE_DEBUG_NATIVE
+  $previousExtraCaCertificates = $env:NODE_EXTRA_CA_CERTS
+  $stderrPath = Join-Path `
+    $ErrorDirectory `
+    "windows-request-$([Guid]::NewGuid().ToString('N')).stderr.log"
+  $output = @()
+  $exitCode = 1
+  try {
+    $env:KB1_DIRECT_REQUEST_HEADERS = ConvertTo-Json `
+      -InputObject $Headers `
+      -Compress
+    $env:NODE_OPTIONS = $null
+    $env:NODE_PATH = $null
+    $env:NODE_USE_ENV_PROXY = $null
+    $env:NODE_DEBUG = $null
+    $env:NODE_DEBUG_NATIVE = $null
+    $env:NODE_EXTRA_CA_CERTS = $null
+    $output = @(
+      & $NodePath `
+        --input-type=module `
+        -e $bootstrapScript `
+        -- `
+        "data:text/javascript;base64," `
+        $encodedRequestScript `
+        ([string]$Uri.AbsoluteUri) `
+        $Method `
+        ([string]$TimeoutSec) `
+        2> $stderrPath
+    )
+    $exitCode = $LASTEXITCODE
+  } finally {
+    foreach ($environmentValue in @(
+      @{ Name = "KB1_DIRECT_REQUEST_HEADERS"; Value = $previousHeaders },
+      @{ Name = "NODE_OPTIONS"; Value = $previousNodeOptions },
+      @{ Name = "NODE_PATH"; Value = $previousNodePath },
+      @{ Name = "NODE_USE_ENV_PROXY"; Value = $previousNodeProxy },
+      @{ Name = "NODE_DEBUG"; Value = $previousNodeDebug },
+      @{ Name = "NODE_DEBUG_NATIVE"; Value = $previousNodeDebugNative },
+      @{
+        Name = "NODE_EXTRA_CA_CERTS"
+        Value = $previousExtraCaCertificates
+      }
+    )) {
+      if ($null -eq $environmentValue.Value) {
+        Remove-Item `
+          -LiteralPath "Env:$($environmentValue.Name)" `
+          -ErrorAction SilentlyContinue
+      } else {
+        [Environment]::SetEnvironmentVariable(
+          [string]$environmentValue.Name,
+          [string]$environmentValue.Value
+        )
+      }
+    }
+    Remove-Item `
+      -LiteralPath $stderrPath `
+      -Force `
+      -ErrorAction SilentlyContinue
+  }
+
+  $encodedBody = ($output -join "").Trim()
+  $body = ""
+  if (-not [string]::IsNullOrWhiteSpace($encodedBody)) {
+    try {
+      $body = [Text.Encoding]::UTF8.GetString(
+        [Convert]::FromBase64String($encodedBody)
+      )
+    } catch {
+      throw "Direct Node request returned invalid encoded output."
+    }
+  }
+  if ($exitCode -ne 0) {
+    if ([string]::IsNullOrWhiteSpace($body)) {
+      throw "Direct Node request failed with exit code $exitCode."
+    }
+    throw $body
+  }
+  if ([string]::IsNullOrWhiteSpace($body)) {
+    return $null
+  }
+  return $body | ConvertFrom-Json
 }
 
 function Set-RuntimeUrls {
@@ -652,6 +754,8 @@ function Stop-KB1Task {
       $urlHost = Get-LifecycleUrlHost ([string]$taskConfig.bindHost)
       $shutdown = Invoke-DirectRestMethod `
         -Uri "http://${urlHost}:$($taskConfig.port)/api/control/shutdown" `
+        -NodePath ([string]$taskConfig.nodePath) `
+        -ErrorDirectory ([string]$taskConfig.taskStateRoot) `
         -Method Post `
         -Headers @{ "x-kb1-control-token" = [string]$taskConfig.controlToken } `
         -TimeoutSec 3
@@ -793,7 +897,11 @@ function Assert-HealthyTask {
         throw "Scheduled Task '$TaskName' is not running."
       }
 
-      $health = Invoke-DirectRestMethod -Uri $healthUrl -TimeoutSec 2
+      $health = Invoke-DirectRestMethod `
+        -Uri $healthUrl `
+        -NodePath ([string]$taskConfig.nodePath) `
+        -ErrorDirectory ([string]$taskConfig.taskStateRoot) `
+        -TimeoutSec 2
       $expectedStatusFile = Join-Path ([string]$taskConfig.kb1Home) "daemon\status.json"
       $runtimeState = Get-Content `
         -LiteralPath ([string]$taskConfig.runtimeStatePath) `

--- a/skills/kb-1-daemon-setup/scripts/install_kb1_daemon_user_task.ps1
+++ b/skills/kb-1-daemon-setup/scripts/install_kb1_daemon_user_task.ps1
@@ -10,7 +10,7 @@ param(
   [string]$RepoDir = $(if ($env:KB1_REPO_DIR) {
     $env:KB1_REPO_DIR
   } else {
-    [IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\..\.."))
+    ""
   }),
 
   [string]$KB1Home = $(if ($env:KB1_HOME) {
@@ -66,6 +66,12 @@ foreach ($environmentOverride in @{
   }
 }
 $ErrorActionPreference = "Stop"
+if ([string]::IsNullOrWhiteSpace($RepoDir)) {
+  if ([string]::IsNullOrWhiteSpace($PSScriptRoot)) {
+    throw "Could not resolve the installer script directory."
+  }
+  $RepoDir = Join-Path $PSScriptRoot "..\..\.."
+}
 $RepoDir = [IO.Path]::GetFullPath($RepoDir)
 $KB1Home = [IO.Path]::GetFullPath($KB1Home)
 if ($BindHost.StartsWith("[") -and $BindHost.EndsWith("]")) {

--- a/skills/kb-1-daemon-setup/scripts/install_kb1_daemon_user_task.ps1
+++ b/skills/kb-1-daemon-setup/scripts/install_kb1_daemon_user_task.ps1
@@ -119,6 +119,59 @@ function Get-LifecycleUrlHost {
   return $probeHost
 }
 
+function Invoke-DirectRestMethod {
+  param(
+    [Parameter(Mandatory = $true)]
+    [Uri]$Uri,
+    [ValidateSet("Get", "Post")]
+    [string]$Method = "Get",
+    [hashtable]$Headers = @{},
+    [ValidateRange(1, 300)]
+    [int]$TimeoutSec = 30
+  )
+
+  if (-not ("System.Net.Http.HttpClient" -as [type])) {
+    Add-Type -AssemblyName System.Net.Http
+  }
+
+  $handler = [Net.Http.HttpClientHandler]::new()
+  $handler.UseProxy = $false
+  $client = [Net.Http.HttpClient]::new($handler)
+  $client.Timeout = [TimeSpan]::FromSeconds($TimeoutSec)
+  $httpMethod = if ($Method -eq "Post") {
+    [Net.Http.HttpMethod]::Post
+  } else {
+    [Net.Http.HttpMethod]::Get
+  }
+  $request = [Net.Http.HttpRequestMessage]::new($httpMethod, $Uri)
+  foreach ($header in $Headers.GetEnumerator()) {
+    $request.Headers.TryAddWithoutValidation(
+      [string]$header.Key,
+      [string]$header.Value
+    ) | Out-Null
+  }
+
+  $response = $null
+  try {
+    $response = $client.SendAsync($request).GetAwaiter().GetResult()
+    $body = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+    if (-not $response.IsSuccessStatusCode) {
+      throw "HTTP $([int]$response.StatusCode) $($response.ReasonPhrase): $body"
+    }
+    if ([string]::IsNullOrWhiteSpace($body)) {
+      return $null
+    }
+    return $body | ConvertFrom-Json
+  } finally {
+    if ($null -ne $response) {
+      $response.Dispose()
+    }
+    $request.Dispose()
+    $client.Dispose()
+    $handler.Dispose()
+  }
+}
+
 function Set-RuntimeUrls {
   $healthHost = Get-LifecycleUrlHost $script:BindHost
   $taskKey = Get-TaskStorageKey
@@ -594,7 +647,7 @@ function Stop-KB1Task {
       $taskConfig = Get-Content -LiteralPath $installedConfigPath -Raw |
         ConvertFrom-Json
       $urlHost = Get-LifecycleUrlHost ([string]$taskConfig.bindHost)
-      $shutdown = Invoke-RestMethod `
+      $shutdown = Invoke-DirectRestMethod `
         -Uri "http://${urlHost}:$($taskConfig.port)/api/control/shutdown" `
         -Method Post `
         -Headers @{ "x-kb1-control-token" = [string]$taskConfig.controlToken } `
@@ -737,7 +790,7 @@ function Assert-HealthyTask {
         throw "Scheduled Task '$TaskName' is not running."
       }
 
-      $health = Invoke-RestMethod -Uri $healthUrl -TimeoutSec 2
+      $health = Invoke-DirectRestMethod -Uri $healthUrl -TimeoutSec 2
       $expectedStatusFile = Join-Path ([string]$taskConfig.kb1Home) "daemon\status.json"
       $runtimeState = Get-Content `
         -LiteralPath ([string]$taskConfig.runtimeStatePath) `

--- a/skills/kb-1-daemon-setup/scripts/install_kb1_daemon_user_task.ps1
+++ b/skills/kb-1-daemon-setup/scripts/install_kb1_daemon_user_task.ps1
@@ -144,6 +144,9 @@ function Invoke-DirectRestMethod {
     [Net.Http.HttpMethod]::Get
   }
   $request = [Net.Http.HttpRequestMessage]::new($httpMethod, $Uri)
+  # Windows PowerShell 5.1 can omit the required brackets when it derives the
+  # Host header for an IPv6 literal. Pin the RFC-form authority explicitly.
+  $request.Headers.Host = $Uri.Authority
   foreach ($header in $Headers.GetEnumerator()) {
     $request.Headers.TryAddWithoutValidation(
       [string]$header.Key,

--- a/skills/kb-1-daemon-setup/scripts/run_kb1_daemon_user_task.ps1
+++ b/skills/kb-1-daemon-setup/scripts/run_kb1_daemon_user_task.ps1
@@ -1,0 +1,442 @@
+#Requires -Version 5.1
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ConfigPath
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($env:OS -ne "Windows_NT") {
+  throw "The KB-1 user task runner is supported only on Windows."
+}
+
+function Test-EquivalentPath {
+  param(
+    [string]$Left,
+    [string]$Right
+  )
+
+  return [string]::Equals(
+    [IO.Path]::GetFullPath($Left).TrimEnd("\"),
+    [IO.Path]::GetFullPath($Right).TrimEnd("\"),
+    [StringComparison]::OrdinalIgnoreCase
+  )
+}
+
+function Test-PathAtOrWithin {
+  param(
+    [string]$Candidate,
+    [string]$Root
+  )
+
+  $candidateFull = [IO.Path]::GetFullPath($Candidate).TrimEnd("\")
+  $rootFull = [IO.Path]::GetFullPath($Root).TrimEnd("\")
+  return (
+    [string]::Equals(
+      $candidateFull,
+      $rootFull,
+      [StringComparison]::OrdinalIgnoreCase
+    ) -or
+    $candidateFull.StartsWith(
+      "$rootFull\",
+      [StringComparison]::OrdinalIgnoreCase
+    )
+  )
+}
+
+function Get-TaskStorageKey {
+  param([string]$TaskName)
+
+  $sha256 = [Security.Cryptography.SHA256]::Create()
+  try {
+    $bytes = [Text.Encoding]::UTF8.GetBytes($TaskName.ToUpperInvariant())
+    $hash = $sha256.ComputeHash($bytes)
+    return ([BitConverter]::ToString($hash).Replace("-", "").Substring(0, 16)).ToLowerInvariant()
+  } finally {
+    $sha256.Dispose()
+  }
+}
+
+function Assert-NoUntrustedWriteAccess {
+  param([string[]]$Paths)
+
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $trustedWriteSids = @(
+    [string]$identity.User.Value,
+    "S-1-5-18",
+    "S-1-5-32-544",
+    "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464"
+  )
+  $writeMask = (
+    [Security.AccessControl.FileSystemRights]::WriteData -bor
+    [Security.AccessControl.FileSystemRights]::AppendData -bor
+    [Security.AccessControl.FileSystemRights]::WriteExtendedAttributes -bor
+    [Security.AccessControl.FileSystemRights]::WriteAttributes -bor
+    [Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+    [Security.AccessControl.FileSystemRights]::Delete -bor
+    [Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+    [Security.AccessControl.FileSystemRights]::TakeOwnership
+  )
+
+  foreach ($path in $Paths) {
+    $item = Get-Item -LiteralPath $path -Force
+    if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+      throw "Refusing to execute through reparse-point path: $path"
+    }
+    $acl = Get-Acl -LiteralPath $path
+    $ownerSid = $acl.GetOwner(
+      [Security.Principal.SecurityIdentifier]
+    ).Value
+    if ($ownerSid -notin $trustedWriteSids) {
+      throw "Refusing to execute through path owned by an untrusted principal: $path"
+    }
+    foreach ($accessRule in @($acl.Access)) {
+      if (
+        $accessRule.AccessControlType -ne
+          [Security.AccessControl.AccessControlType]::Allow -or
+        (
+          $accessRule.PropagationFlags -band
+          [Security.AccessControl.PropagationFlags]::InheritOnly
+        ) -ne 0 -or
+        ($accessRule.FileSystemRights -band $writeMask) -eq 0
+      ) {
+        continue
+      }
+      $ruleSid = $accessRule.IdentityReference.Translate(
+        [Security.Principal.SecurityIdentifier]
+      ).Value
+      if ($ruleSid -notin $trustedWriteSids) {
+        throw "Refusing to execute through path writable by an untrusted principal: $path"
+      }
+    }
+  }
+}
+
+function Get-LocalDirectoryChain {
+  param([string]$Path)
+
+  $fullPath = [IO.Path]::GetFullPath($Path)
+  $root = [IO.Path]::GetPathRoot($fullPath)
+  if (
+    [string]::IsNullOrWhiteSpace($root) -or
+    -not [regex]::IsMatch($root, '^[A-Za-z]:\\$')
+  ) {
+    throw "KB1_HOME must be an absolute path on a local Windows drive."
+  }
+  $relativePath = $fullPath.Substring($root.Length)
+  $components = @(
+    $relativePath -split '[\\/]' |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+
+  $chain = @($root)
+  $current = $root
+  foreach ($component in $components) {
+    $current = Join-Path $current $component
+    $chain += $current
+  }
+  return $chain
+}
+
+function Assert-NoUntrustedReplaceAccess {
+  param([string[]]$Paths)
+
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $trustedWriteSids = @(
+    [string]$identity.User.Value,
+    "S-1-5-18",
+    "S-1-5-32-544",
+    "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464"
+  )
+  $replaceMask = (
+    [Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+    [Security.AccessControl.FileSystemRights]::Delete -bor
+    [Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+    [Security.AccessControl.FileSystemRights]::TakeOwnership
+  )
+
+  foreach ($path in $Paths) {
+    $item = Get-Item -LiteralPath $path -Force
+    if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+      throw "Refusing to trust reparse-point path: $path"
+    }
+    $acl = Get-Acl -LiteralPath $path
+    $ownerSid = $acl.GetOwner(
+      [Security.Principal.SecurityIdentifier]
+    ).Value
+    if ($ownerSid -notin $trustedWriteSids) {
+      throw "Refusing to trust KB1_HOME beneath a directory owned by an untrusted principal: $path"
+    }
+    foreach ($accessRule in @($acl.Access)) {
+      if (
+        $accessRule.AccessControlType -ne
+          [Security.AccessControl.AccessControlType]::Allow -or
+        (
+          $accessRule.PropagationFlags -band
+          [Security.AccessControl.PropagationFlags]::InheritOnly
+        ) -ne 0 -or
+        ($accessRule.FileSystemRights -band $replaceMask) -eq 0
+      ) {
+        continue
+      }
+      $ruleSid = $accessRule.IdentityReference.Translate(
+        [Security.Principal.SecurityIdentifier]
+      ).Value
+      if ($ruleSid -notin $trustedWriteSids) {
+        throw "Refusing to trust KB1_HOME beneath a replaceable directory: $path"
+      }
+    }
+  }
+}
+
+function Assert-TrustedKB1Home {
+  param([string]$Path)
+
+  $chain = @(Get-LocalDirectoryChain $Path)
+  for ($index = 0; $index -lt $chain.Count; $index++) {
+    $candidate = [string]$chain[$index]
+    if (-not (Test-Path -LiteralPath $candidate -PathType Container)) {
+      throw "KB1_HOME path component is missing or is not a directory: $candidate"
+    }
+    if ($index -eq ($chain.Count - 1)) {
+      Assert-NoUntrustedWriteAccess -Paths @($candidate)
+    } else {
+      Assert-NoUntrustedReplaceAccess -Paths @($candidate)
+    }
+  }
+  $pendingDirectories = [Collections.Generic.Queue[string]]::new()
+  $pendingDirectories.Enqueue([IO.Path]::GetFullPath($Path))
+  while ($pendingDirectories.Count -gt 0) {
+    $directory = $pendingDirectories.Dequeue()
+    foreach ($item in @(
+      Get-ChildItem -LiteralPath $directory -Force -ErrorAction Stop
+    )) {
+      if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "KB1_HOME contains a reparse point that could redirect vault access: $($item.FullName)"
+      }
+      if ($item.PSIsContainer) {
+        Assert-NoUntrustedWriteAccess -Paths @($item.FullName)
+        $pendingDirectories.Enqueue([string]$item.FullName)
+      }
+    }
+  }
+  $resolved = [IO.Path]::GetFullPath(
+    (Resolve-Path -LiteralPath $Path -ErrorAction Stop).Path
+  )
+  if (-not (Test-EquivalentPath $Path $resolved)) {
+    throw "KB1_HOME did not resolve to its configured canonical path."
+  }
+}
+
+function Assert-TrustedPathChain {
+  param(
+    [string]$Path,
+    [switch]$Directory
+  )
+
+  $fullPath = [IO.Path]::GetFullPath($Path)
+  $trustedDirectory = if ($Directory) {
+    $fullPath
+  } else {
+    Split-Path -Parent $fullPath
+  }
+  $chain = @(Get-LocalDirectoryChain $trustedDirectory)
+  if ($chain.Count -gt 1) {
+    Assert-NoUntrustedReplaceAccess -Paths @(
+      $chain[0..($chain.Count - 2)]
+    )
+  }
+  Assert-NoUntrustedWriteAccess -Paths @($trustedDirectory)
+  if (-not $Directory) {
+    Assert-NoUntrustedWriteAccess -Paths @($fullPath)
+  }
+}
+
+$localAppData = [Environment]::GetFolderPath(
+  [Environment+SpecialFolder]::LocalApplicationData
+)
+$appStateRoot = Join-Path $localAppData "KB-1"
+$expectedTaskStateRoot = Join-Path $appStateRoot "tasks"
+if (
+  -not (Test-EquivalentPath (Split-Path -Parent $ConfigPath) $expectedTaskStateRoot)
+) {
+  throw "KB-1 task configuration is outside the per-user task-state root."
+}
+Assert-NoUntrustedWriteAccess -Paths @(
+  $localAppData,
+  $appStateRoot,
+  $expectedTaskStateRoot,
+  $ConfigPath
+)
+Assert-TrustedPathChain -Path $localAppData -Directory
+
+$config = Get-Content -LiteralPath $ConfigPath -Raw | ConvertFrom-Json
+foreach ($property in @(
+  "kind",
+  "taskName",
+  "ownerSid",
+  "nodePath",
+  "repoDir",
+  "entrypoint",
+  "taskStateRoot",
+  "kb1Home",
+  "bindHost",
+  "port",
+  "logPath",
+  "stdoutPath",
+  "stderrPath",
+  "runtimeStatePath",
+  "controlToken"
+)) {
+  if ([string]::IsNullOrWhiteSpace([string]$config.$property)) {
+    throw "KB-1 task config is missing required property: $property"
+  }
+}
+if ([string]$config.kind -ne "kb1-windows-user-task") {
+  throw "KB-1 task config has an invalid ownership signature."
+}
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+if ([string]$config.ownerSid -ne [string]$identity.User.Value) {
+  throw "KB-1 task config belongs to a different Windows user."
+}
+if (-not (Test-EquivalentPath ([string]$config.taskStateRoot) $expectedTaskStateRoot)) {
+  throw "KB-1 task config names an unexpected task-state root."
+}
+$expectedRuntimeRoot = Join-Path `
+  $expectedTaskStateRoot `
+  "windows-runtimes\$(Get-TaskStorageKey ([string]$config.taskName))"
+if (-not (Test-PathAtOrWithin ([string]$config.repoDir) $expectedRuntimeRoot)) {
+  throw "KB-1 task repository is outside its protected per-user runtime root."
+}
+Assert-TrustedKB1Home -Path ([string]$config.kb1Home)
+Assert-TrustedPathChain -Path ([string]$config.nodePath)
+Assert-TrustedPathChain -Path ([string]$config.repoDir) -Directory
+
+$expectedRunner = Join-Path `
+  ([string]$config.repoDir) `
+  "skills\kb-1-daemon-setup\scripts\run_kb1_daemon_user_task.ps1"
+$expectedEntrypoint = Join-Path `
+  ([string]$config.repoDir) `
+  "apps\daemon\dist\main.js"
+if (
+  -not (Test-EquivalentPath $PSCommandPath $expectedRunner) -or
+  -not (Test-EquivalentPath ([string]$config.entrypoint) $expectedEntrypoint)
+) {
+  throw "KB-1 task code paths do not match the configured repository."
+}
+foreach ($statePath in @(
+  [string]$config.logPath,
+  [string]$config.stdoutPath,
+  [string]$config.stderrPath,
+  [string]$config.runtimeStatePath
+)) {
+  if (
+    -not (Test-EquivalentPath (Split-Path -Parent $statePath) $expectedTaskStateRoot)
+  ) {
+    throw "KB-1 task state path is outside the per-user task-state root."
+  }
+}
+
+$codePaths = @(
+  [string]$config.nodePath,
+  (Split-Path -Parent ([string]$config.nodePath)),
+  $expectedRuntimeRoot,
+  (Split-Path -Parent ([string]$config.repoDir)),
+  [string]$config.repoDir,
+  [string]$config.entrypoint,
+  $PSCommandPath
+)
+$repoAclRoot = [IO.Path]::GetFullPath([string]$config.repoDir).TrimEnd("\")
+foreach ($codeFile in @([string]$config.entrypoint, $PSCommandPath)) {
+  $parentPath = Split-Path -Parent $codeFile
+  while (
+    [string]::Equals(
+      $parentPath,
+      $repoAclRoot,
+      [StringComparison]::OrdinalIgnoreCase
+    ) -or
+    $parentPath.StartsWith(
+      "$repoAclRoot\",
+      [StringComparison]::OrdinalIgnoreCase
+    )
+  ) {
+    $codePaths += $parentPath
+    if ([string]::Equals(
+      $parentPath,
+      $repoAclRoot,
+      [StringComparison]::OrdinalIgnoreCase
+    )) {
+      break
+    }
+    $parentPath = Split-Path -Parent $parentPath
+  }
+}
+Assert-NoUntrustedWriteAccess -Paths @($codePaths | Select-Object -Unique)
+
+$logPath = [string]$config.logPath
+$logDirectory = Split-Path -Parent $logPath
+New-Item -ItemType Directory -Path $logDirectory -Force | Out-Null
+
+$env:NODE_ENV = "production"
+$env:NODE_OPTIONS = $null
+$env:NODE_PATH = $null
+$env:KB1_HOME = [string]$config.kb1Home
+$env:KB1_HOST = [string]$config.bindHost
+$env:KB1_PORT = [string]$config.port
+$env:KB1_CONTROL_TOKEN = [string]$config.controlToken
+$env:KB1_INSTANCE_ID = [Guid]::NewGuid().ToString("N")
+Set-Location -LiteralPath ([string]$config.repoDir)
+
+"[$([DateTimeOffset]::Now.ToString("o"))] Starting KB-1 Local" |
+  Out-File -LiteralPath $logPath -Append -Encoding utf8
+
+Remove-Item `
+  -LiteralPath ([string]$config.runtimeStatePath) `
+  -Force `
+  -ErrorAction SilentlyContinue
+
+$nodeArguments = '"{0}"' -f ([string]$config.entrypoint).Replace('"', '\"')
+$daemonProcess = $null
+$daemonExitCode = $null
+try {
+  $daemonProcess = Start-Process `
+    -FilePath ([string]$config.nodePath) `
+    -ArgumentList $nodeArguments `
+    -WorkingDirectory ([string]$config.repoDir) `
+    -NoNewWindow `
+    -PassThru `
+    -RedirectStandardOutput ([string]$config.stdoutPath) `
+    -RedirectStandardError ([string]$config.stderrPath)
+
+  $runtimeState = [ordered]@{
+    version = 1
+    runnerPid = $PID
+    daemonPid = $daemonProcess.Id
+    daemonStartTimeFileTimeUtc = [string]$daemonProcess.StartTime.ToFileTimeUtc()
+    instanceId = $env:KB1_INSTANCE_ID
+    startedAt = [DateTimeOffset]::Now.ToString("o")
+  }
+  $runtimeState | ConvertTo-Json |
+    Set-Content -LiteralPath ([string]$config.runtimeStatePath) -Encoding utf8
+
+  $daemonProcess.WaitForExit()
+  $daemonExitCode = $daemonProcess.ExitCode
+} finally {
+  if ($null -ne $daemonProcess -and -not $daemonProcess.HasExited) {
+    $daemonProcess.Kill()
+    if (-not $daemonProcess.WaitForExit(5000)) {
+      throw "The detached KB-1 daemon did not exit after its runner failed."
+    }
+  }
+  Remove-Item `
+    -LiteralPath ([string]$config.runtimeStatePath) `
+    -Force `
+    -ErrorAction SilentlyContinue
+}
+
+"[$([DateTimeOffset]::Now.ToString("o"))] KB-1 Local exited with code $daemonExitCode" |
+  Out-File -LiteralPath $logPath -Append -Encoding utf8
+
+exit $daemonExitCode


### PR DESCRIPTION
## Summary

- add a per-user Windows Scheduled Task lifecycle for install, start, stop, status, upgrade, rollback, and uninstall
- stage exact-commit runtimes transactionally and protect `KB1_HOME`, executable ancestry, ACLs, junctions, and cross-session operations
- make process termination and vault trash behavior portable on Windows
- add authenticated graceful daemon shutdown that rejects new work and drains admitted HTTP, MCP, WebSocket, and document activity
- add Windows CI smoke coverage and update setup, packaging, release, and README guidance

## Why

The merged Windows-support replacement established the portability baseline and preserved the original contributor's commits. This follow-up closes the remaining lifecycle, upgrade-safety, shutdown-drain, and Windows trust-boundary gaps needed for dependable source-based Windows operation.

## Validation

- `pnpm check`
- `pnpm --filter @kb-1/local-mcp test` — 8 tests passed, 96.6% line coverage
- `git diff --check`
- structured autoreview at high reasoning — no actionable findings

## Windows verification gate

The native PowerShell Scheduled Task smoke test is wired into the `windows-latest` GitHub Actions job and must pass before merge. It could not be executed on the macOS development host.

## Scope note

This provides source-based Windows support. A signed MSI/MSIX and a Windows Service Control Manager integration remain separate future packaging work.
