### PR TITLE
perf(doc-session): instrument live sync and skip valid snapshot rewrites

### DIFF
--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -732,6 +732,11 @@ describe('daemon vault management API', () => {
   });
 
   it('edits a live document over the scoped Yjs WebSocket and persists to the scoped vault', async () => {
+    const traceId = '123e4567-e89b-42d3-a456-426614174000';
+    const timingLogs: unknown[] = [];
+    const logSpy = vi.spyOn(console, 'log').mockImplementation((label, fields) => {
+      if (label === '[document timing]') timingLogs.push(fields);
+    });
     await fetch(`${base()}/api/vaults`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -746,12 +751,28 @@ describe('daemon vault management API', () => {
     // A scoped Yjs socket opens against the addressed vault's document manager.
     // The daemon's own shutdown (in afterEach) drains and closes it in order, so
     // the document-session state is flushed before the throwaway home is removed.
-    const socket = new WebSocket(`ws://127.0.0.1:${port}/api/vaults/ws-vault/files/doc.md/yjs`);
+    const socket = new WebSocket(`ws://127.0.0.1:${port}/api/vaults/ws-vault/files/doc.md/yjs`, {
+      headers: { 'x-kb1-document-trace-id': traceId }
+    });
     const opened = new Promise<void>((resolveOpen, rejectOpen) => {
       socket.once('open', () => resolveOpen());
       socket.once('error', rejectOpen);
     });
     await opened;
+    await vi.waitUntil(
+      () => timingLogs.some((entry) =>
+        (entry as { stage?: unknown }).stage === 'initial_sync.emitted'
+      ),
+      { timeout: 1_000 }
+    );
+
+    expect(timingLogs).toEqual(expect.arrayContaining([
+      expect.objectContaining({ component: 'daemon', traceId, stage: 'websocket.accepted' }),
+      expect.objectContaining({ component: 'daemon', traceId, stage: 'document_session.attached' }),
+      expect.objectContaining({ component: 'daemon', traceId, stage: 'markdown.read' }),
+      expect.objectContaining({ component: 'daemon', traceId, stage: 'initial_sync.emitted' })
+    ]));
+    expect(JSON.stringify(timingLogs)).not.toContain('doc.md');
 
     // An unknown-vault scoped socket is refused: the upgrade is destroyed, so the
     // client sees an error/close rather than an open.
@@ -762,6 +783,7 @@ describe('daemon vault management API', () => {
       badSocket.once('close', () => resolveBad('refused'));
     });
     expect(badResult).toBe('refused');
+    logSpy.mockRestore();
   });
 });
 

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 import { serve } from '@hono/node-server';
-import { bindYjsWebSocket, type DocumentSessionManager, type DocumentUpdateAttribution } from '@kb-1/doc-session';
+import {
+  bindYjsWebSocket,
+  type DocumentSessionManager,
+  type DocumentUpdateAttribution,
+  type YjsWebSocketTimingEvent
+} from '@kb-1/doc-session';
 import { createLocalMcpEndpoint } from '@kb-1/local-mcp';
 import { TunnelClient, type TunnelClientLogger } from '@kb-1/tunnel-client';
 import type { VaultChangeEventKind } from '@kb-1/vault-service';
@@ -38,6 +43,7 @@ import {
 } from './vault-registry.js';
 
 const VAULT_TREE_CHANGED_TOPIC = 'vault.tree.changed';
+const DOCUMENT_TRACE_HEADER = 'x-kb1-document-trace-id';
 const TREE_DIRTY_EVENT_KINDS = new Set<VaultChangeEventKind>([
   'file_created',
   'folder_created',
@@ -237,6 +243,13 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Sta
     }
 
     server.on('upgrade', (request, socket, head) => {
+      const documentTraceId = traceIdFromDocumentRequest(request);
+      const documentTimingStartedAt = performance.now();
+      const onDocumentTiming = documentTraceId
+        ? (event: YjsWebSocketTimingEvent) => {
+            logDocumentTiming(documentTraceId, documentTimingStartedAt, event);
+          }
+        : undefined;
       if (shutdownRequested) {
         socket.destroy();
         return;
@@ -258,17 +271,32 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Sta
       }
 
       webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
+        if (documentTraceId) {
+          logDocumentTiming(documentTraceId, documentTimingStartedAt, {
+            stage: 'websocket.accepted',
+            durationMs: elapsedDocumentTimingMs(documentTimingStartedAt)
+          });
+        }
         // Track the connection's whole lifecycle — handshake, session open (which
-        // writes the session-state snapshot), and the bound stream — in the drain
+        // may repair the session-state snapshot), and the bound stream — in the drain
         // set synchronously, before any await. Shutdown must wait for a connection
         // that is still opening, or its in-flight state write can outlive teardown.
         const lifecycle = (async () => {
           const bindingLease = target.manager.attachClientSession(target.documentPath);
+          if (documentTraceId) {
+            logDocumentTiming(documentTraceId, documentTimingStartedAt, {
+              stage: 'document_session.attached',
+              durationMs: elapsedDocumentTimingMs(documentTimingStartedAt)
+            });
+          }
           try {
             const binding = await bindYjsWebSocket(
               bindingLease.session,
               webSocket,
-              attribution.attribution ? { attribution: attribution.attribution } : {}
+              {
+                ...(attribution.attribution ? { attribution: attribution.attribution } : {}),
+                ...(onDocumentTiming ? { onTiming: onDocumentTiming } : {})
+              }
             );
             try {
               await binding.closed;
@@ -439,6 +467,38 @@ function documentUpdateAttributionForActor(actor: VaultActor): DocumentUpdateAtt
 
 function firstHeaderValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
+}
+
+function traceIdFromDocumentRequest(request: IncomingMessage): string | undefined {
+  const value = firstHeaderValue(request.headers[DOCUMENT_TRACE_HEADER]);
+  return value && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+    ? value
+    : undefined;
+}
+
+function logDocumentTiming(
+  traceId: string,
+  startedAt: number,
+  event: {
+    stage: string;
+    durationMs: number;
+    outcome?: string;
+    ackId?: string;
+  }
+): void {
+  console.log('[document timing]', {
+    component: 'daemon',
+    traceId,
+    stage: event.stage,
+    elapsedMs: elapsedDocumentTimingMs(startedAt),
+    durationMs: event.durationMs,
+    ...(event.outcome ? { outcome: event.outcome } : {}),
+    ...(event.ackId ? { ackId: event.ackId } : {})
+  });
+}
+
+function elapsedDocumentTimingMs(startedAt: number): number {
+  return Math.max(0, Math.round((performance.now() - startedAt) * 100) / 100);
 }
 
 /** Parse `/api/vaults/<id>/files/<rawPath>` into its id and raw file path. */

--- a/packages/doc-session/src/index.ts
+++ b/packages/doc-session/src/index.ts
@@ -7,6 +7,9 @@ export {
   PersistFailedError,
   type DocumentSessionFailure,
   type DocumentSessionEventHandler,
+  type DocumentSessionTimingEvent,
+  type DocumentSessionTimingHandler,
+  type DocumentSessionTimingStage,
   type DocumentSessionMutationOptions,
   type DocumentSessionWarning,
   type OneFileDocumentSessionOptions,
@@ -26,6 +29,8 @@ export {
   bindYjsWebSocket,
   type BoundYjsWebSocket,
   type YjsWebSocketBindingOptions,
+  type YjsWebSocketTimingEvent,
+  type YjsWebSocketTimingHandler,
   type YjsWebSocketLike
 } from './websocket.js';
 export {

--- a/packages/doc-session/src/manager.ts
+++ b/packages/doc-session/src/manager.ts
@@ -44,6 +44,7 @@ export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurf
   private readonly sessions = new Map<string, OneFileDocumentSession>();
   private readonly clientCounts = new Map<string, number>();
   private readonly idleCloseTimers = new Map<string, NodeJS.Timeout>();
+  private readonly closingSessions = new Set<Promise<void>>();
   private readonly eventHandlers = new Set<DocumentSessionEventHandler>();
 
   constructor(options: DocumentSessionManagerOptions) {
@@ -129,7 +130,7 @@ export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurf
   }
 
   getOpenSessionCount(): number {
-    return this.sessions.size;
+    return this.sessions.size + this.closingSessions.size;
   }
 
   async flushDirtySessions(): Promise<FlushDocumentSessionsResult> {
@@ -219,6 +220,7 @@ export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurf
       clearTimeout(timer);
     }
     this.idleCloseTimers.clear();
+    await Promise.allSettled([...this.closingSessions]);
     await Promise.all([...this.sessions.values()].map((session) => session.close()));
     this.sessions.clear();
     this.clientCounts.clear();
@@ -261,9 +263,15 @@ export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurf
       return;
     }
     const timer = setTimeout(() => {
-      void this.closeSession(vaultPath).catch((error: unknown) => {
-        console.warn(`KB-1 failed to close idle document session for ${vaultPath}.`, error);
-      });
+      const closing = this.closeSession(vaultPath);
+      this.closingSessions.add(closing);
+      void closing
+        .catch((error: unknown) => {
+          console.warn(`KB-1 failed to close idle document session for ${vaultPath}.`, error);
+        })
+        .finally(() => {
+          this.closingSessions.delete(closing);
+        });
     }, this.idleSessionGraceMs);
     timer.unref?.();
     this.idleCloseTimers.set(vaultPath, timer);

--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -10,6 +10,7 @@ import {
   OneFileDocumentSession,
   DocumentSessionManager,
   type DocumentSessionEvent,
+  type DocumentSessionTimingEvent,
   type DocumentSessionWarning
 } from './index.js';
 
@@ -176,6 +177,56 @@ describe('OneFileDocumentSession', () => {
     await session.close();
   });
 
+  it('reports cold-open timings to every concurrent opener', async () => {
+    await writeFileWithParents(filePath, 'from disk\n');
+    const stateFilePath = join(kb1Home, '.kb1', 'doc-session-state', 'concurrent.json');
+    const session = new OneFileDocumentSession(filePath, { stateFilePath });
+    const firstTimings: DocumentSessionTimingEvent[] = [];
+    const secondTimings: DocumentSessionTimingEvent[] = [];
+
+    await Promise.all([
+      session.open({ onTiming: (event) => firstTimings.push(event) }),
+      session.open({ onTiming: (event) => secondTimings.push(event) }),
+    ]);
+
+    expect(firstTimings).toEqual(secondTimings);
+    expect(firstTimings.map((event) => event.stage)).toEqual([
+      'markdown.read',
+      'yjs_state.read',
+      'yjs_state.atomic_write_fsync',
+    ]);
+    await session.close();
+  });
+
+  it('does not rewrite a valid Yjs state snapshot during a cold reopen', async () => {
+    await writeFileWithParents(filePath, 'from disk\n');
+    const stateFilePath = join(kb1Home, '.kb1', 'doc-session-state', 'valid.json');
+    const firstTimings: DocumentSessionTimingEvent[] = [];
+    const first = new OneFileDocumentSession(filePath, { stateFilePath });
+
+    await first.open({ onTiming: (event) => firstTimings.push(event) });
+    await first.close();
+
+    expect(firstTimings).toContainEqual(expect.objectContaining({
+      stage: 'yjs_state.atomic_write_fsync',
+      outcome: 'written'
+    }));
+
+    const secondTimings: DocumentSessionTimingEvent[] = [];
+    const second = new OneFileDocumentSession(filePath, { stateFilePath });
+    await second.open({ onTiming: (event) => secondTimings.push(event) });
+
+    expect(second.ydoc.getText('markdown').toString()).toBe('from disk\n');
+    expect(secondTimings).toContainEqual(expect.objectContaining({
+      stage: 'yjs_state.restore',
+      outcome: 'valid'
+    }));
+    expect(secondTimings).not.toContainEqual(expect.objectContaining({
+      stage: 'yjs_state.atomic_write_fsync'
+    }));
+    await second.close();
+  });
+
   it('materializes Yjs edits to the filesystem', async () => {
     const session = new OneFileDocumentSession(filePath, { defaultContent: '' });
     await session.open();
@@ -186,6 +237,32 @@ describe('OneFileDocumentSession', () => {
     await session.flush();
 
     await expect(readFile(filePath, 'utf8')).resolves.toBe('written through Yjs\n');
+    await session.close();
+  });
+
+  it('does not replay persist timings when one observer flushes the same cycle twice', async () => {
+    const stateFilePath = join(kb1Home, '.kb1', 'doc-session-state', 'flush.json');
+    const session = new OneFileDocumentSession(filePath, {
+      defaultContent: '',
+      stateFilePath,
+    });
+    await session.open();
+
+    session.ydoc.getText('markdown').insert(0, 'written through Yjs\n');
+    const timings: DocumentSessionTimingEvent[] = [];
+    const onTiming = (event: DocumentSessionTimingEvent): void => {
+      timings.push(event);
+    };
+    await Promise.all([
+      session.flush({ onTiming }),
+      session.flush({ onTiming }),
+    ]);
+
+    expect(timings.map((event) => event.stage)).toEqual([
+      'markdown.read',
+      'markdown.atomic_write_fsync',
+      'yjs_state.atomic_write_fsync',
+    ]);
     await session.close();
   });
 

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -21,6 +21,7 @@ const DOCUMENT_SESSION_STATE_VERSION = 1;
 const EXTERNAL_CHANGE_ORIGIN = Symbol('kb1.external-change');
 const WATCH_DEBOUNCE_MS = 150;
 const WATCH_POLL_MS = 2000;
+const TIMING_REPLAY_EVENT_LIMIT = 32;
 const WINDOWS_WATCH_DIRECTORY_CACHE = new Map<string, string>();
 
 export function resolveWatchDirectory(
@@ -68,6 +69,35 @@ export interface OneFileDocumentSessionOptions {
   warn?: (warning: DocumentSessionWarning) => void;
   watchDebounceMs?: number;
   watchPollMs?: number;
+}
+
+export type DocumentSessionTimingStage =
+  | 'markdown.read'
+  | 'yjs_state.read'
+  | 'yjs_state.restore'
+  | 'yjs_state.atomic_write_fsync'
+  | 'markdown.atomic_write_fsync';
+
+export interface DocumentSessionTimingEvent {
+  stage: DocumentSessionTimingStage;
+  durationMs: number;
+  outcome?: 'disabled' | 'missing' | 'valid' | 'stale' | 'invalid' | 'repaired' | 'written';
+}
+
+export type DocumentSessionTimingHandler = (event: DocumentSessionTimingEvent) => void;
+
+interface DocumentSessionOpenOptions {
+  createIfMissing?: boolean;
+  onTiming?: DocumentSessionTimingHandler;
+}
+
+interface DocumentSessionFlushOptions {
+  onTiming?: DocumentSessionTimingHandler;
+}
+
+interface TimingCycle {
+  events: DocumentSessionTimingEvent[];
+  handlerReferences: Map<DocumentSessionTimingHandler, number>;
 }
 
 export type DocumentSessionEventHandler = (event: DocumentSessionEvent) => void;
@@ -170,6 +200,7 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
   private readonly eventHandlers = new Set<DocumentSessionEventHandler>();
   private opened = false;
   private openPromise: Promise<void> | undefined;
+  private openTimingCycle: TimingCycle | undefined;
   private lastWrittenHash: string | undefined;
   private lastWrittenContent: string | undefined;
   private nonEmptyMaterializedContent = false;
@@ -178,6 +209,7 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
   private pendingPersistAttribution: DocumentUpdateAttribution | undefined;
   private persistRequested = false;
   private persistPromise: Promise<void> | undefined;
+  private persistTimingCycle: TimingCycle | undefined;
   private persistFailed = false;
   private persistFailureError: PersistFailedError | undefined;
   private activePersistFailureEvent: DocumentSessionEvent | undefined;
@@ -213,31 +245,58 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
     return this.nonEmptyMaterializedContent;
   }
 
-  async open(options: { createIfMissing?: boolean } = {}): Promise<void> {
+  async open(options: DocumentSessionOpenOptions = {}): Promise<void> {
     if (this.opened) {
       return;
     }
 
     if (!this.openPromise) {
-      this.openPromise = this.loadFromFile(options.createIfMissing ?? this.createMissingOnOpen).finally(() => {
+      const timingCycle = createTimingCycle();
+      this.openTimingCycle = timingCycle;
+      this.openPromise = this.loadFromFile(
+        options.createIfMissing ?? this.createMissingOnOpen,
+      ).finally(() => {
         this.openPromise = undefined;
+        if (this.openTimingCycle === timingCycle) {
+          this.openTimingCycle = undefined;
+        }
       });
     }
 
-    await this.openPromise;
+    await observeTimingCycle(
+      this.openPromise,
+      this.openTimingCycle,
+      options.onTiming,
+    );
   }
 
-  private async loadFromFile(createIfMissing: boolean): Promise<void> {
+  private async loadFromFile(
+    createIfMissing: boolean,
+  ): Promise<void> {
+    const onTiming = (event: DocumentSessionTimingEvent): void => {
+      recordTimingEvent(this.openTimingCycle, event);
+    };
+    const markdownReadStartedAt = performance.now();
     const content = await this.readFile({ createIfMissing });
+    emitTiming(onTiming, {
+      stage: 'markdown.read',
+      durationMs: elapsedMs(markdownReadStartedAt),
+    });
     const contentHash = hashContent(content);
-    const restoredFromState = await this.tryRestoreStateSnapshot(content, contentHash);
-    if (!restoredFromState) {
+    const restoreOutcome = await this.tryRestoreStateSnapshot(
+      content,
+      contentHash,
+      onTiming,
+    );
+    if (restoreOutcome !== 'valid' && restoreOutcome !== 'repaired') {
       this.text.insert(0, content);
     }
     this.nonEmptyMaterializedContent = content.length > 0;
     this.lastWrittenHash = contentHash;
     this.lastWrittenContent = content;
-    await this.writeStateSnapshot(contentHash);
+    if (restoreOutcome !== 'valid') {
+      await this.writeStateSnapshot(contentHash, onTiming);
+    }
     this.doc.on('update', this.handleDocumentUpdate);
     this.opened = true;
     this.startWatching();
@@ -348,12 +407,12 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
     return this.applyPositionedContent(edit(this.currentContentAfterOpen()), options);
   }
 
-  async flush(): Promise<void> {
+  async flush(options: DocumentSessionFlushOptions = {}): Promise<void> {
     if (this.persistPromise) {
-      await this.persistPromise;
+      await this.observePersist(this.persistPromise, options.onTiming);
     }
     if (this.persistFailureError) {
-      await this.requestPersist();
+      await this.observePersist(this.requestPersist(), options.onTiming);
     }
   }
 
@@ -480,8 +539,13 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
     this.persistRequested = true;
 
     if (!this.persistPromise) {
+      const timingCycle = createTimingCycle();
+      this.persistTimingCycle = timingCycle;
       this.persistPromise = this.persistLoop().finally(() => {
         this.persistPromise = undefined;
+        if (this.persistTimingCycle === timingCycle) {
+          this.persistTimingCycle = undefined;
+        }
       });
     }
 
@@ -515,7 +579,12 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
     const content = this.currentContent();
     const attribution = this.pendingPersistAttribution;
     this.pendingPersistAttribution = undefined;
+    const markdownReadStartedAt = performance.now();
     const diskContent = await readOptionalFile(this.filePath);
+    this.recordPersistTiming({
+      stage: 'markdown.read',
+      durationMs: elapsedMs(markdownReadStartedAt),
+    });
     const diskHash = diskContent === undefined ? undefined : hashContent(diskContent);
 
     // Re-check disk immediately before writing so external edits observed between debounce and persist are merged first.
@@ -533,8 +602,16 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
     const contentHash = hashContent(content);
     this.pendingWriteHash = contentHash;
     try {
+      const markdownWriteStartedAt = performance.now();
       await atomicWriteFile(this.filePath, content);
-      await this.writeStateSnapshot(contentHash);
+      this.recordPersistTiming({
+        stage: 'markdown.atomic_write_fsync',
+        durationMs: elapsedMs(markdownWriteStartedAt),
+        outcome: 'written',
+      });
+      await this.writeStateSnapshot(contentHash, (event) => {
+        this.recordPersistTiming(event);
+      });
       this.lastWrittenHash = contentHash;
       this.lastWrittenContent = content;
       this.nonEmptyMaterializedContent = content.length > 0;
@@ -752,11 +829,35 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
     this.emitEvent(eventKind);
   }
 
-  private async tryRestoreStateSnapshot(content: string, contentHash: string): Promise<boolean> {
-    if (!this.stateFilePath) return false;
+  private async tryRestoreStateSnapshot(
+    content: string,
+    contentHash: string,
+    onTiming?: DocumentSessionTimingHandler,
+  ): Promise<'disabled' | 'missing' | 'valid' | 'stale' | 'invalid' | 'repaired'> {
+    if (!this.stateFilePath) {
+      emitTiming(onTiming, {
+        stage: 'yjs_state.read',
+        durationMs: 0,
+        outcome: 'disabled',
+      });
+      return 'disabled';
+    }
+    const stateReadStartedAt = performance.now();
     const raw = await readOptionalFile(this.stateFilePath);
-    if (raw === undefined) return false;
+    if (raw === undefined) {
+      emitTiming(onTiming, {
+        stage: 'yjs_state.read',
+        durationMs: elapsedMs(stateReadStartedAt),
+        outcome: 'missing',
+      });
+      return 'missing';
+    }
+    emitTiming(onTiming, {
+      stage: 'yjs_state.read',
+      durationMs: elapsedMs(stateReadStartedAt),
+    });
 
+    const restoreStartedAt = performance.now();
     try {
       const parsed = JSON.parse(raw) as Partial<DocumentSessionStateFile>;
       if (
@@ -764,33 +865,73 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
         parsed.contentHash !== contentHash ||
         typeof parsed.updateBase64 !== 'string'
       ) {
-        return false;
+        emitTiming(onTiming, {
+          stage: 'yjs_state.restore',
+          durationMs: elapsedMs(restoreStartedAt),
+          outcome: 'stale',
+        });
+        return 'stale';
       }
 
       Y.applyUpdate(this.doc, decodeBase64Bytes(parsed.updateBase64), this);
       if (this.text.toString() === content) {
-        return true;
+        emitTiming(onTiming, {
+          stage: 'yjs_state.restore',
+          durationMs: elapsedMs(restoreStartedAt),
+          outcome: 'valid',
+        });
+        return 'valid';
       }
 
       this.doc.transact(() => {
         this.text.delete(0, this.text.length);
         this.text.insert(0, content);
       }, this);
-      return true;
+      emitTiming(onTiming, {
+        stage: 'yjs_state.restore',
+        durationMs: elapsedMs(restoreStartedAt),
+        outcome: 'repaired',
+      });
+      return 'repaired';
     } catch (error) {
       console.warn(`KB-1 ignored invalid Yjs state snapshot for ${this.filePath}.`, error);
-      return false;
+      emitTiming(onTiming, {
+        stage: 'yjs_state.restore',
+        durationMs: elapsedMs(restoreStartedAt),
+        outcome: 'invalid',
+      });
+      return 'invalid';
     }
   }
 
-  private async writeStateSnapshot(contentHash = hashContent(this.currentContent())): Promise<void> {
+  private async writeStateSnapshot(
+    contentHash = hashContent(this.currentContent()),
+    onTiming?: DocumentSessionTimingHandler,
+  ): Promise<void> {
     if (!this.stateFilePath) return;
     const snapshot: DocumentSessionStateFile = {
       version: DOCUMENT_SESSION_STATE_VERSION,
       contentHash,
       updateBase64: encodeBase64Bytes(Y.encodeStateAsUpdate(this.doc))
     };
+    const stateWriteStartedAt = performance.now();
     await atomicWriteFile(this.stateFilePath, `${JSON.stringify(snapshot)}\n`);
+    emitTiming(onTiming, {
+      stage: 'yjs_state.atomic_write_fsync',
+      durationMs: elapsedMs(stateWriteStartedAt),
+      outcome: 'written',
+    });
+  }
+
+  private async observePersist(
+    persist: Promise<void>,
+    onTiming?: DocumentSessionTimingHandler,
+  ): Promise<void> {
+    await observeTimingCycle(persist, this.persistTimingCycle, onTiming);
+  }
+
+  private recordPersistTiming(event: DocumentSessionTimingEvent): void {
+    recordTimingEvent(this.persistTimingCycle, event);
   }
 
   private async deleteStateSnapshot(): Promise<void> {
@@ -907,6 +1048,70 @@ async function readOptionalFile(filePath: string): Promise<string | undefined> {
 
 function hashContent(content: string): string {
   return createHash('sha256').update(content).digest('hex');
+}
+
+function elapsedMs(startedAt: number): number {
+  return Math.max(0, Math.round((performance.now() - startedAt) * 100) / 100);
+}
+
+function createTimingCycle(): TimingCycle {
+  return {
+    events: [],
+    handlerReferences: new Map(),
+  };
+}
+
+async function observeTimingCycle(
+  operation: Promise<void>,
+  timingCycle: TimingCycle | undefined,
+  handler: DocumentSessionTimingHandler | undefined,
+): Promise<void> {
+  if (!handler || !timingCycle) {
+    await operation;
+    return;
+  }
+
+  const referenceCount = timingCycle.handlerReferences.get(handler) ?? 0;
+  if (referenceCount === 0) {
+    for (const event of timingCycle.events) emitTiming(handler, event);
+  }
+  timingCycle.handlerReferences.set(handler, referenceCount + 1);
+  try {
+    await operation;
+  } finally {
+    const remainingReferences = (timingCycle.handlerReferences.get(handler) ?? 1) - 1;
+    if (remainingReferences === 0) {
+      timingCycle.handlerReferences.delete(handler);
+    } else {
+      timingCycle.handlerReferences.set(handler, remainingReferences);
+    }
+  }
+}
+
+function recordTimingEvent(
+  timingCycle: TimingCycle | undefined,
+  event: DocumentSessionTimingEvent,
+): void {
+  if (!timingCycle) return;
+  if (timingCycle.events.length === TIMING_REPLAY_EVENT_LIMIT) {
+    timingCycle.events.shift();
+  }
+  timingCycle.events.push(event);
+  for (const handler of timingCycle.handlerReferences.keys()) {
+    emitTiming(handler, event);
+  }
+}
+
+function emitTiming(
+  handler: DocumentSessionTimingHandler | undefined,
+  event: DocumentSessionTimingEvent,
+): void {
+  if (!handler) return;
+  try {
+    handler(event);
+  } catch {
+    // Diagnostic observers must never affect document availability or durability.
+  }
 }
 
 function encodeBase64Bytes(bytes: Uint8Array): string {

--- a/packages/doc-session/src/websocket.test.ts
+++ b/packages/doc-session/src/websocket.test.ts
@@ -28,6 +28,7 @@ import {
   encodeAckedSyncUpdate,
   type AttributedSyncUpdate,
   type DocumentSessionEvent,
+  type YjsWebSocketTimingEvent,
   type YjsWebSocketLike
 } from './index.js';
 import { bindYjsWebSocket } from './websocket.js';
@@ -89,10 +90,17 @@ describe('Yjs WebSocket session', () => {
   it('acknowledges a tagged client update only after it is persisted', async () => {
     await mkdir(join(kb1Home, 'demo-vault'), { recursive: true });
     const filePath = join(kb1Home, 'demo-vault', 'acked.md');
-    const session = new OneFileDocumentSession(filePath, { defaultContent: '' });
+    const stateFilePath = join(kb1Home, '.kb1', 'doc-session-state', 'acked.json');
+    const session = new OneFileDocumentSession(filePath, {
+      defaultContent: '',
+      stateFilePath
+    });
     await session.open();
     const socket = new FakeSocket();
-    const binding = await bindYjsWebSocket(session, socket);
+    const timings: YjsWebSocketTimingEvent[] = [];
+    const binding = await bindYjsWebSocket(session, socket, {
+      onTiming: (event) => timings.push(event)
+    });
     const clientDoc = new Y.Doc();
     clientDoc.getText('markdown').insert(0, 'acked browser edit\n');
 
@@ -110,6 +118,18 @@ describe('Yjs WebSocket session', () => {
     const ack = findSyncUpdateAck(socket.sent, 'update-1');
     expect(ack?.ackId).toBe('update-1');
     expect(typeof ack?.ts).toBe('number');
+    expect(timings.map((event) => event.stage)).toEqual(expect.arrayContaining([
+      'document_session.open',
+      'initial_sync.emitted',
+      'markdown.read',
+      'markdown.atomic_write_fsync',
+      'yjs_state.atomic_write_fsync',
+      'save_ack.emitted'
+    ]));
+    const timingStages = timings.map((event) => event.stage);
+    expect(timingStages.lastIndexOf('save_ack.emitted')).toBeGreaterThan(
+      timingStages.lastIndexOf('yjs_state.atomic_write_fsync')
+    );
 
     socket.emitClose();
     await binding.closed;

--- a/packages/doc-session/src/websocket.ts
+++ b/packages/doc-session/src/websocket.ts
@@ -8,6 +8,8 @@ import {
   DOCUMENT_SESSION_UNSAFE_DIVERGENCE_FAILURE,
   DocumentSessionNotFoundError,
   PersistFailedError,
+  type DocumentSessionTimingEvent,
+  type DocumentSessionTimingHandler,
   type OneFileDocumentSession
 } from './session.js';
 import {
@@ -44,13 +46,29 @@ export interface BoundYjsWebSocket {
 
 export interface YjsWebSocketBindingOptions {
   attribution?: DocumentUpdateAttribution;
+  onTiming?: YjsWebSocketTimingHandler;
 }
+
+export type YjsWebSocketTimingEvent =
+  | DocumentSessionTimingEvent
+  | {
+      stage:
+        | 'document_session.open'
+        | 'initial_sync.emitted'
+        | 'synced_marker.emitted'
+        | 'save_ack.emitted';
+      durationMs: number;
+      ackId?: string;
+    };
+
+export type YjsWebSocketTimingHandler = (event: YjsWebSocketTimingEvent) => void;
 
 export async function bindYjsWebSocket(
   session: OneFileDocumentSession,
   socket: YjsWebSocketLike,
   options: YjsWebSocketBindingOptions = {}
 ): Promise<BoundYjsWebSocket> {
+  const bindingStartedAt = performance.now();
   let cleanupStarted = false;
   let sessionReady = false;
   const pendingMessages: unknown[] = [];
@@ -113,6 +131,10 @@ export async function bindYjsWebSocket(
     }
     syncedMessageSent = true;
     sendBytes(socket, encodeSyncedMessage());
+    emitTiming(options.onTiming, {
+      stage: 'synced_marker.emitted',
+      durationMs: elapsedMs(bindingStartedAt),
+    });
   };
 
   const processSyncMessage = (data: unknown) => {
@@ -136,8 +158,14 @@ export async function bindYjsWebSocket(
           return;
         }
         Y.applyUpdate(session.ydoc, ackedUpdate.update, socketUpdateOrigin);
-        void session.flush().then(() => {
+        const saveStartedAt = performance.now();
+        void session.flush({ onTiming: options.onTiming as DocumentSessionTimingHandler | undefined }).then(() => {
           sendBytes(socket, encodeSyncUpdateAck({ ackId: ackedUpdate.ackId, ts: Date.now() }));
+          emitTiming(options.onTiming, {
+            stage: 'save_ack.emitted',
+            durationMs: elapsedMs(saveStartedAt),
+            ackId: ackedUpdate.ackId,
+          });
         }, (error: unknown) => {
           if (error instanceof PersistFailedError) {
             deferredPersistedAckIds.add(ackedUpdate.ackId);
@@ -174,7 +202,15 @@ export async function bindYjsWebSocket(
   socket.on('error', cleanup);
 
   try {
-    await session.open({ createIfMissing: false });
+    const sessionOpenStartedAt = performance.now();
+    await session.open({
+      createIfMissing: false,
+      onTiming: options.onTiming as DocumentSessionTimingHandler | undefined,
+    });
+    emitTiming(options.onTiming, {
+      stage: 'document_session.open',
+      durationMs: elapsedMs(sessionOpenStartedAt),
+    });
   } catch (error) {
     if (error instanceof DocumentSessionNotFoundError) {
       socket.close(DOCUMENT_SESSION_FAILURE_CLOSE_CODE, JSON.stringify(error.failure));
@@ -207,6 +243,10 @@ export async function bindYjsWebSocket(
 
   sendSync(socket, (encoder) => {
     syncProtocol.writeSyncStep1(encoder, session.ydoc);
+  });
+  emitTiming(options.onTiming, {
+    stage: 'initial_sync.emitted',
+    durationMs: elapsedMs(bindingStartedAt),
   });
 
   return { closed };
@@ -300,6 +340,22 @@ function stateVectorsShareClient(left: Map<number, number>, right: Map<number, n
 
 function closeUnsafeDivergence(socket: YjsWebSocketLike): void {
   socket.close(DOCUMENT_SESSION_FAILURE_CLOSE_CODE, JSON.stringify(DOCUMENT_SESSION_UNSAFE_DIVERGENCE_FAILURE));
+}
+
+function elapsedMs(startedAt: number): number {
+  return Math.max(0, Math.round((performance.now() - startedAt) * 100) / 100);
+}
+
+function emitTiming(
+  handler: YjsWebSocketTimingHandler | undefined,
+  event: YjsWebSocketTimingEvent,
+): void {
+  if (!handler) return;
+  try {
+    handler(event);
+  } catch {
+    // Diagnostic observers must never affect document availability or durability.
+  }
 }
 
 function toUint8Array(data: unknown): Uint8Array | undefined {


### PR DESCRIPTION
## What changed

- add privacy-safe, correlated timing across live document restore, sync, save, and close paths
- skip rewriting Yjs state when the restored snapshot is already valid
- preserve authoritative Markdown durability and existing `Saved` semantics
- track in-flight idle closes so shutdown and cleanup remain deterministic

## Why

Hosted document latency was difficult to attribute across the Cloud relay and daemon, and valid restored state was being rewritten unnecessarily. This adds bounded observability while removing avoidable work without changing durability authority.

## Impact

- faster valid-snapshot restore path
- correlated performance evidence without logging document contents or paths
- no hot-document cache enablement and no deployment changes

## Verification

- `pnpm check`
- doc-session test suite: 90 passing
- daemon test suite: 161 passing
- tunnel client test suite: 47 passing
- Yjs and release smoke tests
- structured autoreview; accepted findings fixed and affected checks rerun
