### PR TITLE
perf: add bounded one-hop MCP relay calls

### DIFF
--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -835,6 +835,53 @@ describe('daemon multi-vault MCP surface', () => {
     expect(listVaults?.inputSchema.properties ?? {}).not.toHaveProperty('vaultId');
   });
 
+  it('preserves the authenticated relay actor on production MCP mutations', async () => {
+    const actor = {
+      kind: 'integration',
+      id: 'relay-integration-1',
+      name: 'Cloud relay',
+      client: 'kb-1-cloud'
+    } as const;
+    const attributedTransport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp`),
+      {
+        requestInit: {
+          headers: {
+            'x-kb1-actor': JSON.stringify(actor)
+          }
+        }
+      }
+    );
+    const attributedClient = new Client({
+      name: 'caller-controlled-client-name',
+      version: '1.0.0'
+    });
+
+    try {
+      await attributedClient.connect(attributedTransport);
+      await expect(mcpToolJson(attributedClient, 'create_note', {
+        vaultId: 'demo-vault',
+        path: 'attributed.md',
+        content: 'attributed\n'
+      })).resolves.toMatchObject({ ok: true, path: 'attributed.md' });
+    } finally {
+      await attributedTransport.terminateSession().catch(() => undefined);
+    }
+
+    const auditText = await readFile(
+      join(kb1Home, 'vaults', 'demo-vault', '.kb1', 'audit', 'changes.jsonl'),
+      'utf8'
+    );
+    const rows = auditText.trim().split('\n').map((line) => JSON.parse(line) as {
+      actor?: unknown;
+      path?: string;
+    });
+    expect(rows.at(-1)).toMatchObject({
+      actor,
+      path: 'attributed.md'
+    });
+  });
+
   it('rejects a data-tool call that omits vaultId (no default vault)', async () => {
     const missing = await client.callTool({ name: 'create_note', arguments: { path: 'nope.md', content: 'x\n' } });
     expect(missing.isError).toBe(true);

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -98,7 +98,14 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Sta
   // One MCP endpoint, every vault: vaultId resolution and vault enumeration both
   // go through the SAME live registry the HTTP layer uses — no second vault map.
   // Every data tool requires a vaultId; there is no default vault.
-  const mcpEndpoint = createLocalMcpEndpoint(mcpVaultProvider(registry));
+  const mcpEndpoint = createLocalMcpEndpoint(mcpVaultProvider(registry), {
+    actorFromRequest: (request) => {
+      const parsed = actorFromHeaders(
+        request.headers.get(ACTOR_HEADER) ?? undefined
+      );
+      return parsed.ok ? parsed.actor : parsed;
+    }
+  });
   const relay = createRelayLifecycleController(config, registry);
   const shutdownSignal = new AbortController();
   let closeDaemon: (() => Promise<void>) | undefined;

--- a/packages/local-mcp/src/server.test.ts
+++ b/packages/local-mcp/src/server.test.ts
@@ -51,6 +51,40 @@ describe("local MCP server", () => {
     await endpoint.close();
   });
 
+  it("rejects an initialization actor that the endpoint cannot authorize", async () => {
+    const endpoint = createLocalMcpEndpoint(emptyService(), {
+      actorFromRequest: () => ({
+        ok: false,
+        error: "invalid_actor",
+        message: "actor attribution rejected",
+      }),
+    });
+    const response = await endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: { name: "rejected-actor", version: "1.0.0" },
+          },
+        }),
+      }),
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { message: "Bad Request: actor attribution rejected" },
+    });
+    await endpoint.close();
+  });
+
   it("waits for an accepted initialization request before closing sessions", async () => {
     const endpoint = createLocalMcpEndpoint(emptyService());
     const request = new Request("http://127.0.0.1/mcp", {
@@ -244,8 +278,11 @@ describe("local MCP server", () => {
       readRawFile: async (input: ServiceInput<"readRawFile">) => ({
         ok: true,
         path: input.path,
-        filePath: fixturePath,
-        size: 8,
+        filePath:
+          input.path === "assets/huge.bin"
+            ? "/this-file-must-not-be-read"
+            : fixturePath,
+        size: input.path === "assets/huge.bin" ? 1024 * 1024 + 1 : 8,
         mtimeMs: 2,
         artifact: {
           kind: "attachment",
@@ -455,6 +492,20 @@ describe("local MCP server", () => {
         path: "assets/pixel.png",
       }),
     ).toMatchObject({ ok: true, path: "assets/pixel.png", preview: "image" });
+    const oversizedAttachment = await client.callTool({
+      name: "read_attachment",
+      arguments: {
+        vaultId: V,
+        path: "assets/huge.bin",
+      },
+    });
+    expect(oversizedAttachment.isError).toBe(true);
+    expect(textContent(oversizedAttachment)).toContain(
+      '"error":"too_large"',
+    );
+    expect(textContent(oversizedAttachment)).toContain(
+      '"maxBytes":1048576',
+    );
     expect(
       await toolJson(client, "upload_attachment", {
         vaultId: V,
@@ -624,6 +675,276 @@ describe("local MCP server", () => {
     expect(mutationActors).toEqual([actor]);
 
     await transport.terminateSession();
+    await endpoint.close();
+  });
+
+  it("expires an abandoned MCP initialization after its handshake budget", async () => {
+    const endpoint = createLocalMcpEndpoint(emptyService(), {
+      sessionInitializationTimeoutMs: 10,
+      sessionIdleTimeoutMs: 1_000,
+    });
+    const initialized = await endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: {
+              name: "abandoned-initialize-test-client",
+              version: "1.0.0",
+            },
+          },
+        }),
+      }),
+    );
+    const sessionId = initialized.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+
+    const malformedFollowUp = await endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+          "mcp-session-id": sessionId!,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "unsupported/method",
+        }),
+      }),
+    );
+    await malformedFollowUp.text();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const expired = await endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+          "mcp-session-id": sessionId!,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 99,
+          method: "tools/list",
+        }),
+      }),
+    );
+    expect(expired.status).toBe(400);
+    await expired.text();
+    await initialized.body
+      ?.cancel("initialize response abandoned")
+      .catch(() => undefined);
+
+    await endpoint.close();
+  });
+
+  it("recognizes an initialized notification inside a JSON-RPC batch", async () => {
+    const endpoint = createLocalMcpEndpoint(emptyService(), {
+      sessionInitializationTimeoutMs: 10,
+      sessionIdleTimeoutMs: 1_000,
+    });
+    const initialized = await endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: {
+              name: "batch-initialize-test-client",
+              version: "1.0.0",
+            },
+          },
+        }),
+      }),
+    );
+    const sessionId = initialized.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+    await initialized.text();
+
+    const acknowledged = await endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+          "mcp-session-id": sessionId!,
+        },
+        body: JSON.stringify([{
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        }]),
+      }),
+    );
+    expect(acknowledged.status).toBe(202);
+    await acknowledged.text();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const stillActive = await endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+          "mcp-session-id": sessionId!,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/list",
+        }),
+      }),
+    );
+    expect(stillActive.status).toBe(200);
+    await stillActive.text();
+    await endpoint.close();
+  });
+
+  it("claims an existing session before parsing a slow request body", async () => {
+    const endpoint = createLocalMcpEndpoint(emptyService(), {
+      sessionInitializationTimeoutMs: 1_000,
+      sessionIdleTimeoutMs: 10,
+    });
+    let sessionId: string | null = null;
+    const client = new Client({
+      name: "slow-body-test-client",
+      version: "1.0.0",
+    });
+    const transport = new StreamableHTTPClientTransport(
+      new URL("http://127.0.0.1/mcp"),
+      {
+        fetch: async (input, init) => {
+          const response = await endpoint.handleRequest(
+            input instanceof Request ? input : new Request(input, init),
+          );
+          sessionId ??= response.headers.get("mcp-session-id");
+          return response;
+        },
+      },
+    );
+    await client.connect(transport);
+    expect(sessionId).toBeTruthy();
+
+    let releaseBody: (() => void) | undefined;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        releaseBody = () => {
+          controller.enqueue(
+            new TextEncoder().encode(JSON.stringify({
+              jsonrpc: "2.0",
+              id: 2,
+              method: "tools/list",
+            })),
+          );
+          controller.close();
+        };
+      },
+    });
+    const slowRequest = endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+          "mcp-session-id": sessionId!,
+        },
+        body,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    releaseBody?.();
+
+    const response = await within(slowRequest, "slow request did not finish");
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('"id":2');
+    await endpoint.close();
+  });
+
+  it("expires a completed MCP session after its idle budget", async () => {
+    const endpoint = createLocalMcpEndpoint(emptyService(), {
+      sessionInitializationTimeoutMs: 1_000,
+      sessionIdleTimeoutMs: 10,
+    });
+    const initialized = await endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            clientInfo: {
+              name: "idle-expiry-test-client",
+              version: "1.0.0",
+            },
+          },
+        }),
+      }),
+    );
+    const sessionId = initialized.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+    await initialized.text();
+
+    const acknowledged = await endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+          "mcp-session-id": sessionId!,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "notifications/initialized",
+        }),
+      }),
+    );
+    expect(acknowledged.status).toBe(202);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const expired = await endpoint.handleRequest(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          accept: "application/json, text/event-stream",
+          "content-type": "application/json",
+          "mcp-session-id": sessionId!,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 99,
+          method: "tools/list",
+        }),
+      }),
+    );
+    expect(expired.status).toBe(400);
+    await expired.text();
     await endpoint.close();
   });
 

--- a/packages/local-mcp/src/server.ts
+++ b/packages/local-mcp/src/server.ts
@@ -2,7 +2,10 @@ import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import {
+  isInitializeRequest,
+  isInitializedNotification,
+} from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod/v4";
 
 import type {
@@ -23,6 +26,9 @@ const unknownActor: LocalMcpActor = localAgentActor("unknown local caller");
 /** The single synthetic vault id used when the endpoint is built from a bare service. */
 const SINGLE_VAULT_ID = "default";
 const MAX_INLINE_ATTACHMENT_BYTES = 4 * 1024;
+const MAX_INLINE_ATTACHMENT_READ_BYTES = 1024 * 1024;
+const DEFAULT_SESSION_INITIALIZATION_TIMEOUT_MS = 30_000;
+const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 5 * 60_000;
 
 export interface LocalMcpEndpoint {
   handleRequest(request: Request): Promise<Response>;
@@ -33,6 +39,8 @@ interface LocalMcpEndpointOptions {
   actorFromRequest?: (
     request: Request,
   ) => LocalMcpActor | ServiceFailure | undefined;
+  sessionInitializationTimeoutMs?: number;
+  sessionIdleTimeoutMs?: number;
 }
 
 interface LocalMcpServerOptions {
@@ -45,6 +53,9 @@ type ToolOperationTracker = <T>(operation: () => Promise<T>) => Promise<T>;
 interface SessionRecord {
   server: McpServer;
   transport: WebStandardStreamableHTTPServerTransport;
+  activeRequests: number;
+  initializationTimer?: ReturnType<typeof setTimeout>;
+  idleTimer?: ReturnType<typeof setTimeout>;
 }
 
 /**
@@ -181,6 +192,12 @@ export function createLocalMcpEndpoint(
           await Promise.all([...activeOperations]);
           const records = [...sessions.values()];
           sessions.clear();
+          for (const record of records) {
+            if (record.initializationTimer) {
+              clearTimeout(record.initializationTimer);
+            }
+            if (record.idleTimer) clearTimeout(record.idleTimer);
+          }
           await Promise.all(records.map(({ server }) => server.close()));
         })();
       }
@@ -199,7 +216,26 @@ async function handleMcpRequest(
   const sessionId = request.headers.get("mcp-session-id") ?? undefined;
   const existing = sessionId ? sessions.get(sessionId) : undefined;
   if (existing) {
-    return existing.transport.handleRequest(request);
+    return trackSessionRequest(
+      sessions,
+      sessionId!,
+      existing,
+      async () => {
+        const parsedBody =
+          request.method === "POST"
+            ? await request
+                .clone()
+                .json()
+                .catch(() => undefined)
+            : undefined;
+        return {
+          response: await existing.transport.handleRequest(request),
+          isInitializationAcknowledgement:
+            containsInitializedNotification(parsedBody),
+        };
+      },
+      options.sessionIdleTimeoutMs ?? DEFAULT_SESSION_IDLE_TIMEOUT_MS,
+    );
   }
 
   const parsedBody =
@@ -232,16 +268,166 @@ async function handleMcpRequest(
 
   transport.onclose = () => {
     const id = transport.sessionId ?? assignedSessionId;
-    if (id) sessions.delete(id);
+    if (!id) return;
+    const record = sessions.get(id);
+    if (record?.transport !== transport) return;
+    if (record.initializationTimer) {
+      clearTimeout(record.initializationTimer);
+    }
+    if (record.idleTimer) clearTimeout(record.idleTimer);
+    sessions.delete(id);
   };
 
   await server.connect(transport);
-  const response = await transport.handleRequest(request, { parsedBody });
-  const id = transport.sessionId ?? assignedSessionId;
-  if (id) {
-    sessions.set(id, { server, transport });
+  let response: Response;
+  try {
+    response = await transport.handleRequest(request, { parsedBody });
+  } catch (error) {
+    await server.close().catch(() => undefined);
+    throw error;
   }
-  return response;
+  const id = transport.sessionId ?? assignedSessionId;
+  /* v8 ignore next 4 -- a successful initialize with our generator always assigns an id */
+  if (!id) {
+    await server.close().catch(() => undefined);
+    return response;
+  }
+  const record: SessionRecord = {
+    server,
+    transport,
+    activeRequests: 1,
+  };
+  sessions.set(id, record);
+  record.initializationTimer = setTimeout(() => {
+    if (sessions.get(id) !== record) return;
+    sessions.delete(id);
+    void record.server.close().catch(() => undefined);
+  }, options.sessionInitializationTimeoutMs ?? DEFAULT_SESSION_INITIALIZATION_TIMEOUT_MS);
+  record.initializationTimer.unref();
+  return finishSessionRequestWhenConsumed(
+    sessions,
+    id,
+    record,
+    response,
+    options.sessionIdleTimeoutMs ?? DEFAULT_SESSION_IDLE_TIMEOUT_MS,
+  );
+}
+
+async function trackSessionRequest(
+  sessions: Map<string, SessionRecord>,
+  sessionId: string,
+  record: SessionRecord,
+  request: () => Promise<{
+    response: Response;
+    isInitializationAcknowledgement: boolean;
+  }>,
+  idleTimeoutMs: number,
+): Promise<Response> {
+  if (record.idleTimer) {
+    clearTimeout(record.idleTimer);
+    record.idleTimer = undefined;
+  }
+  record.activeRequests += 1;
+  try {
+    const { response, isInitializationAcknowledgement } = await request();
+    if (
+      isInitializationAcknowledgement &&
+      response.ok &&
+      record.initializationTimer
+    ) {
+      clearTimeout(record.initializationTimer);
+      record.initializationTimer = undefined;
+    }
+    return finishSessionRequestWhenConsumed(
+      sessions,
+      sessionId,
+      record,
+      response,
+      idleTimeoutMs,
+    );
+  } catch (error) {
+    finishSessionRequest(sessions, sessionId, record, idleTimeoutMs);
+    throw error;
+  }
+}
+
+function containsInitializedNotification(parsedBody: unknown): boolean {
+  const messages = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
+  return messages.some((message) => isInitializedNotification(message));
+}
+
+function finishSessionRequestWhenConsumed(
+  sessions: Map<string, SessionRecord>,
+  sessionId: string,
+  record: SessionRecord,
+  response: Response,
+  idleTimeoutMs: number,
+): Response {
+  if (!response.body) {
+    finishSessionRequest(sessions, sessionId, record, idleTimeoutMs);
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  let finished = false;
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    finishSessionRequest(sessions, sessionId, record, idleTimeoutMs);
+  };
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          controller.close();
+          reader.releaseLock();
+          finish();
+          return;
+        }
+        controller.enqueue(chunk.value);
+      } catch (error) {
+        controller.error(error);
+        reader.releaseLock();
+        finish();
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        reader.releaseLock();
+        finish();
+      }
+    },
+  });
+  return new Response(body, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+function finishSessionRequest(
+  sessions: Map<string, SessionRecord>,
+  sessionId: string,
+  record: SessionRecord,
+  idleTimeoutMs: number,
+): void {
+  record.activeRequests = Math.max(0, record.activeRequests - 1);
+  if (sessions.get(sessionId) !== record || record.activeRequests > 0) return;
+
+  record.idleTimer = setTimeout(() => {
+    if (
+      sessions.get(sessionId) !== record ||
+      record.activeRequests > 0
+    ) {
+      return;
+    }
+    sessions.delete(sessionId);
+    void record.server.close().catch(() => undefined);
+  }, idleTimeoutMs);
+  record.idleTimer.unref();
 }
 
 export function createLocalMcpServer(
@@ -387,6 +573,16 @@ export function createLocalMcpServer(
           ok: false,
           error: "invalid_request",
           message: `"${input.path}" is an editable text document, not an attachment. Use read_note instead.`,
+        };
+      }
+      if (result.size > MAX_INLINE_ATTACHMENT_READ_BYTES) {
+        return {
+          ok: false,
+          error: "too_large",
+          message:
+            `"${input.path}" is too large for inline MCP attachment reads.`,
+          maxBytes: MAX_INLINE_ATTACHMENT_READ_BYTES,
+          size: result.size,
         };
       }
 

--- a/packages/tunnel-client/package.json
+++ b/packages/tunnel-client/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@kb-1/tunnel-protocol": "workspace:*",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "ws": "8.21.0"
   },
   "devDependencies": {

--- a/packages/tunnel-client/src/heartbeat.test.ts
+++ b/packages/tunnel-client/src/heartbeat.test.ts
@@ -88,7 +88,10 @@ describe('TunnelClient control heartbeat', () => {
       type: 'control.hello',
       version: 2,
       token: 'token-1',
-      features: [TUNNEL_FEATURES.RELAY_FRAMES_V1],
+      features: [
+        TUNNEL_FEATURES.RELAY_FRAMES_V1,
+        TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
+      ],
     }));
 
     await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_INTERVAL_MS);
@@ -197,7 +200,10 @@ describe('TunnelClient control heartbeat', () => {
       token: 'token-1',
       daemonVersion: '0.1.0',
       daemonBuild: 'registry.fly.io/kb1@sha256:abc123',
-      features: [TUNNEL_FEATURES.RELAY_FRAMES_V1],
+      features: [
+        TUNNEL_FEATURES.RELAY_FRAMES_V1,
+        TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
+      ],
     }));
   });
 

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -2,11 +2,14 @@ import { EventEmitter } from 'node:events';
 import { gzipSync } from 'node:zlib';
 import {
   RELAY_ERROR_CODES,
+  RELAY_PENDING_REQUEST_LIMIT,
   RELAY_TRANSPORT_PROTOCOL_VERSION,
   TUNNEL_CLOSE_CODES,
+  TUNNEL_FEATURES,
   TUNNEL_PENDING_STREAM_FRAME_LIMIT,
   TUNNEL_WS_FRAME_BYTE_LIMIT,
   encodeTunnelMessage,
+  type RelayFrame,
 } from '@kb-1/tunnel-protocol';
 import {
   ChunkedHttpRequestAssembler,
@@ -232,6 +235,609 @@ describe('TunnelClient typed relay RPC', () => {
     });
   });
 
+  it('handles mcp.tool.call in one relay RPC while preserving actor attribution', async () => {
+    const observedMethods: string[] = [];
+    const observedToolCalls: unknown[] = [];
+    let toolResultText = '{"ok":true}';
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      observedMethods.push(request.method);
+      expect(request.url).toBe('http://daemon.test/mcp');
+      expect(request.headers.get('x-kb1-actor')).toBe(JSON.stringify({
+        kind: 'integration',
+        id: 'integration-1',
+        name: 'Codex',
+        client: 'codex',
+      }));
+
+      if (request.method === 'GET') {
+        return new Response(null, { status: 405 });
+      }
+      if (request.method === 'DELETE') {
+        return new Response(null, { status: 200 });
+      }
+
+      const message = await request.json() as {
+        id?: string | number;
+        method?: string;
+        params?: { protocolVersion?: string };
+      };
+      if (message.method === 'initialize') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            protocolVersion: message.params?.protocolVersion,
+            capabilities: { tools: {} },
+            serverInfo: { name: 'kb-1-test-daemon', version: '0.0.0' },
+          },
+        }, {
+          headers: { 'mcp-session-id': 'session-1' },
+        });
+      }
+      if (message.method === 'notifications/initialized') {
+        return new Response(null, { status: 202 });
+      }
+      if (message.method === 'tools/call') {
+        observedToolCalls.push(message);
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            content: [{ type: 'text', text: toolResultText }],
+          },
+        });
+      }
+      throw new Error(`Unexpected MCP request: ${JSON.stringify(message)}`);
+    });
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+
+    const response = await (
+      client as unknown as {
+        handleRelayRpcRequest(request: {
+          type: 'rpc.request';
+          version: typeof RELAY_TRANSPORT_PROTOCOL_VERSION;
+          id: string;
+          capability: string;
+          deadlineMs?: number;
+          payload?: {
+            encoding: 'json';
+            value: Record<string, unknown>;
+          };
+          context?: Record<string, unknown>;
+        }): Promise<unknown>;
+      }
+    ).handleRelayRpcRequest({
+      type: 'rpc.request',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-mcp-1',
+      capability: 'mcp.tool.call',
+      deadlineMs: 1_000,
+      payload: {
+        encoding: 'json',
+        value: {
+          toolName: 'read_note',
+          arguments: { vaultId: 'ledger', path: 'README.md' },
+          clientName: 'codex',
+        },
+      },
+      context: {
+        actor: {
+          kind: 'integration',
+          id: 'integration-1',
+          name: 'Codex',
+          client: 'codex',
+        },
+      },
+    });
+
+    expect(response).toEqual({
+      type: 'rpc.response',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-mcp-1',
+      ok: true,
+      payload: {
+        encoding: 'json',
+        value: {
+          content: [{ type: 'text', text: '{"ok":true}' }],
+        },
+      },
+    });
+    expect(observedToolCalls).toHaveLength(1);
+    expect(observedMethods.filter((method) => method === 'POST').length).toBe(3);
+    expect(observedMethods).toContain('DELETE');
+
+    toolResultText = 'x'.repeat(192 * 1024);
+    const oversizedResponse = await (
+      client as unknown as {
+        handleRelayRpcRequest(request: {
+          type: 'rpc.request';
+          version: typeof RELAY_TRANSPORT_PROTOCOL_VERSION;
+          id: string;
+          capability: string;
+          deadlineMs?: number;
+          payload?: {
+            encoding: 'json';
+            value: Record<string, unknown>;
+          };
+          context?: Record<string, unknown>;
+        }): Promise<unknown>;
+      }
+    ).handleRelayRpcRequest({
+      type: 'rpc.request',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-mcp-large',
+      capability: 'mcp.tool.call',
+      payload: {
+        encoding: 'json',
+        value: { toolName: 'read_note', arguments: {} },
+      },
+      context: {
+        actor: {
+          kind: 'integration',
+          id: 'integration-1',
+          name: 'Codex',
+          client: 'codex',
+        },
+      },
+    });
+    expect(oversizedResponse).toMatchObject({
+      ok: false,
+      error: { code: RELAY_ERROR_CODES.PAYLOAD_TOO_LARGE },
+    });
+
+    const oversizedMutationResponse = await (
+      client as unknown as {
+        handleRelayRpcRequest(request: {
+          type: 'rpc.request';
+          version: typeof RELAY_TRANSPORT_PROTOCOL_VERSION;
+          id: string;
+          capability: string;
+          payload: {
+            encoding: 'json';
+            value: Record<string, unknown>;
+          };
+          context: Record<string, unknown>;
+        }): Promise<unknown>;
+      }
+    ).handleRelayRpcRequest({
+      type: 'rpc.request',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-mcp-large-mutation-result',
+      capability: 'mcp.tool.call',
+      payload: {
+        encoding: 'json',
+        value: { toolName: 'append_note', arguments: {} },
+      },
+      context: {
+        actor: {
+          kind: 'integration',
+          id: 'integration-1',
+          name: 'Codex',
+          client: 'codex',
+        },
+      },
+    });
+    expect(oversizedMutationResponse).toMatchObject({
+      ok: true,
+      payload: {
+        value: {
+          content: [{
+            type: 'text',
+            text: expect.stringContaining('"resultOmitted":true'),
+          }],
+        },
+      },
+    });
+  });
+
+  it('rejects malformed mcp.tool.call payloads before reaching the daemon', async () => {
+    const fetchImpl = vi.fn();
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+
+    const response = await (
+      client as unknown as {
+        handleRelayRpcRequest(request: {
+          type: 'rpc.request';
+          version: typeof RELAY_TRANSPORT_PROTOCOL_VERSION;
+          id: string;
+          capability: string;
+          payload?: { encoding: 'json'; value: Record<string, unknown> };
+          context?: Record<string, unknown>;
+        }): Promise<unknown>;
+      }
+    ).handleRelayRpcRequest({
+      type: 'rpc.request',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-mcp-bad',
+      capability: 'mcp.tool.call',
+      payload: {
+        encoding: 'json',
+        value: { toolName: '', arguments: [] },
+      },
+      context: {
+        actor: { kind: 'integration', client: 'codex' },
+      },
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(response).toMatchObject({
+      type: 'rpc.response',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-mcp-bad',
+      ok: false,
+      error: { code: RELAY_ERROR_CODES.BAD_MESSAGE },
+    });
+  });
+
+  it.each([
+    {
+      label: 'non-object arguments',
+      payload: { toolName: 'read_note', arguments: [] },
+      context: { actor: { kind: 'integration', client: 'codex' } },
+    },
+    {
+      label: 'missing actor',
+      payload: { toolName: 'read_note', arguments: {} },
+      context: {},
+    },
+    {
+      label: 'non-string actor fields',
+      payload: { toolName: 'read_note', arguments: {} },
+      context: { actor: { kind: 'integration', id: 42 } },
+    },
+  ])('rejects $label for mcp.tool.call without a daemon fetch', async ({ payload, context }) => {
+    const fetchImpl = vi.fn();
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+
+    const response = await (
+      client as unknown as {
+        handleRelayRpcRequest(request: {
+          type: 'rpc.request';
+          version: typeof RELAY_TRANSPORT_PROTOCOL_VERSION;
+          id: string;
+          capability: string;
+          payload?: { encoding: 'json'; value: Record<string, unknown> };
+          context?: Record<string, unknown>;
+        }): Promise<unknown>;
+      }
+    ).handleRelayRpcRequest({
+      type: 'rpc.request',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-mcp-invalid',
+      capability: 'mcp.tool.call',
+      payload: { encoding: 'json', value: payload },
+      context,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(response).toMatchObject({
+      ok: false,
+      error: { code: RELAY_ERROR_CODES.BAD_MESSAGE },
+    });
+  });
+
+  it('returns a deadline error and independently terminates the initialized MCP session', async () => {
+    const observedMethods: string[] = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      observedMethods.push(request.method);
+      if (request.method === 'DELETE') {
+        return new Response(null, { status: 200 });
+      }
+
+      const message = await request.json() as {
+        id?: string | number;
+        method?: string;
+        params?: { protocolVersion?: string };
+      };
+      if (message.method === 'initialize') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            protocolVersion: message.params?.protocolVersion,
+            capabilities: { tools: {} },
+            serverInfo: { name: 'kb-1-test-daemon', version: '0.0.0' },
+          },
+        }, {
+          headers: { 'mcp-session-id': 'session-timeout' },
+        });
+      }
+      if (message.method === 'notifications/initialized') {
+        return new Response(null, { status: 202 });
+      }
+      if (message.method !== 'tools/call') {
+        throw new Error(`Unexpected MCP request: ${JSON.stringify(message)}`);
+      }
+
+      const signal = init?.signal;
+      if (!signal) throw new Error('Expected the relay deadline signal');
+      if (signal.aborted) {
+        throw signal.reason;
+      }
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => reject(signal.reason),
+          { once: true },
+        );
+      });
+    });
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+
+    const response = await (
+      client as unknown as {
+        handleRelayRpcRequest(request: {
+          type: 'rpc.request';
+          version: typeof RELAY_TRANSPORT_PROTOCOL_VERSION;
+          id: string;
+          capability: string;
+          deadlineMs: number;
+          payload: { encoding: 'json'; value: Record<string, unknown> };
+          context: Record<string, unknown>;
+        }): Promise<unknown>;
+      }
+    ).handleRelayRpcRequest({
+      type: 'rpc.request',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-mcp-timeout',
+      capability: 'mcp.tool.call',
+      deadlineMs: 5,
+      payload: {
+        encoding: 'json',
+        value: { toolName: 'read_note', arguments: {} },
+      },
+      context: {
+        actor: { kind: 'integration', client: 'codex' },
+      },
+    });
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: { code: RELAY_ERROR_CODES.DEADLINE_EXCEEDED },
+    });
+    expect(observedMethods).toContain('DELETE');
+  });
+
+  it('returns a completed tool result without waiting for session cleanup', async () => {
+    let markCleanupStarted: (() => void) | undefined;
+    const cleanupStarted = new Promise<void>((resolve) => {
+      markCleanupStarted = resolve;
+    });
+    let releaseCleanup: (() => void) | undefined;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      if (request.method === 'DELETE') {
+        markCleanupStarted?.();
+        return new Promise<Response>((resolve) => {
+          releaseCleanup = () => resolve(new Response(null, { status: 200 }));
+        });
+      }
+
+      const message = await request.json() as {
+        id?: string | number;
+        method?: string;
+        params?: { protocolVersion?: string };
+      };
+      if (message.method === 'initialize') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            protocolVersion: message.params?.protocolVersion,
+            capabilities: { tools: {} },
+            serverInfo: { name: 'kb-1-test-daemon', version: '0.0.0' },
+          },
+        }, {
+          headers: { 'mcp-session-id': 'session-slow-cleanup' },
+        });
+      }
+      if (message.method === 'notifications/initialized') {
+        return new Response(null, { status: 202 });
+      }
+      if (message.method === 'tools/call') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            content: [{ type: 'text', text: '{"ok":true}' }],
+          },
+        });
+      }
+      throw new Error(`Unexpected MCP request: ${JSON.stringify(message)}`);
+    });
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+
+    const responsePromise = (
+      client as unknown as {
+        handleRelayRpcRequest(request: {
+          type: 'rpc.request';
+          version: typeof RELAY_TRANSPORT_PROTOCOL_VERSION;
+          id: string;
+          capability: string;
+          deadlineMs: number;
+          payload: { encoding: 'json'; value: Record<string, unknown> };
+          context: Record<string, unknown>;
+        }): Promise<unknown>;
+      }
+    ).handleRelayRpcRequest({
+      type: 'rpc.request',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-mcp-slow-cleanup',
+      capability: 'mcp.tool.call',
+      deadlineMs: 1_000,
+      payload: {
+        encoding: 'json',
+        value: { toolName: 'append_note', arguments: {} },
+      },
+      context: {
+        actor: { kind: 'integration', client: 'codex' },
+      },
+    });
+
+    const response = await Promise.race([
+      responsePromise,
+      new Promise<never>((_resolve, reject) => {
+        setTimeout(
+          () => reject(new Error('Tool result waited for MCP cleanup')),
+          100,
+        );
+      }),
+    ]);
+    expect(response).toMatchObject({
+      ok: true,
+      payload: {
+        value: {
+          content: [{ type: 'text', text: '{"ok":true}' }],
+        },
+      },
+    });
+    await cleanupStarted;
+    releaseCleanup?.();
+  });
+
+  it('aborts an in-flight MCP tool and cleans up its session on relay cancellation', async () => {
+    let toolCallStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      toolCallStarted = resolve;
+    });
+    const observedMethods: string[] = [];
+    const observedJsonRpcMethods: Array<string | undefined> = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = new Request(input, init);
+      observedMethods.push(request.method);
+      if (request.method === 'DELETE') {
+        return new Response(null, { status: 200 });
+      }
+
+      const message = await request.json() as {
+        id?: string | number;
+        method?: string;
+        params?: { protocolVersion?: string };
+      };
+      observedJsonRpcMethods.push(message.method);
+      if (message.method === 'initialize') {
+        return Response.json({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            protocolVersion: message.params?.protocolVersion,
+            capabilities: { tools: {} },
+            serverInfo: { name: 'kb-1-test-daemon', version: '0.0.0' },
+          },
+        }, {
+          headers: { 'mcp-session-id': 'session-cancel' },
+        });
+      }
+      if (message.method === 'notifications/initialized') {
+        return new Response(null, { status: 202 });
+      }
+      if (message.method === 'notifications/cancelled') {
+        expect(request.signal.aborted).toBe(false);
+        return new Response(null, { status: 202 });
+      }
+      if (message.method !== 'tools/call') {
+        throw new Error(`Unexpected MCP request: ${JSON.stringify(message)}`);
+      }
+
+      toolCallStarted?.();
+      const signal = init?.signal;
+      if (!signal) throw new Error('Expected the relay cancellation signal');
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => reject(signal.reason),
+          { once: true },
+        );
+      });
+    });
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+    const control = new FakeSocket();
+    control.open();
+    const handleRelayFrame = (
+      client as unknown as {
+        handleRelayFrame(control: unknown, frame: RelayFrame): Promise<void>;
+      }
+    ).handleRelayFrame.bind(client);
+
+    const request = handleRelayFrame(control, {
+      type: 'rpc.request',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'rpc-mcp-cancel',
+      capability: 'mcp.tool.call',
+      deadlineMs: 1_000,
+      payload: {
+        encoding: 'json',
+        value: { toolName: 'append_note', arguments: { content: 'new' } },
+      },
+      context: {
+        actor: { kind: 'integration', client: 'codex' },
+      },
+    });
+    await started;
+
+    await handleRelayFrame(control, {
+      type: 'cancel',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      target: { kind: 'rpc', id: 'rpc-mcp-cancel' },
+      reason: 'Cloud caller disconnected',
+    });
+    await request;
+
+    const sent = control.sent.map(({ data }) =>
+      JSON.parse(Buffer.from(data as Uint8Array).toString('utf8')) as {
+        frame?: { ok?: boolean; error?: { code?: string } };
+      });
+    expect(sent.at(-1)?.frame).toMatchObject({
+      ok: false,
+      error: {
+        code: RELAY_ERROR_CODES.INDETERMINATE,
+        message: expect.stringContaining('reconcile state before retrying'),
+      },
+    });
+    expect(observedMethods).toContain('DELETE');
+    await vi.waitFor(() => {
+      expect(observedJsonRpcMethods).toContain('notifications/cancelled');
+    });
+  });
+
+  it('advertises one-hop MCP tool support as a control feature', () => {
+    expect(TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1).toBe(
+      'relay.mcp-tool-call.bounded-results.v1',
+    );
+  });
+
   it('rejects unknown typed relay RPC capabilities without proxying arbitrary paths', async () => {
     const fetchImpl = vi.fn();
     const client = new TunnelClient({
@@ -265,6 +871,52 @@ describe('TunnelClient typed relay RPC', () => {
       ok: false,
       error: { code: RELAY_ERROR_CODES.UNKNOWN_CAPABILITY },
     });
+  });
+
+  it('applies relay RPC backpressure before creating another MCP session', async () => {
+    const fetchImpl = vi.fn();
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+    const pending = (
+      client as unknown as {
+        pendingRelayRpcRequests: Map<string, AbortController>;
+      }
+    ).pendingRelayRpcRequests;
+    for (let index = 0; index < RELAY_PENDING_REQUEST_LIMIT; index += 1) {
+      pending.set(`existing-${index}`, new AbortController());
+    }
+    const control = new FakeSocket();
+    control.open();
+
+    await (
+      client as unknown as {
+        handleRelayFrame(control: unknown, frame: RelayFrame): Promise<void>;
+      }
+    ).handleRelayFrame(control, {
+      type: 'rpc.request',
+      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+      id: 'over-capacity',
+      capability: 'mcp.tool.call',
+      payload: {
+        encoding: 'json',
+        value: { toolName: 'read_note', arguments: {} },
+      },
+      context: {
+        actor: { kind: 'integration', client: 'codex' },
+      },
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    const lastSent = control.sent.at(-1);
+    if (!lastSent) throw new Error('Expected a backpressure response');
+    const sent = JSON.parse(
+      Buffer.from(lastSent.data as Uint8Array).toString('utf8'),
+    ) as { frame?: { error?: { code?: string } } };
+    expect(sent.frame?.error?.code).toBe(RELAY_ERROR_CODES.BACKPRESSURE);
   });
 });
 

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -1,6 +1,7 @@
 import {
   PendingFrameBuffer,
   RELAY_ERROR_CODES,
+  RELAY_PENDING_REQUEST_LIMIT,
   RELAY_TRANSPORT_PROTOCOL_VERSION,
   TUNNEL_CLOSE_CODES,
   TUNNEL_FEATURES,
@@ -28,6 +29,8 @@ import {
   type TunnelWebSocketCloseEnvelope,
   type TunnelWebSocketOpenEnvelope,
 } from '@kb-1/tunnel-protocol';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { gunzipSync } from 'node:zlib';
 import { WebSocket } from 'ws';
 
@@ -70,6 +73,22 @@ export type BackoffOptions = {
 const DEFAULT_BACKOFF_BASE_MS = 250;
 const DEFAULT_BACKOFF_MAX_MS = 10_000;
 const DEFAULT_BACKOFF_JITTER_RATIO = 0.25;
+const MCP_RELAY_CLIENT_NAME = 'kb-1-cloud-relay';
+const MCP_RELAY_MAX_PAYLOAD_BYTES = 192 * 1024;
+const MAX_MCP_TOOL_NAME_BYTES = 256;
+const MAX_MCP_CLIENT_NAME_BYTES = 256;
+const MAX_ACTOR_HEADER_BYTES = 1_024;
+const MCP_SESSION_CLEANUP_TIMEOUT_MS = 1_000;
+const MCP_READ_ONLY_TOOLS = new Set([
+  'list_vaults',
+  'vault_info',
+  'list_files',
+  'list_attachments',
+  'read_attachment',
+  'get_folder_metadata',
+  'read_note',
+  'search',
+]);
 export const CONTROL_HEARTBEAT_INTERVAL_MS = 15_000;
 export const CONTROL_HEARTBEAT_TIMEOUT_MS = 12_000;
 export const CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT = 2;
@@ -109,6 +128,7 @@ export class TunnelClient {
   private controlHeartbeatMisses = 0;
   private readonly httpAssembler = new ChunkedHttpRequestAssembler();
   private readonly pendingHttpRequests = new Map<string, PendingDaemonHttpRequest>();
+  private readonly pendingRelayRpcRequests = new Map<string, AbortController>();
   private stopped = true;
   private reconnectAttempt = 0;
 
@@ -134,6 +154,7 @@ export class TunnelClient {
     }
     this.clearControlHeartbeat();
     this.abortPendingHttpRequests();
+    this.abortPendingRelayRpcRequests('Tunnel client stopping');
     this.control?.close(1001, 'Tunnel client stopping');
     this.control = undefined;
   }
@@ -195,7 +216,10 @@ export class TunnelClient {
         token: this.config.token,
         ...(this.config.daemonVersion ? { daemonVersion: this.config.daemonVersion } : {}),
         ...(this.config.daemonBuild ? { daemonBuild: this.config.daemonBuild } : {}),
-        features: [TUNNEL_FEATURES.RELAY_FRAMES_V1],
+        features: [
+          TUNNEL_FEATURES.RELAY_FRAMES_V1,
+          TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
+        ],
       }));
       this.startControlHeartbeat(control);
       this.logger.log('info', 'relay control connected', {
@@ -215,6 +239,7 @@ export class TunnelClient {
         this.control = undefined;
         this.clearControlHeartbeat();
         this.abortPendingHttpRequests();
+        this.abortPendingRelayRpcRequests('Relay control disconnected');
       }
 
       if (this.stopped) return;
@@ -297,38 +322,87 @@ export class TunnelClient {
   }
 
   private async handleRelayFrame(control: WebSocket, frame: RelayFrame): Promise<void> {
+    if (frame.type === 'cancel' && frame.target.kind === 'rpc') {
+      this.pendingRelayRpcRequests
+        .get(frame.target.id)
+        ?.abort(new Error(frame.reason ?? 'Relay cancelled RPC request'));
+      return;
+    }
+
     if (frame.type !== 'rpc.request') {
       this.logger.log('warn', 'relay frame type is not handled by tunnel client', { frameType: frame.type });
       return;
     }
 
-    control.send(encodeJsonBytes({
-      type: 'relay.frame',
-      frame: await this.handleRelayRpcRequest(frame),
-    }));
+    if (this.pendingRelayRpcRequests.has(frame.id)) {
+      control.send(encodeJsonBytes({
+        type: 'relay.frame',
+        frame: relayRpcError(
+          frame.id,
+          RELAY_ERROR_CODES.BACKPRESSURE,
+          `Relay RPC request ${frame.id} is already in flight`,
+        ),
+      }));
+      return;
+    }
+    if (this.pendingRelayRpcRequests.size >= RELAY_PENDING_REQUEST_LIMIT) {
+      control.send(encodeJsonBytes({
+        type: 'relay.frame',
+        frame: relayRpcError(
+          frame.id,
+          RELAY_ERROR_CODES.BACKPRESSURE,
+          `Relay RPC concurrency limit of ${RELAY_PENDING_REQUEST_LIMIT} reached`,
+        ),
+      }));
+      return;
+    }
+
+    const abort = new AbortController();
+    this.pendingRelayRpcRequests.set(frame.id, abort);
+    try {
+      control.send(encodeJsonBytes({
+        type: 'relay.frame',
+        frame: await this.handleRelayRpcRequest(frame, abort.signal),
+      }));
+    } finally {
+      if (this.pendingRelayRpcRequests.get(frame.id) === abort) {
+        this.pendingRelayRpcRequests.delete(frame.id);
+      }
+    }
   }
 
-  private async handleRelayRpcRequest(request: RelayRpcRequestFrame): Promise<RelayRpcResponseFrame> {
+  private async handleRelayRpcRequest(
+    request: RelayRpcRequestFrame,
+    relaySignal?: AbortSignal,
+  ): Promise<RelayRpcResponseFrame> {
     switch (request.capability) {
       case 'vault.list':
-        return this.handleVaultListRpc(request);
+        return this.handleVaultListRpc(request, relaySignal);
+      case 'mcp.tool.call':
+        return this.handleMcpToolCallRpc(request, relaySignal);
       default:
         return relayRpcError(request.id, RELAY_ERROR_CODES.UNKNOWN_CAPABILITY, `Unknown relay capability: ${request.capability}`);
     }
   }
 
-  private async handleVaultListRpc(request: RelayRpcRequestFrame): Promise<RelayRpcResponseFrame> {
-    const abort = new AbortController();
+  private async handleVaultListRpc(
+    request: RelayRpcRequestFrame,
+    relaySignal?: AbortSignal,
+  ): Promise<RelayRpcResponseFrame> {
+    const deadlineAbort = new AbortController();
     const timeout = setTimeout(
-      () => abort.abort(),
+      () => deadlineAbort.abort(new Error('Vault list relay RPC deadline exceeded')),
       request.deadlineMs ?? TUNNEL_HTTP_REQUEST_TIMEOUT_MS,
     );
+    const signal = relaySignal
+      ? AbortSignal.any([deadlineAbort.signal, relaySignal])
+      : deadlineAbort.signal;
 
     try {
       const response = await this.fetchImpl(new URL('/api/vaults', this.config.daemonUrl), {
         method: 'GET',
         headers: { accept: 'application/json' },
-        signal: abort.signal,
+        signal,
       });
       if (!response.ok) {
         return relayRpcError(request.id, RELAY_ERROR_CODES.INTERNAL, `Daemon vault list failed with status ${response.status}`);
@@ -344,12 +418,189 @@ export class TunnelClient {
     } catch (error) {
       return relayRpcError(
         request.id,
-        abort.signal.aborted ? RELAY_ERROR_CODES.DEADLINE_EXCEEDED : RELAY_ERROR_CODES.INTERNAL,
+        deadlineAbort.signal.aborted
+          ? RELAY_ERROR_CODES.DEADLINE_EXCEEDED
+          : relaySignal?.aborted
+            ? RELAY_ERROR_CODES.CANCELLED
+            : RELAY_ERROR_CODES.INTERNAL,
         `Daemon vault list RPC failed: ${String(error)}`,
       );
     } finally {
       clearTimeout(timeout);
     }
+  }
+
+  private async handleMcpToolCallRpc(
+    request: RelayRpcRequestFrame,
+    relaySignal?: AbortSignal,
+  ): Promise<RelayRpcResponseFrame> {
+    const parsed = parseMcpToolCallRpcRequest(request);
+    if (!parsed.ok) {
+      return relayRpcError(request.id, RELAY_ERROR_CODES.BAD_MESSAGE, parsed.message);
+    }
+
+    const deadlineAbort = new AbortController();
+    const timeout = setTimeout(
+      () => deadlineAbort.abort(new Error('MCP relay RPC deadline exceeded')),
+      request.deadlineMs ?? TUNNEL_HTTP_REQUEST_TIMEOUT_MS,
+    );
+    const operationSignal = relaySignal
+      ? AbortSignal.any([deadlineAbort.signal, relaySignal])
+      : deadlineAbort.signal;
+    let toolCallDispatched = false;
+    let cleaningUp = false;
+    const transport = new StreamableHTTPClientTransport(
+      new URL('/mcp', this.config.daemonUrl),
+      {
+        fetch: (input, init) => {
+          if (cleaningUp) {
+            const cleanupAbort = new AbortController();
+            const cleanupTimeout = setTimeout(
+              () => cleanupAbort.abort(new Error('MCP session cleanup timed out')),
+              MCP_SESSION_CLEANUP_TIMEOUT_MS,
+            );
+            return this.fetchImpl(input, { ...init, signal: cleanupAbort.signal })
+              .finally(() => clearTimeout(cleanupTimeout));
+          }
+          const transportSignal =
+            input instanceof Request ? input.signal : init?.signal;
+          if (operationSignal.aborted) {
+            const cancellationAbort = new AbortController();
+            const cancellationTimeout = setTimeout(
+              () => cancellationAbort.abort(
+                new Error('MCP cancellation notification timed out'),
+              ),
+              MCP_SESSION_CLEANUP_TIMEOUT_MS,
+            );
+            const cancellationSignal = transportSignal
+              ? AbortSignal.any([
+                cancellationAbort.signal,
+                transportSignal,
+              ])
+              : cancellationAbort.signal;
+            return this.fetchImpl(input, {
+              ...init,
+              signal: cancellationSignal,
+            }).finally(() => clearTimeout(cancellationTimeout));
+          }
+          const signals = [
+            operationSignal,
+            ...(transportSignal ? [transportSignal] : []),
+          ];
+          const signal = signals.length === 1
+            ? signals[0]
+            : AbortSignal.any(signals);
+          return this.fetchImpl(input, { ...init, signal });
+        },
+        requestInit: {
+          headers: { 'x-kb1-actor': parsed.actorHeader },
+        },
+      },
+    );
+    const client = new Client({
+      name: parsed.clientName,
+      version: '0.0.1',
+    });
+
+    try {
+      await client.connect(transport);
+      toolCallDispatched = true;
+      const result = await client.callTool(
+        {
+          name: parsed.toolName,
+          arguments: parsed.arguments,
+        },
+        undefined,
+        { signal: operationSignal },
+      );
+      if (
+        Buffer.byteLength(JSON.stringify(result), 'utf8')
+        > MCP_RELAY_MAX_PAYLOAD_BYTES
+      ) {
+        if (!MCP_READ_ONLY_TOOLS.has(parsed.toolName)) {
+          const originalSucceeded = result.isError !== true;
+          return {
+            type: 'rpc.response',
+            version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+            id: request.id,
+            ok: true,
+            payload: {
+              encoding: 'json',
+              value: {
+                ...(originalSucceeded ? {} : { isError: true }),
+                content: [{
+                  type: 'text',
+                  text: JSON.stringify(originalSucceeded
+                    ? {
+                      ok: true,
+                      resultOmitted: true,
+                      message:
+                        'Mutation completed, but its full result exceeded the one-hop relay limit. Read current state before another mutation.',
+                    }
+                    : {
+                      ok: false,
+                      error: 'result_too_large',
+                      resultOmitted: true,
+                      message:
+                        'Mutation rejection exceeded the one-hop relay limit. Reconcile current state before retrying.',
+                    }),
+                }],
+              },
+            },
+          };
+        }
+        return relayRpcError(
+          request.id,
+          RELAY_ERROR_CODES.PAYLOAD_TOO_LARGE,
+          'Daemon MCP tool result is too large for one-hop relay RPC',
+        );
+      }
+      return {
+        type: 'rpc.response',
+        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
+        id: request.id,
+        ok: true,
+        payload: { encoding: 'json', value: result as RelayJsonValue },
+      };
+    } catch (error) {
+      const aborted =
+        deadlineAbort.signal.aborted || relaySignal?.aborted === true;
+      const mutationOutcomeIsIndeterminate =
+        aborted &&
+        toolCallDispatched &&
+        !MCP_READ_ONLY_TOOLS.has(parsed.toolName);
+      return relayRpcError(
+        request.id,
+        mutationOutcomeIsIndeterminate
+          ? RELAY_ERROR_CODES.INDETERMINATE
+          : deadlineAbort.signal.aborted
+            ? RELAY_ERROR_CODES.DEADLINE_EXCEEDED
+            : relaySignal?.aborted
+              ? RELAY_ERROR_CODES.CANCELLED
+              : RELAY_ERROR_CODES.INTERNAL,
+        mutationOutcomeIsIndeterminate
+          ? `Daemon MCP mutation outcome is indeterminate after relay cancellation; reconcile state before retrying: ${String(error)}`
+          : `Daemon MCP tool RPC failed: ${String(error)}`,
+      );
+    } finally {
+      clearTimeout(timeout);
+      cleaningUp = true;
+      void transport
+        .terminateSession()
+        .catch((error: unknown) => {
+          this.logger.log('warn', 'daemon MCP relay session cleanup failed', {
+            error: String(error),
+          });
+        })
+        .finally(() => transport.close().catch(() => undefined));
+    }
+  }
+
+  private abortPendingRelayRpcRequests(reason: string): void {
+    for (const abort of this.pendingRelayRpcRequests.values()) {
+      abort.abort(new Error(reason));
+    }
+    this.pendingRelayRpcRequests.clear();
   }
 
   private startControlHeartbeat(control: WebSocket): void {
@@ -867,6 +1118,82 @@ function relayRpcError(
     ok: false,
     error: { code, message },
   };
+}
+
+type ParsedMcpToolCallRpcRequest =
+  | {
+      ok: true;
+      toolName: string;
+      arguments: Record<string, unknown>;
+      clientName: string;
+      actorHeader: string;
+    }
+  | { ok: false; message: string };
+
+function parseMcpToolCallRpcRequest(
+  request: RelayRpcRequestFrame,
+): ParsedMcpToolCallRpcRequest {
+  if (request.payload?.encoding !== 'json' || !isRelayJsonObject(request.payload.value)) {
+    return { ok: false, message: 'mcp.tool.call requires a JSON object payload' };
+  }
+
+  const toolName = request.payload.value.toolName;
+  if (
+    typeof toolName !== 'string'
+    || toolName.length === 0
+    || Buffer.byteLength(toolName, 'utf8') > MAX_MCP_TOOL_NAME_BYTES
+  ) {
+    return { ok: false, message: 'mcp.tool.call toolName must be a non-empty string no larger than 256 bytes' };
+  }
+
+  const args = request.payload.value.arguments;
+  if (args !== undefined && !isRelayJsonObject(args)) {
+    return { ok: false, message: 'mcp.tool.call arguments must be a JSON object when provided' };
+  }
+
+  const requestedClientName = request.payload.value.clientName;
+  if (
+    requestedClientName !== undefined
+    && (
+      typeof requestedClientName !== 'string'
+      || requestedClientName.length === 0
+      || Buffer.byteLength(requestedClientName, 'utf8') > MAX_MCP_CLIENT_NAME_BYTES
+    )
+  ) {
+    return { ok: false, message: 'mcp.tool.call clientName must be a non-empty string no larger than 256 bytes when provided' };
+  }
+
+  const actor = request.context?.actor;
+  if (!isRelayJsonObject(actor) || (actor.kind !== 'user' && actor.kind !== 'integration')) {
+    return { ok: false, message: 'mcp.tool.call requires an attributed user or integration actor' };
+  }
+  for (const key of ['id', 'name', 'client'] as const) {
+    if (actor[key] !== undefined && typeof actor[key] !== 'string') {
+      return { ok: false, message: `mcp.tool.call actor.${key} must be a string when provided` };
+    }
+  }
+
+  const actorHeader = JSON.stringify({
+    kind: actor.kind,
+    ...(typeof actor.id === 'string' ? { id: actor.id } : {}),
+    ...(typeof actor.name === 'string' ? { name: actor.name } : {}),
+    ...(typeof actor.client === 'string' ? { client: actor.client } : {}),
+  });
+  if (Buffer.byteLength(actorHeader, 'utf8') > MAX_ACTOR_HEADER_BYTES) {
+    return { ok: false, message: 'mcp.tool.call actor must be no larger than 1 KiB' };
+  }
+
+  return {
+    ok: true,
+    toolName,
+    arguments: (args ?? {}) as Record<string, unknown>,
+    clientName: requestedClientName ?? MCP_RELAY_CLIENT_NAME,
+    actorHeader,
+  };
+}
+
+function isRelayJsonObject(value: unknown): value is RelayJsonObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 export function relayInternalUrl(relayUrl: URL, internalPath: string): URL {

--- a/packages/tunnel-protocol/src/index.test.ts
+++ b/packages/tunnel-protocol/src/index.test.ts
@@ -48,7 +48,10 @@ it("round-trips control hello feature advertisement", () => {
     token: "test-token",
     daemonVersion: "0.1.0",
     daemonBuild: "registry.example/kb1d@sha256:abc123",
-    features: [TUNNEL_FEATURES.RELAY_FRAMES_V1]
+    features: [
+      TUNNEL_FEATURES.RELAY_FRAMES_V1,
+      TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1
+    ]
   } as const;
 
   expect(decodeTunnelMessage(encodeTunnelMessage(hello))).toEqual(hello);
@@ -152,6 +155,10 @@ it("exports named pending stream caps and close codes", () => {
   expect(TUNNEL_CLOSE_CODES.PENDING_STREAM_TIMEOUT).not.toBe(
     TUNNEL_CLOSE_CODES.PENDING_STREAM_OVERFLOW
   );
+});
+
+it("defines an explicit indeterminate mutation outcome", () => {
+  expect(RELAY_ERROR_CODES.INDETERMINATE).toBe("indeterminate");
 });
 
 it("uses named pending stream caps by default", () => {

--- a/packages/tunnel-protocol/src/index.ts
+++ b/packages/tunnel-protocol/src/index.ts
@@ -22,7 +22,9 @@ export const RELAY_PENDING_REQUEST_LIMIT = 128 as const;
 export const RELAY_DEFAULT_REQUEST_TIMEOUT_MS = 15_000 as const;
 
 export const TUNNEL_FEATURES = {
-  RELAY_FRAMES_V1: "relay.frame.v1"
+  RELAY_FRAMES_V1: "relay.frame.v1",
+  MCP_TOOL_CALL_BOUNDED_RESULTS_V1:
+    "relay.mcp-tool-call.bounded-results.v1"
 } as const;
 
 export type TunnelFeature = (typeof TUNNEL_FEATURES)[keyof typeof TUNNEL_FEATURES];
@@ -34,6 +36,7 @@ export const RELAY_ERROR_CODES = {
   UNAUTHORIZED: "unauthorized",
   DEADLINE_EXCEEDED: "deadline-exceeded",
   CANCELLED: "cancelled",
+  INDETERMINATE: "indeterminate",
   PAYLOAD_TOO_LARGE: "payload-too-large",
   BACKPRESSURE: "backpressure",
   INTERNAL: "internal"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,9 @@ importers:
       '@kb-1/tunnel-protocol':
         specifier: workspace:*
         version: link:../tunnel-protocol
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.4.3)
       ws:
         specifier: 8.21.0
         version: 8.21.0


### PR DESCRIPTION
## Summary

- add a capability-gated, bounded one-hop `mcp.tool.call` relay path
- preserve exact actor attribution while propagating cancellation and deadlines
- bound requests/results, add relay backpressure, and return unambiguous compact receipts for oversized mutation results
- harden MCP session initialization, idle expiration, cleanup, and attachment reads

## Why

Cloud MCP calls currently establish a full streamed MCP session for each tool invocation. That adds several control-channel round trips and exposes session lifecycle races under load. The new advertised `relay.mcp-tool-call.bounded-results.v1` contract lets compatible Cloud workers use one typed request while older callers keep the existing path.

Mutation retries remain fail-closed: an aborted dispatched mutation is reported as indeterminate, and oversized successful mutation results return a bounded success receipt instead of looking like a failed write.

## Validation

- `pnpm check`
- focused local-MCP, tunnel-protocol, and tunnel-client suites: 84 tests passed
- external autoreview: clean, no actionable findings

## Rollout order

Merge this PR before the dependent `kb-1-cloud` PR. Cloud must then update its `kb-1-daemon` submodule pointer to this merge and rerun its integrated checks.
