### PR TITLE
fix: harden relay control liveness and upgrade auth

### DIFF
--- a/apps/daemon/src/ui-static.ts
+++ b/apps/daemon/src/ui-static.ts
@@ -31,7 +31,7 @@ export async function serveUi(webBuildDir: string, pathname: string): Promise<Re
 
   const body = await readFile(filePath);
 
-  return new Response(body, {
+  return new Response(new Uint8Array(body), {
     headers: {
       'content-type': contentTypeFor(filePath)
     }

--- a/packages/tunnel-client/src/heartbeat.test.ts
+++ b/packages/tunnel-client/src/heartbeat.test.ts
@@ -9,7 +9,10 @@ class MockWebSocket extends EventEmitter {
   readonly sent: unknown[] = [];
   terminated = false;
 
-  constructor(readonly url: URL) {
+  constructor(
+    readonly url: URL,
+    readonly options?: { headers?: Record<string, string> },
+  ) {
     super();
     MockWebSocket.instances.push(this);
   }
@@ -57,10 +60,11 @@ describe('TunnelClient control heartbeat', () => {
     vi.restoreAllMocks();
   });
 
-  it('terminates a missed-pong control socket to trip the existing reconnect path', async () => {
+  it('tolerates one missed pong, resets on recovery, and reconnects after consecutive misses', async () => {
     const {
       CONTROL_DURABLE_LIVENESS_INTERVAL_MS,
       CONTROL_HEARTBEAT_INTERVAL_MS,
+      CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT,
       CONTROL_HEARTBEAT_TIMEOUT_MS,
       TunnelClient,
     } = await import('./index.js');
@@ -75,6 +79,9 @@ describe('TunnelClient control heartbeat', () => {
 
     client.start();
     const firstControl = MockWebSocket.instances[0];
+    expect(firstControl.options?.headers).toEqual({
+      authorization: 'Bearer token-1',
+    });
     firstControl.open();
 
     expect(sentText(firstControl, 0)).toBe(encodeTunnelMessage({
@@ -89,23 +96,84 @@ describe('TunnelClient control heartbeat', () => {
     expect(typeof firstControl.sent[1]).toBe('string');
     expect(firstControl.sent).toHaveLength(2);
 
-    firstControl.message(encodeTunnelMessage({ type: 'control.pong' }));
     await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_TIMEOUT_MS);
     expect(firstControl.terminated).toBe(false);
+    expect(logger.log).toHaveBeenCalledWith(
+      'warn',
+      'relay control heartbeat missed; waiting for next probe',
+      {
+        consecutiveMisses: 1,
+        reconnectAfterMisses: CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT,
+      },
+    );
 
-    await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(
+      CONTROL_HEARTBEAT_INTERVAL_MS - CONTROL_HEARTBEAT_TIMEOUT_MS,
+    );
     expect(CONTROL_DURABLE_LIVENESS_INTERVAL_MS).toBe(2 * CONTROL_HEARTBEAT_INTERVAL_MS);
     expect(sentText(firstControl, 2)).toBe(encodeTunnelMessage({ type: 'control.ping' }));
     expect(typeof firstControl.sent[2]).toBe('string');
     expect(Buffer.isBuffer(firstControl.sent[3])).toBe(true);
     expect(sentText(firstControl, 3)).toBe(encodeTunnelMessage({ type: 'control.ping' }));
 
+    firstControl.message(encodeTunnelMessage({ type: 'control.pong' }));
+    await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_TIMEOUT_MS);
+    expect(firstControl.terminated).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(
+      CONTROL_HEARTBEAT_INTERVAL_MS - CONTROL_HEARTBEAT_TIMEOUT_MS,
+    );
+    expect(sentText(firstControl, 4)).toBe(encodeTunnelMessage({ type: 'control.ping' }));
+
+    await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_TIMEOUT_MS);
+    expect(firstControl.terminated).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(
+      CONTROL_HEARTBEAT_INTERVAL_MS - CONTROL_HEARTBEAT_TIMEOUT_MS,
+    );
+    expect(sentText(firstControl, 5)).toBe(encodeTunnelMessage({ type: 'control.ping' }));
+    expect(Buffer.isBuffer(firstControl.sent[6])).toBe(true);
+
     await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_TIMEOUT_MS);
     expect(firstControl.terminated).toBe(true);
-    expect(logger.log).toHaveBeenCalledWith('warn', 'relay control heartbeat missed; terminating socket to reconnect');
+    expect(logger.log).toHaveBeenCalledWith(
+      'warn',
+      'relay control heartbeat missed; terminating socket to reconnect',
+      {
+        consecutiveMisses: CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT,
+        reconnectAfterMisses: CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT,
+      },
+    );
 
     await vi.advanceTimersByTimeAsync(250);
     expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it('logs the relay close reason before scheduling reconnect', async () => {
+    const { TunnelClient } = await import('./index.js');
+    const logger = { log: vi.fn() };
+    const client = new TunnelClient({
+      relayUrl: new URL('http://relay.example/t/dev1'),
+      daemonUrl: new URL('http://127.0.0.1:9891'),
+      token: 'token-1',
+      logger,
+      random: () => 0,
+    });
+
+    client.start();
+    const control = MockWebSocket.instances[0];
+    control.open();
+    control.close(4005, 'Tunnel handshake timed out');
+
+    expect(logger.log).toHaveBeenCalledWith(
+      'warn',
+      'relay control closed; reconnect scheduled',
+      {
+        code: 4005,
+        reason: 'Tunnel handshake timed out',
+        delayMs: 250,
+      },
+    );
   });
 
   it('advertises optional daemon version metadata on control hello', async () => {

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -102,9 +102,12 @@ describe('tunnel-client helpers', () => {
   });
 
   it('normalizes gzipped materialized response bodies before serializing them over the tunnel', async () => {
-    const body = await materializedResponseBody(new Response(gzipSync(Buffer.from('{"ok":true}')), {
+    const body = await materializedResponseBody(new Response(
+      new Uint8Array(gzipSync(Buffer.from('{"ok":true}'))),
+      {
       headers: { 'content-encoding': 'gzip' },
-    }));
+      },
+    ));
 
     expect(body.toString('utf8')).toBe('{"ok":true}');
   });

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -71,7 +71,8 @@ const DEFAULT_BACKOFF_BASE_MS = 250;
 const DEFAULT_BACKOFF_MAX_MS = 10_000;
 const DEFAULT_BACKOFF_JITTER_RATIO = 0.25;
 export const CONTROL_HEARTBEAT_INTERVAL_MS = 15_000;
-export const CONTROL_HEARTBEAT_TIMEOUT_MS = 5_000;
+export const CONTROL_HEARTBEAT_TIMEOUT_MS = 12_000;
+export const CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT = 2;
 export const CONTROL_DURABLE_LIVENESS_INTERVAL_MS = 30_000;
 
 const hopByHopHeaders = new Set([
@@ -105,6 +106,7 @@ export class TunnelClient {
   private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
   private controlHeartbeatInterval: ReturnType<typeof setInterval> | undefined;
   private controlHeartbeatDeadline: ReturnType<typeof setTimeout> | undefined;
+  private controlHeartbeatMisses = 0;
   private readonly httpAssembler = new ChunkedHttpRequestAssembler();
   private readonly pendingHttpRequests = new Map<string, PendingDaemonHttpRequest>();
   private stopped = true;
@@ -181,7 +183,9 @@ export class TunnelClient {
     // Coordinated relay wire paths: keep `/__kb1_tunnel/*` stable until the
     // cloud relay and all clients migrate together.
     const controlUrl = relayInternalUrl(this.config.relayUrl, '/__kb1_tunnel/control');
-    const control = new WebSocket(controlUrl);
+    const control = new WebSocket(controlUrl, {
+      headers: { authorization: `Bearer ${this.config.token}` },
+    });
     this.control = control;
 
     control.on('open', () => {
@@ -206,7 +210,7 @@ export class TunnelClient {
       });
     });
 
-    control.on('close', (code) => {
+    control.on('close', (code, reason) => {
       if (this.control === control) {
         this.control = undefined;
         this.clearControlHeartbeat();
@@ -223,7 +227,11 @@ export class TunnelClient {
 
       const delayMs = createBackoffDelay(this.reconnectAttempt, {}, this.random);
       this.reconnectAttempt += 1;
-      this.logger.log('warn', 'relay control closed; reconnect scheduled', { code, delayMs });
+      this.logger.log('warn', 'relay control closed; reconnect scheduled', {
+        code,
+        reason: reason.toString(),
+        delayMs,
+      });
       this.reconnectTimer = setTimeout(() => {
         this.reconnectTimer = undefined;
         this.connectControl();
@@ -248,6 +256,7 @@ export class TunnelClient {
         return;
       case 'control.pong':
         this.clearControlHeartbeatDeadline();
+        this.controlHeartbeatMisses = 0;
         return;
       case 'control.error':
         this.logger.log('error', 'relay control rejected message', {
@@ -345,6 +354,7 @@ export class TunnelClient {
 
   private startControlHeartbeat(control: WebSocket): void {
     this.clearControlHeartbeat();
+    this.controlHeartbeatMisses = 0;
     let durableLivenessElapsedMs = 0;
     this.controlHeartbeatInterval = setInterval(() => {
       if (this.control !== control || this.stopped || control.readyState !== WebSocket.OPEN) {
@@ -365,7 +375,20 @@ export class TunnelClient {
       this.controlHeartbeatDeadline = setTimeout(() => {
         if (this.control !== control || this.stopped) return;
 
-        this.logger.log('warn', 'relay control heartbeat missed; terminating socket to reconnect');
+        this.controlHeartbeatDeadline = undefined;
+        this.controlHeartbeatMisses += 1;
+        if (this.controlHeartbeatMisses < CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT) {
+          this.logger.log('warn', 'relay control heartbeat missed; waiting for next probe', {
+            consecutiveMisses: this.controlHeartbeatMisses,
+            reconnectAfterMisses: CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT,
+          });
+          return;
+        }
+
+        this.logger.log('warn', 'relay control heartbeat missed; terminating socket to reconnect', {
+          consecutiveMisses: this.controlHeartbeatMisses,
+          reconnectAfterMisses: CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT,
+        });
         control.terminate();
       }, CONTROL_HEARTBEAT_TIMEOUT_MS);
     }, CONTROL_HEARTBEAT_INTERVAL_MS);
@@ -377,6 +400,7 @@ export class TunnelClient {
       this.controlHeartbeatInterval = undefined;
     }
     this.clearControlHeartbeatDeadline();
+    this.controlHeartbeatMisses = 0;
   }
 
   private clearControlHeartbeatDeadline(): void {
@@ -488,7 +512,9 @@ export class TunnelClient {
     const daemonWsUrl = new URL(envelope.path, this.config.daemonUrl);
     daemonWsUrl.protocol = daemonWsUrl.protocol === 'https:' ? 'wss:' : 'ws:';
 
-    const relaySocket = new WebSocket(dialbackUrl);
+    const relaySocket = new WebSocket(dialbackUrl, {
+      headers: { authorization: `Bearer ${this.config.token}` },
+    });
     const daemonSocket = new WebSocket(daemonWsUrl, {
       headers: withoutHopByHop(envelope.headers),
     });


### PR DESCRIPTION
## What changed

- Send `Authorization: Bearer <token>` during both control and dialback WebSocket upgrades while retaining the in-band hello authentication check.
- Extend the heartbeat response window from 5 seconds to 12 seconds.
- Tolerate one missed pong and reconnect only after two consecutive misses.
- Reset the missed-heartbeat count after recovery and log WebSocket close codes and reasons.
- Add regression coverage for delayed/missed heartbeats, recovery, reconnect, upgrade headers, and close diagnostics.
- Normalize Node buffers to `Uint8Array` at the Fetch `BodyInit` boundaries used by the test/runtime toolchain.

## Why

Production relay control connections could flap during ordinary latency: a single delayed pong caused the daemon to terminate a healthy socket, and control/dialback upgrades did not carry credentials until the first application frame. That contributed to `1012: No workspace control channel connected` errors, slow vault loading, and unreliable document opening.

## Impact

The daemon is more tolerant of transient scheduling/network delays and supplies upgrade-time proof required by the coordinated Cloud hardening PR. This PR must be merged and rolled into the managed-daemon fleet before the Cloud enforcement PR is merged or deployed.

## Verification

- `pnpm check`
- Focused tunnel-client heartbeat and upgrade-auth tests
- Structured autoreview: clean
- Paired with the dependent Cloud diff in the full Docker/browser E2E suite: 25 passed, 1 intentionally skipped, including relay vault opening, bidirectional edits, reload/disk persistence, reconnect recovery, file-tree synchronization, CRDT merging, and daemon/cloud convergence
