### PR TITLE
fix(doc-session): fence terminal sessions and serialize path mutations

### DIFF
--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -1,4 +1,5 @@
 import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { EventEmitter } from 'node:events';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -8,8 +9,16 @@ import { WebSocket } from 'ws';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
-import { DOCUMENT_SESSION_FAILURE_CLOSE_CODE } from '@kb-1/doc-session';
-import { isDaemonCliEntrypoint, startDaemon } from './main.js';
+import {
+  DOCUMENT_SESSION_FAILURE_CLOSE_CODE,
+  type ClientDocumentSession
+} from '@kb-1/doc-session';
+import {
+  bindDocumentWebSocketAfterAttach,
+  isDaemonCliEntrypoint,
+  startDaemon,
+  type AwaitedDocumentWebSocket
+} from './main.js';
 import * as statusModule from './status.js';
 
 describe('daemon startup', () => {
@@ -42,6 +51,36 @@ describe('daemon startup', () => {
     await expect(access(join(kb1Home, 'daemon', 'status.json'))).rejects.toBeTruthy();
 
     await close(blocker);
+  });
+
+  it('releases a delayed document lease when its socket closes before attachment', async () => {
+    let resolveLease: ((lease: ClientDocumentSession) => void) | undefined;
+    const leasePromise = new Promise<ClientDocumentSession>((resolve) => {
+      resolveLease = resolve;
+    });
+    const release = vi.fn();
+    const socketEvents = new EventEmitter();
+    const socket = Object.assign(socketEvents, {
+      readyState: 1,
+      send: vi.fn(),
+      close: vi.fn(),
+    }) as unknown as AwaitedDocumentWebSocket;
+    const bind = vi.fn(async () => ({ closed: Promise.resolve() }));
+
+    const lifecycle = bindDocumentWebSocketAfterAttach(
+      () => leasePromise,
+      socket,
+      {},
+      () => {},
+      bind as never
+    );
+    socketEvents.emit('close');
+    (socket as { readyState: number }).readyState = 3;
+    resolveLease?.({ session: {} as ClientDocumentSession['session'], release });
+
+    await expect(lifecycle).resolves.toBeUndefined();
+    expect(bind).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledOnce();
   });
 
   it('ignores KB2_* env vars during startup', async () => {

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -2,8 +2,11 @@
 import { serve } from '@hono/node-server';
 import {
   bindYjsWebSocket,
+  type ClientDocumentSession,
   type DocumentSessionManager,
   type DocumentUpdateAttribution,
+  type YjsWebSocketBindingOptions,
+  type YjsWebSocketLike,
   type YjsWebSocketTimingEvent
 } from '@kb-1/doc-session';
 import { createLocalMcpEndpoint } from '@kb-1/local-mcp';
@@ -282,29 +285,24 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Sta
         // set synchronously, before any await. Shutdown must wait for a connection
         // that is still opening, or its in-flight state write can outlive teardown.
         const lifecycle = (async () => {
-          const bindingLease = target.manager.attachClientSession(target.documentPath);
-          if (documentTraceId) {
-            logDocumentTiming(documentTraceId, documentTimingStartedAt, {
-              stage: 'document_session.attached',
-              durationMs: elapsedDocumentTimingMs(documentTimingStartedAt)
-            });
-          }
           try {
-            const binding = await bindYjsWebSocket(
-              bindingLease.session,
+            await bindDocumentWebSocketAfterAttach(
+              () => target.manager.attachClientSession(target.documentPath),
               webSocket,
               {
                 ...(attribution.attribution ? { attribution: attribution.attribution } : {}),
                 ...(onDocumentTiming ? { onTiming: onDocumentTiming } : {})
+              },
+              () => {
+                if (documentTraceId) {
+                  logDocumentTiming(documentTraceId, documentTimingStartedAt, {
+                    stage: 'document_session.attached',
+                    durationMs: elapsedDocumentTimingMs(documentTimingStartedAt)
+                  });
+                }
               }
             );
-            try {
-              await binding.closed;
-            } finally {
-              bindingLease.release();
-            }
           } catch (error) {
-            bindingLease.release();
             console.error(error);
             webSocket.close(1011, 'Document session failed to open');
           }
@@ -318,6 +316,50 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Sta
 
     server.once('error', fail);
   });
+}
+
+export interface AwaitedDocumentWebSocket extends YjsWebSocketLike {
+  once(event: 'close' | 'error', listener: () => void): this;
+  off(event: 'close' | 'error', listener: () => void): this;
+}
+
+export async function bindDocumentWebSocketAfterAttach(
+  attach: () => Promise<ClientDocumentSession>,
+  socket: AwaitedDocumentWebSocket,
+  options: YjsWebSocketBindingOptions = {},
+  onAttached: () => void = () => {},
+  bind: typeof bindYjsWebSocket = bindYjsWebSocket
+): Promise<void> {
+  let lease: ClientDocumentSession | undefined;
+  let closedBeforeBinding = socket.readyState !== 1;
+  let observingEarlyClose = true;
+  const observeEarlyClose = (): void => {
+    closedBeforeBinding = true;
+  };
+  socket.once('close', observeEarlyClose);
+  socket.once('error', observeEarlyClose);
+
+  try {
+    lease = await attach();
+    onAttached();
+    if (closedBeforeBinding || socket.readyState !== 1) {
+      return;
+    }
+
+    // bindYjsWebSocket installs its own close/error listeners synchronously
+    // before its first await, so transferring observation here has no event gap.
+    socket.off('close', observeEarlyClose);
+    socket.off('error', observeEarlyClose);
+    observingEarlyClose = false;
+    const binding = await bind(lease.session, socket, options);
+    await binding.closed;
+  } finally {
+    if (observingEarlyClose) {
+      socket.off('close', observeEarlyClose);
+      socket.off('error', observeEarlyClose);
+    }
+    lease?.release();
+  }
 }
 
 async function migrateLegacyDaemonHome(kb1Home: string): Promise<void> {

--- a/packages/doc-session/src/index.ts
+++ b/packages/doc-session/src/index.ts
@@ -21,6 +21,7 @@ export {
 export {
   DEFAULT_IDLE_SESSION_GRACE_MS,
   DocumentSessionManager,
+  DocumentSessionPathConflictError,
   type ClientDocumentSession,
   type FlushDocumentSessionsResult,
   type DocumentSessionManagerOptions

--- a/packages/doc-session/src/manager.ts
+++ b/packages/doc-session/src/manager.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 
+import { statOrNull } from '@kb-1/vault-core';
+
 import { OneFileDocumentSession, type DocumentSessionEventHandler, type OneFileDocumentSessionOptions } from './session.js';
 
 export const DEFAULT_IDLE_SESSION_GRACE_MS = 30_000;
@@ -20,15 +22,29 @@ export interface FlushDocumentSessionsResult {
   flushed: number;
 }
 
+export class DocumentSessionPathConflictError extends Error {
+  constructor(
+    readonly fromPath: string,
+    readonly toPath: string
+  ) {
+    super(`Document session destination is already active: ${toPath}`);
+    this.name = 'DocumentSessionPathConflictError';
+  }
+}
+
 interface DocumentSessionManagerRuntimeSurface {
   onEvent(handler: DocumentSessionEventHandler): () => void;
-  attachClientSession(vaultPath: string): ClientDocumentSession;
+  attachClientSession(vaultPath: string): Promise<ClientDocumentSession>;
   withSession<T>(
     vaultPath: string,
     operation: (session: OneFileDocumentSession) => Promise<T>,
     options?: Partial<Pick<OneFileDocumentSessionOptions, 'defaultContent'>>
   ): Promise<T>;
   getOpenSession(vaultPath: string): OneFileDocumentSession | undefined;
+  withStablePath<T>(
+    vaultPath: string,
+    operation: (liveSession: OneFileDocumentSession | undefined) => Promise<T>
+  ): Promise<T>;
   getOpenSessionCount(): number;
   flushDirtySessions(): Promise<FlushDocumentSessionsResult>;
   moveSession(fromPath: string, toPath: string, moveOnDisk: () => Promise<void>): Promise<boolean>;
@@ -37,15 +53,28 @@ interface DocumentSessionManagerRuntimeSurface {
   close(): Promise<void>;
 }
 
+interface PathReservation {
+  readonly matches: (vaultPath: string) => boolean;
+  readonly settled: Promise<void>;
+  readonly release: () => void;
+}
+
 export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurface {
   private readonly root: string;
   private readonly options: Omit<OneFileDocumentSessionOptions, 'eventPath'>;
   private readonly idleSessionGraceMs: number;
   private readonly sessions = new Map<string, OneFileDocumentSession>();
-  private readonly clientCounts = new Map<string, number>();
+  private readonly clientCounts = new Map<OneFileDocumentSession, number>();
+  private readonly operationCounts = new Map<OneFileDocumentSession, number>();
+  private readonly activeSessionOperations = new Set<Promise<void>>();
   private readonly idleCloseTimers = new Map<string, NodeJS.Timeout>();
   private readonly closingSessions = new Set<Promise<void>>();
   private readonly eventHandlers = new Set<DocumentSessionEventHandler>();
+  private readonly pathReservations = new Set<PathReservation>();
+  private structureMutationTail: Promise<void> = Promise.resolve();
+  private closePromise: Promise<void> | undefined;
+  private closing = false;
+  private closed = false;
 
   constructor(options: DocumentSessionManagerOptions) {
     this.root = options.root;
@@ -62,6 +91,10 @@ export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurf
   }
 
   getSession(vaultPath: string, overrides: Partial<Pick<OneFileDocumentSessionOptions, 'defaultContent'>> = {}): OneFileDocumentSession {
+    this.assertActive();
+    if (this.hasPathReservation(vaultPath)) {
+      throw new Error(`Document session path is transitioning: ${vaultPath}`);
+    }
     this.cancelIdleClose(vaultPath);
     const existing = this.sessions.get(vaultPath);
     if (existing) return existing;
@@ -86,25 +119,30 @@ export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurf
     return session;
   }
 
-  attachClientSession(vaultPath: string): ClientDocumentSession {
-    const session = this.getSession(vaultPath);
-    this.cancelIdleClose(vaultPath);
-    this.clientCounts.set(vaultPath, (this.clientCounts.get(vaultPath) ?? 0) + 1);
-    let released = false;
-    return {
-      session,
-      release: () => {
-        if (released) return;
-        released = true;
-        const nextCount = (this.clientCounts.get(vaultPath) ?? 1) - 1;
-        if (nextCount > 0) {
-          this.clientCounts.set(vaultPath, nextCount);
-          return;
+  async attachClientSession(vaultPath: string): Promise<ClientDocumentSession> {
+    return this.withAvailablePath(vaultPath, () => {
+      const session = this.getSession(vaultPath);
+      this.cancelIdleClose(vaultPath);
+      this.clientCounts.set(session, (this.clientCounts.get(session) ?? 0) + 1);
+      let released = false;
+      return {
+        session,
+        release: () => {
+          if (released) return;
+          released = true;
+          const currentPath = this.findSessionPath(session) ?? vaultPath;
+          const nextCount = (this.clientCounts.get(session) ?? 1) - 1;
+          if (nextCount > 0) {
+            this.clientCounts.set(session, nextCount);
+            return;
+          }
+          this.clientCounts.delete(session);
+          if (!this.hasActiveOperations(session)) {
+            this.scheduleIdleClose(currentPath);
+          }
         }
-        this.clientCounts.delete(vaultPath);
-        this.scheduleIdleClose(vaultPath);
-      }
-    };
+      };
+    });
   }
 
   async withSession<T>(
@@ -112,21 +150,40 @@ export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurf
     operation: (session: OneFileDocumentSession) => Promise<T>,
     options: Partial<Pick<OneFileDocumentSessionOptions, 'defaultContent'>> = {}
   ): Promise<T> {
-    this.cancelIdleClose(vaultPath);
-    const session = this.getSession(vaultPath, options);
-    try {
-      return await operation(session);
-    } finally {
-      if (!this.hasClients(vaultPath)) {
-        this.scheduleIdleClose(vaultPath);
-      }
-    }
+    return this.withAvailablePath(vaultPath, () => {
+      this.cancelIdleClose(vaultPath);
+      const session = this.getSession(vaultPath, options);
+      return this.runSessionOperation(vaultPath, session, operation);
+    });
   }
 
   getOpenSession(vaultPath: string): OneFileDocumentSession | undefined {
+    if (this.closing) return undefined;
+    if (this.hasPathReservation(vaultPath)) {
+      throw new Error(`Document session path is transitioning: ${vaultPath}`);
+    }
     const session = this.sessions.get(vaultPath);
     if (!session?.isOpened()) return undefined;
     return session;
+  }
+
+  async withStablePath<T>(
+    vaultPath: string,
+    operation: (liveSession: OneFileDocumentSession | undefined) => Promise<T>
+  ): Promise<T> {
+    const pathAlreadyReserved = this.hasPathReservation(vaultPath);
+    const pathReservation = this.reserveExactPaths([vaultPath]);
+    const sessionAtReservation = pathAlreadyReserved ? undefined : this.sessions.get(vaultPath);
+    const openReservation = sessionAtReservation?.reserveStableOpenState();
+    return this.runStructureMutation(pathReservation, () => {
+      const session = this.sessions.get(vaultPath);
+      if (openReservation && session === sessionAtReservation) {
+        return openReservation.run((opened) => operation(opened ? session : undefined));
+      }
+      openReservation?.release();
+      if (!session) return operation(undefined);
+      return session.withStableOpenState((opened) => operation(opened ? session : undefined));
+    });
   }
 
   getOpenSessionCount(): number {
@@ -148,13 +205,26 @@ export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurf
     toPath: string,
     moveOnDisk: () => Promise<void>
   ): Promise<boolean> {
-    const session = this.sessions.get(fromPath);
-    if (!session) return false;
+    return this.runStructureMutation(this.reserveExactPaths([fromPath, toPath]), async () => {
+      const session = this.sessions.get(fromPath);
+      const sourceStat = await statOrNull(this.toFilePath(fromPath));
+      if (!sourceStat?.isFile()) {
+        await moveOnDisk();
+        return false;
+      }
+      const destination = this.sessions.get(toPath);
+      if (destination && destination !== session) {
+        throw new DocumentSessionPathConflictError(fromPath, toPath);
+      }
+      if (!session) {
+        await moveOnDisk();
+        return false;
+      }
 
-    await session.moveTo(this.toFilePath(toPath), toPath, moveOnDisk, this.toStateFilePath(toPath));
-    this.sessions.delete(fromPath);
-    this.sessions.set(toPath, session);
-    return true;
+      await session.moveTo(this.toFilePath(toPath), toPath, moveOnDisk, this.toStateFilePath(toPath));
+      this.rekeySession(fromPath, toPath, session);
+      return true;
+    });
   }
 
   async moveSessionSubtree(
@@ -162,31 +232,54 @@ export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurf
     toFolder: string,
     moveOnDisk: () => Promise<void>
   ): Promise<string[]> {
-    const moved: string[] = [];
-    const matches = [...this.sessions.entries()]
-      .filter(([path]) => path.startsWith(`${fromFolder}/`))
-      .sort(([left], [right]) => left.localeCompare(right));
-    if (matches.length === 0) {
-      await moveOnDisk();
-      return moved;
-    }
+    return this.runStructureMutation(this.reserveSubtrees([fromFolder, toFolder]), async () => {
+      const moved: string[] = [];
+      const sourceStat = await statOrNull(this.toFilePath(fromFolder));
+      if (!sourceStat?.isDirectory()) {
+        await moveOnDisk();
+        return moved;
+      }
+      const matches = [...this.sessions.entries()]
+        .filter(([path]) => path.startsWith(`${fromFolder}/`))
+        .sort(([left], [right]) => left.localeCompare(right));
+      const sourceSessions = new Set(matches.map(([, session]) => session));
+      const destinationCollision = [...this.sessions.entries()].find(([path, session]) => (
+        (path === toFolder || path.startsWith(`${toFolder}/`)) && !sourceSessions.has(session)
+      ));
+      if (destinationCollision) {
+        throw new DocumentSessionPathConflictError(fromFolder, destinationCollision[0]);
+      }
+      if (matches.length === 0) {
+        await moveOnDisk();
+        return moved;
+      }
 
-    // All live child sessions share one disk move; each session then completes its own in-memory path rebinding after that promise settles.
-    await Promise.all(matches.map(([, session]) => session.prepareForPathTransition()));
-    const diskMove = Promise.resolve().then(moveOnDisk);
-    await Promise.all(matches.map(async ([fromPath, session]) => {
-      const toPath = `${toFolder}/${fromPath.slice(fromFolder.length + 1)}`;
-      await session.completeMoveAfterTransition(this.toFilePath(toPath), toPath, diskMove, this.toStateFilePath(toPath));
-      this.sessions.delete(fromPath);
-      this.sessions.set(toPath, session);
-      moved.push(toPath);
-    }));
-    return moved;
+      // All live child sessions share one disk move; each session then completes its own in-memory path rebinding after that promise settles.
+      await Promise.all(matches.map(([, session]) => session.prepareForPathTransition()));
+      const diskMove = Promise.resolve().then(moveOnDisk);
+      await Promise.all(matches.map(async ([fromPath, session]) => {
+        const toPath = `${toFolder}/${fromPath.slice(fromFolder.length + 1)}`;
+        await session.completeMoveAfterTransition(this.toFilePath(toPath), toPath, diskMove, this.toStateFilePath(toPath));
+        this.rekeySession(fromPath, toPath, session);
+        moved.push(toPath);
+      }));
+      return moved;
+    });
   }
 
   async deleteSession(path: string, deleteOnDisk: () => Promise<void>): Promise<boolean> {
+    return this.runStructureMutation(
+      this.reserveExactPaths([path]),
+      () => this.deleteSessionUnlocked(path, deleteOnDisk)
+    );
+  }
+
+  private async deleteSessionUnlocked(path: string, deleteOnDisk: () => Promise<void>): Promise<boolean> {
     const session = this.sessions.get(path);
-    if (!session) return false;
+    if (!session) {
+      await deleteOnDisk();
+      return false;
+    }
 
     await session.deleteWith(deleteOnDisk);
     this.sessions.delete(path);
@@ -194,36 +287,148 @@ export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurf
   }
 
   async deleteSessionSubtree(folderPath: string, deleteOnDisk: () => Promise<void>): Promise<string[]> {
-    const matches = [...this.sessions.keys()]
-      .filter((path) => path.startsWith(`${folderPath}/`))
-      .sort();
-    let diskDeleted = false;
-    const deleted: string[] = [];
+    return this.runStructureMutation(this.reserveSubtrees([folderPath]), async () => {
+      const matches = [...this.sessions.keys()]
+        .filter((path) => path.startsWith(`${folderPath}/`))
+        .sort();
+      let diskDeleted = false;
+      const deleted: string[] = [];
 
-    for (const path of matches) {
-      await this.deleteSession(path, async () => {
-        if (diskDeleted) return;
-        diskDeleted = true;
+      for (const path of matches) {
+        await this.deleteSessionUnlocked(path, async () => {
+          if (diskDeleted) return;
+          diskDeleted = true;
+          await deleteOnDisk();
+        });
+        deleted.push(path);
+      }
+
+      if (!diskDeleted) {
         await deleteOnDisk();
-      });
-      deleted.push(path);
-    }
+      }
+      return deleted;
+    });
+  }
 
-    if (!diskDeleted) {
-      await deleteOnDisk();
-    }
-    return deleted;
+  private async runStructureMutation<T>(reservation: PathReservation, mutation: () => Promise<T>): Promise<T> {
+    this.assertActive();
+    const result = this.structureMutationTail.then(mutation).finally(reservation.release);
+    this.structureMutationTail = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
   }
 
   async close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+    this.closing = true;
+    const closeWork = this.structureMutationTail.then(() => this.closeUnlocked());
+    this.closePromise = closeWork.then(
+      () => {
+        this.closed = true;
+      },
+      (error: unknown) => {
+        this.closing = false;
+        for (const [vaultPath, session] of this.sessions.entries()) {
+          session.resumeAfterCloseFailure();
+          if (!this.isSessionInUse(session)) {
+            this.scheduleIdleClose(vaultPath);
+          }
+        }
+        this.closePromise = undefined;
+        throw error;
+      }
+    );
+    this.structureMutationTail = this.closePromise.then(
+      () => undefined,
+      () => undefined
+    );
+    return this.closePromise;
+  }
+
+  private async closeUnlocked(): Promise<void> {
     for (const timer of this.idleCloseTimers.values()) {
       clearTimeout(timer);
     }
     this.idleCloseTimers.clear();
     await Promise.allSettled([...this.closingSessions]);
-    await Promise.all([...this.sessions.values()].map((session) => session.close()));
+    await Promise.allSettled([...this.activeSessionOperations]);
+    const closeResults = await Promise.allSettled([...this.sessions.values()].map((session) => session.close()));
+    const rejectedClose = closeResults.find((result) => result.status === 'rejected');
+    if (rejectedClose) {
+      throw rejectedClose.reason;
+    }
     this.sessions.clear();
     this.clientCounts.clear();
+    this.operationCounts.clear();
+    this.activeSessionOperations.clear();
+  }
+
+  private reserveExactPaths(paths: string[]): PathReservation {
+    return this.createPathReservation((vaultPath) => paths.includes(vaultPath));
+  }
+
+  private reserveSubtrees(folders: string[]): PathReservation {
+    return this.createPathReservation((vaultPath) => (
+      folders.some((folder) => vaultPath === folder || vaultPath.startsWith(`${folder}/`))
+    ));
+  }
+
+  private createPathReservation(matches: (vaultPath: string) => boolean): PathReservation {
+    this.assertActive();
+    let releaseReservation: (() => void) | undefined;
+    const settled = new Promise<void>((resolve) => {
+      releaseReservation = resolve;
+    });
+    let released = false;
+    const reservation: PathReservation = {
+      matches,
+      settled,
+      release: () => {
+        if (released) return;
+        released = true;
+        this.pathReservations.delete(reservation);
+        releaseReservation?.();
+      }
+    };
+    this.pathReservations.add(reservation);
+    return reservation;
+  }
+
+  private hasPathReservation(vaultPath: string): boolean {
+    return [...this.pathReservations].some((reservation) => reservation.matches(vaultPath));
+  }
+
+  private async waitForPathAvailability(vaultPath: string): Promise<void> {
+    this.assertActive();
+    while (true) {
+      const reservations = [...this.pathReservations]
+        .filter((reservation) => reservation.matches(vaultPath));
+      if (reservations.length === 0) return;
+      await Promise.all(reservations.map((reservation) => reservation.settled));
+      this.assertActive();
+    }
+  }
+
+  private async withAvailablePath<T>(vaultPath: string, operation: () => T | Promise<T>): Promise<T> {
+    while (true) {
+      await this.waitForPathAvailability(vaultPath);
+      try {
+        return operation();
+      } catch (error) {
+        if (this.hasPathReservation(vaultPath)) continue;
+        throw error;
+      }
+    }
+  }
+
+  private assertActive(): void {
+    if (this.closing || this.closed) {
+      throw new Error('Document session manager is closed.');
+    }
   }
 
   private emitEvent(event: Parameters<DocumentSessionEventHandler>[0]): void {
@@ -244,8 +449,62 @@ export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurf
     return join(this.root, DOCUMENT_SESSION_STATE_DIR, `${hashVaultPath(vaultPath)}.json`);
   }
 
-  private hasClients(vaultPath: string): boolean {
-    return (this.clientCounts.get(vaultPath) ?? 0) > 0;
+  private hasActiveOperations(session: OneFileDocumentSession): boolean {
+    return (this.operationCounts.get(session) ?? 0) > 0;
+  }
+
+  private isSessionInUse(session: OneFileDocumentSession): boolean {
+    return (this.clientCounts.get(session) ?? 0) > 0 || this.hasActiveOperations(session);
+  }
+
+  private runSessionOperation<T>(
+    vaultPath: string,
+    session: OneFileDocumentSession,
+    operation: (session: OneFileDocumentSession) => Promise<T>
+  ): Promise<T> {
+    this.operationCounts.set(session, (this.operationCounts.get(session) ?? 0) + 1);
+    const result = (async () => {
+      try {
+        return await operation(session);
+      } finally {
+        const remaining = (this.operationCounts.get(session) ?? 1) - 1;
+        if (remaining > 0) {
+          this.operationCounts.set(session, remaining);
+        } else {
+          this.operationCounts.delete(session);
+        }
+        const currentPath = this.findSessionPath(session) ?? vaultPath;
+        if (!this.isSessionInUse(session)) {
+          this.scheduleIdleClose(currentPath);
+        }
+      }
+    })();
+    const lifecycle = result.then(
+      () => undefined,
+      () => undefined
+    );
+    this.activeSessionOperations.add(lifecycle);
+    void lifecycle.finally(() => {
+      this.activeSessionOperations.delete(lifecycle);
+    });
+    return result;
+  }
+
+  private findSessionPath(session: OneFileDocumentSession): string | undefined {
+    for (const [vaultPath, candidate] of this.sessions.entries()) {
+      if (candidate === session) return vaultPath;
+    }
+    return undefined;
+  }
+
+  private rekeySession(fromPath: string, toPath: string, session: OneFileDocumentSession): void {
+    this.cancelIdleClose(fromPath);
+    this.cancelIdleClose(toPath);
+    this.sessions.delete(fromPath);
+    this.sessions.set(toPath, session);
+    if (!this.isSessionInUse(session)) {
+      this.scheduleIdleClose(toPath);
+    }
   }
 
   private cancelIdleClose(vaultPath: string): void {
@@ -256,9 +515,11 @@ export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurf
   }
 
   private scheduleIdleClose(vaultPath: string): void {
-    if (this.hasClients(vaultPath) || !this.sessions.has(vaultPath)) return;
+    if (this.closing || this.closed) return;
+    const session = this.sessions.get(vaultPath);
+    if (!session || this.isSessionInUse(session)) return;
     this.cancelIdleClose(vaultPath);
-    if (!this.sessions.get(vaultPath)?.isOpened()) {
+    if (!session.isOpened()) {
       this.sessions.delete(vaultPath);
       return;
     }
@@ -277,11 +538,19 @@ export class DocumentSessionManager implements DocumentSessionManagerRuntimeSurf
     this.idleCloseTimers.set(vaultPath, timer);
   }
 
-  private async closeSession(vaultPath: string): Promise<void> {
+  private closeSession(vaultPath: string): Promise<void> {
+    if (this.closing) return Promise.resolve();
+    return this.runStructureMutation(
+      this.reserveExactPaths([vaultPath]),
+      () => this.closeSessionUnlocked(vaultPath)
+    );
+  }
+
+  private async closeSessionUnlocked(vaultPath: string): Promise<void> {
     this.cancelIdleClose(vaultPath);
-    if (this.hasClients(vaultPath)) return;
     const session = this.sessions.get(vaultPath);
     if (!session) return;
+    if (this.isSessionInUse(session)) return;
     if (session.hasActivePersistFailure()) {
       console.warn(`KB-1 refused to close idle document session for ${vaultPath}; content is not durably persisted.`);
       return;

--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -7,6 +7,7 @@ import * as Y from 'yjs';
 
 import { createFastDiffYTextDelta, resolveWatchDirectory } from './session.js';
 import {
+  DocumentSessionNotFoundError,
   OneFileDocumentSession,
   DocumentSessionManager,
   type DocumentSessionEvent,
@@ -476,7 +477,9 @@ describe('OneFileDocumentSession', () => {
     await writeFileWithParents(filePath, 'start\n');
     const session = new OneFileDocumentSession(filePath, {
       watchDebounceMs: 50,
-      watchPollMs: 10_000
+      // Keep the test valid when the host cannot allocate another native
+      // watcher; the production fallback must preserve the same coalescing.
+      watchPollMs: 250
     });
     session.onEvent((event) => events.push(event));
     await session.open();
@@ -532,7 +535,7 @@ describe('OneFileDocumentSession', () => {
     );
 
     expect(eventKinds(events)).toEqual(['doc-deleted']);
-    await expect(session.getContent()).resolves.toBe('do not silently empty me\n');
+    await expect(session.getContent()).rejects.toBeInstanceOf(DocumentSessionNotFoundError);
     await session.close();
   });
 
@@ -676,6 +679,531 @@ describe('OneFileDocumentSession', () => {
     await session.close();
   });
 
+  it('serializes deletion behind an in-flight move transition', async () => {
+    const events: DocumentSessionEvent[] = [];
+    const targetPath = join(kb1Home, 'demo-vault', 'renamed-after-delete.md');
+    const session = new OneFileDocumentSession(filePath, {
+      defaultContent: 'base\n',
+      eventPath: 'hello-world.md'
+    });
+    session.onEvent((event) => events.push(event));
+    await session.open();
+
+    let resolveTransition: (() => void) | undefined;
+    const transition = new Promise<void>((resolve) => {
+      resolveTransition = resolve;
+    });
+    const move = session.completeMoveAfterTransition(
+      targetPath,
+      'renamed-after-delete.md',
+      transition
+    );
+    const deletion = session.deleteWith(async () => {
+      await rm(targetPath, { force: true });
+    });
+    resolveTransition?.();
+
+    await expect(move).resolves.toBeUndefined();
+    await expect(deletion).resolves.toBeUndefined();
+    await expect(readFile(targetPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(events).toContainEqual(expect.objectContaining({ kind: 'doc-deleted' }));
+    expect(events).toContainEqual(expect.objectContaining({ kind: 'doc-moved' }));
+    expect(events.findIndex((event) => event.kind === 'doc-moved'))
+      .toBeLessThan(events.findIndex((event) => event.kind === 'doc-deleted'));
+    await session.close();
+  });
+
+  it('serializes manager structural mutations before resolving a session path', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const targetPath = join(root, 'renamed-before-delete.md');
+    const manager = new DocumentSessionManager({ root, defaultContent: 'base\n' });
+    const session = manager.getSession('hello-world.md');
+    await session.open();
+
+    let announceMoveStarted: (() => void) | undefined;
+    const moveStarted = new Promise<void>((resolve) => {
+      announceMoveStarted = resolve;
+    });
+    let releaseDiskMove: (() => void) | undefined;
+    const diskMoveReleased = new Promise<void>((resolve) => {
+      releaseDiskMove = resolve;
+    });
+    const move = manager.moveSession('hello-world.md', 'renamed-before-delete.md', async () => {
+      announceMoveStarted?.();
+      await diskMoveReleased;
+      await rename(filePath, targetPath);
+    });
+    await moveStarted;
+
+    const deleteOnDisk = vi.fn(async () => {
+      await rm(filePath, { force: true });
+    });
+    const deletion = manager.deleteSession('hello-world.md', deleteOnDisk);
+    releaseDiskMove?.();
+
+    await expect(move).resolves.toBe(true);
+    await expect(deletion).resolves.toBe(false);
+    expect(deleteOnDisk).toHaveBeenCalledOnce();
+    await expect(readFile(targetPath, 'utf8')).resolves.toBe('base\n');
+    await expect(session.getContent()).resolves.toBe('base\n');
+    await manager.close();
+  });
+
+  it('reserves both session paths while a move is in flight and attaches to the rekeyed session', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const targetPath = join(root, 'reserved-target.md');
+    const manager = new DocumentSessionManager({
+      root,
+      defaultContent: 'base\n',
+      idleSessionGraceMs: 1
+    });
+    const originalLease = await manager.attachClientSession('hello-world.md');
+    await originalLease.session.open();
+
+    let announceMoveStarted: (() => void) | undefined;
+    const moveStarted = new Promise<void>((resolve) => {
+      announceMoveStarted = resolve;
+    });
+    let releaseDiskMove: (() => void) | undefined;
+    const diskMoveReleased = new Promise<void>((resolve) => {
+      releaseDiskMove = resolve;
+    });
+    const move = manager.moveSession('hello-world.md', 'reserved-target.md', async () => {
+      announceMoveStarted?.();
+      await diskMoveReleased;
+      await rename(filePath, targetPath);
+    });
+    await moveStarted;
+
+    expect(() => manager.getSession('hello-world.md')).toThrow('path is transitioning');
+    expect(() => manager.getSession('reserved-target.md')).toThrow('path is transitioning');
+    let attached = false;
+    const destinationLeasePromise = manager.attachClientSession('reserved-target.md').then((lease) => {
+      attached = true;
+      return lease;
+    });
+    await Promise.resolve();
+    expect(attached).toBe(false);
+
+    releaseDiskMove?.();
+    await expect(move).resolves.toBe(true);
+    const destinationLease = await destinationLeasePromise;
+    expect(destinationLease.session).toBe(originalLease.session);
+
+    originalLease.release();
+    destinationLease.release();
+    await waitUntil(() => manager.getOpenSessionCount() === 0, () =>
+      `Timed out waiting for rekeyed client leases to close; count=${manager.getOpenSessionCount()}`
+    );
+    await manager.close();
+  });
+
+  it('drains an in-flight external check before starting the disk move', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const targetPath = join(root, 'after-external-check.md');
+    const manager = new DocumentSessionManager({ root, defaultContent: 'base\n' });
+    const session = manager.getSession('hello-world.md');
+    await session.open();
+    let releaseExternalCheck: (() => void) | undefined;
+    const externalCheck = new Promise<void>((resolve) => {
+      releaseExternalCheck = resolve;
+    });
+    (session as unknown as { externalCheckPromise: Promise<void> | undefined })
+      .externalCheckPromise = externalCheck;
+    let diskMoveStarted = false;
+
+    const move = manager.moveSession('hello-world.md', 'after-external-check.md', async () => {
+      diskMoveStarted = true;
+      await rename(filePath, targetPath);
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const diskMoveStartedBeforeDrain = diskMoveStarted;
+
+    releaseExternalCheck?.();
+    await expect(move).resolves.toBe(true);
+    expect(diskMoveStartedBeforeDrain).toBe(false);
+    await expect(readFile(targetPath, 'utf8')).resolves.toBe('base\n');
+    await manager.close();
+  });
+
+  it('drains an in-flight external check before starting disk deletion', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const manager = new DocumentSessionManager({ root, defaultContent: 'base\n' });
+    const session = manager.getSession('hello-world.md');
+    const events: DocumentSessionEvent[] = [];
+    session.onEvent((event) => events.push(event));
+    await session.open();
+    let releaseExternalCheck: (() => void) | undefined;
+    const externalCheck = new Promise<void>((resolve) => {
+      releaseExternalCheck = resolve;
+    });
+    (session as unknown as { externalCheckPromise: Promise<void> | undefined })
+      .externalCheckPromise = externalCheck;
+    let diskDeleteStarted = false;
+
+    const deletion = manager.deleteSession('hello-world.md', async () => {
+      diskDeleteStarted = true;
+      await rm(filePath);
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    const diskDeleteStartedBeforeDrain = diskDeleteStarted;
+
+    releaseExternalCheck?.();
+    await expect(deletion).resolves.toBe(true);
+    expect(diskDeleteStartedBeforeDrain).toBe(false);
+    await expect(readFile(filePath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(eventKinds(events)).toEqual(['doc-deleted']);
+    await manager.close();
+  });
+
+  it('retries acquisition when a structural reservation wins the availability microtask', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const targetPath = join(root, 'atomic-target.md');
+    const manager = new DocumentSessionManager({ root, defaultContent: 'base\n' });
+    const session = manager.getSession('hello-world.md');
+    await session.open();
+
+    const destinationLeasePromise = manager.attachClientSession('atomic-target.md');
+    const move = manager.moveSession('hello-world.md', 'atomic-target.md', async () => {
+      await rename(filePath, targetPath);
+    });
+
+    await expect(move).resolves.toBe(true);
+    const destinationLease = await destinationLeasePromise;
+    expect(destinationLease.session).toBe(session);
+    destinationLease.release();
+    await manager.close();
+  });
+
+  it('holds a stable cold path until its write completes before allowing attachment', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const stableFilePath = join(root, 'stable-cold.md');
+    await mkdir(root, { recursive: true });
+    const manager = new DocumentSessionManager({ root });
+    let announceStableOperation: (() => void) | undefined;
+    const stableOperationStarted = new Promise<void>((resolve) => {
+      announceStableOperation = resolve;
+    });
+    let releaseStableOperation: (() => void) | undefined;
+    const stableOperationReleased = new Promise<void>((resolve) => {
+      releaseStableOperation = resolve;
+    });
+    const stableWrite = manager.withStablePath('stable-cold.md', async (liveSession) => {
+      expect(liveSession).toBeUndefined();
+      announceStableOperation?.();
+      await stableOperationReleased;
+      await writeFile(stableFilePath, 'stable content\n', 'utf8');
+    });
+    await stableOperationStarted;
+
+    let attached = false;
+    const leasePromise = manager.attachClientSession('stable-cold.md').then((lease) => {
+      attached = true;
+      return lease;
+    });
+    await Promise.resolve();
+    expect(attached).toBe(false);
+
+    releaseStableOperation?.();
+    await stableWrite;
+    const lease = await leasePromise;
+    await expect(lease.session.getContent()).resolves.toBe('stable content\n');
+    lease.release();
+    await manager.close();
+  });
+
+  it('waits for an in-progress open before choosing the live stable-path branch', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const manager = new DocumentSessionManager({ root, defaultContent: 'base\n' });
+    const session = manager.getSession('hello-world.md');
+    const openSurface = session as unknown as {
+      readFile(options: { createIfMissing: boolean }): Promise<string>;
+    };
+    const originalReadFile = openSurface.readFile.bind(session);
+    let announceReadStarted: (() => void) | undefined;
+    const readStarted = new Promise<void>((resolve) => {
+      announceReadStarted = resolve;
+    });
+    let releaseRead: (() => void) | undefined;
+    const readReleased = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    openSurface.readFile = async (options) => {
+      announceReadStarted?.();
+      await readReleased;
+      return originalReadFile(options);
+    };
+
+    const opening = session.open();
+    await readStarted;
+    let stableOperationSettled = false;
+    const stableOperation = manager.withStablePath('hello-world.md', async (liveSession) => {
+      expect(liveSession).toBe(session);
+      if (!liveSession) throw new Error('expected the opening session to become live');
+      return liveSession.applyContent('replacement\n');
+    }).then((content) => {
+      stableOperationSettled = true;
+      return content;
+    });
+    await Promise.resolve();
+    expect(stableOperationSettled).toBe(false);
+
+    releaseRead?.();
+    await opening;
+    await expect(stableOperation).resolves.toBe('replacement\n');
+    await expect(readFile(filePath, 'utf8')).resolves.toBe('replacement\n');
+    await manager.close();
+  });
+
+  it('holds a retained unopened session behind an active cold stable-path operation', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const stableFilePath = join(root, 'retained-cold.md');
+    await mkdir(root, { recursive: true });
+    const manager = new DocumentSessionManager({ root });
+    const session = manager.getSession('retained-cold.md');
+    let announceStableOperation: (() => void) | undefined;
+    const stableOperationStarted = new Promise<void>((resolve) => {
+      announceStableOperation = resolve;
+    });
+    let releaseStableOperation: (() => void) | undefined;
+    const stableOperationReleased = new Promise<void>((resolve) => {
+      releaseStableOperation = resolve;
+    });
+    const stableWrite = manager.withStablePath('retained-cold.md', async (liveSession) => {
+      expect(liveSession).toBeUndefined();
+      announceStableOperation?.();
+      await stableOperationReleased;
+      await writeFile(stableFilePath, 'created while stable\n', 'utf8');
+    });
+    await stableOperationStarted;
+
+    let openSettled = false;
+    const opening = session.open({ createIfMissing: false }).then(() => {
+      openSettled = true;
+    });
+    await Promise.resolve();
+    expect(openSettled).toBe(false);
+
+    releaseStableOperation?.();
+    await stableWrite;
+    await opening;
+    await expect(session.getContent()).resolves.toBe('created while stable\n');
+    await manager.close();
+  });
+
+  it('keeps cold file moves and deletes reserved until their disk callbacks finish', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const sourcePath = join(root, 'cold-source.md');
+    const targetPath = join(root, 'cold-target.md');
+    const deletePath = join(root, 'cold-delete.md');
+    await mkdir(root, { recursive: true });
+    await writeFile(sourcePath, 'move content\n', 'utf8');
+    await writeFile(deletePath, 'delete content\n', 'utf8');
+    const manager = new DocumentSessionManager({ root });
+
+    let announceMoveStarted: (() => void) | undefined;
+    const moveStarted = new Promise<void>((resolve) => {
+      announceMoveStarted = resolve;
+    });
+    let releaseMove: (() => void) | undefined;
+    const moveReleased = new Promise<void>((resolve) => {
+      releaseMove = resolve;
+    });
+    const move = manager.moveSession('cold-source.md', 'cold-target.md', async () => {
+      announceMoveStarted?.();
+      await moveReleased;
+      await rename(sourcePath, targetPath);
+    });
+    await moveStarted;
+    let moveAttachSettled = false;
+    const movedLeasePromise = manager.attachClientSession('cold-target.md').then((lease) => {
+      moveAttachSettled = true;
+      return lease;
+    });
+    await Promise.resolve();
+    expect(moveAttachSettled).toBe(false);
+
+    releaseMove?.();
+    await expect(move).resolves.toBe(false);
+    const movedLease = await movedLeasePromise;
+    await expect(movedLease.session.open({ createIfMissing: false })).resolves.toBeUndefined();
+    await expect(movedLease.session.getContent()).resolves.toBe('move content\n');
+    movedLease.release();
+
+    let announceDeleteStarted: (() => void) | undefined;
+    const deleteStarted = new Promise<void>((resolve) => {
+      announceDeleteStarted = resolve;
+    });
+    let releaseDelete: (() => void) | undefined;
+    const deleteReleased = new Promise<void>((resolve) => {
+      releaseDelete = resolve;
+    });
+    const deletion = manager.deleteSession('cold-delete.md', async () => {
+      announceDeleteStarted?.();
+      await deleteReleased;
+      await rm(deletePath);
+    });
+    await deleteStarted;
+    let deleteAttachSettled = false;
+    const deletedLeasePromise = manager.attachClientSession('cold-delete.md').then((lease) => {
+      deleteAttachSettled = true;
+      return lease;
+    });
+    await Promise.resolve();
+    expect(deleteAttachSettled).toBe(false);
+
+    releaseDelete?.();
+    await expect(deletion).resolves.toBe(false);
+    const deletedLease = await deletedLeasePromise;
+    await expect(deletedLease.session.open({ createIfMissing: false }))
+      .rejects.toBeInstanceOf(DocumentSessionNotFoundError);
+    deletedLease.release();
+    await manager.close();
+  });
+
+  it('retries withSession acquisition when a move reserves the target in the same turn', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const targetPath = join(root, 'async-target.md');
+    const manager = new DocumentSessionManager({ root, defaultContent: 'base\n' });
+    const session = manager.getSession('hello-world.md');
+    await session.open();
+
+    const acquiredSession = manager.withSession('async-target.md', async (active) => active);
+    const move = manager.moveSession('hello-world.md', 'async-target.md', async () => {
+      await rename(filePath, targetPath);
+    });
+
+    await expect(move).resolves.toBe(true);
+    await expect(acquiredSession).resolves.toBe(session);
+    await manager.close();
+  });
+
+  it('does not retain a ghost client count when a moved leased session is deleted', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const targetPath = join(root, 'deleted-after-move.md');
+    const manager = new DocumentSessionManager({
+      root,
+      defaultContent: 'base\n',
+      idleSessionGraceMs: 1
+    });
+    const originalLease = await manager.attachClientSession('hello-world.md');
+    await originalLease.session.open();
+
+    await expect(manager.moveSession('hello-world.md', 'deleted-after-move.md', async () => {
+      await rename(filePath, targetPath);
+    })).resolves.toBe(true);
+    await expect(manager.deleteSession('deleted-after-move.md', () => rm(targetPath))).resolves.toBe(true);
+    originalLease.release();
+
+    const replacementLease = await manager.attachClientSession('deleted-after-move.md');
+    await replacementLease.session.open();
+    replacementLease.release();
+    await waitUntil(() => manager.getOpenSessionCount() === 0, () =>
+      `Timed out waiting for replacement session to close; count=${manager.getOpenSessionCount()}`
+    );
+    await manager.close();
+  });
+
+  it('drains an in-flight structural transition before closing and rejects new acquisitions', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const targetPath = join(root, 'moved-before-close.md');
+    const manager = new DocumentSessionManager({ root, defaultContent: 'base\n' });
+    const session = manager.getSession('hello-world.md');
+    await session.open();
+
+    let announceMoveStarted: (() => void) | undefined;
+    const moveStarted = new Promise<void>((resolve) => {
+      announceMoveStarted = resolve;
+    });
+    let releaseDiskMove: (() => void) | undefined;
+    const diskMoveReleased = new Promise<void>((resolve) => {
+      releaseDiskMove = resolve;
+    });
+    const move = manager.moveSession('hello-world.md', 'moved-before-close.md', async () => {
+      announceMoveStarted?.();
+      await diskMoveReleased;
+      await rename(filePath, targetPath);
+    });
+    await moveStarted;
+
+    let closed = false;
+    const close = manager.close().then(() => {
+      closed = true;
+    });
+    await expect(manager.attachClientSession('moved-before-close.md')).rejects.toThrow('manager is closed');
+    await Promise.resolve();
+    expect(closed).toBe(false);
+
+    releaseDiskMove?.();
+    await expect(move).resolves.toBe(true);
+    await expect(close).resolves.toBeUndefined();
+    expect(manager.getOpenSessionCount()).toBe(0);
+    await expect(readFile(targetPath, 'utf8')).resolves.toBe('base\n');
+    expect(() => manager.getSession('moved-before-close.md')).toThrow('manager is closed');
+  });
+
+  it('restores detached sessions after a failed manager close and allows retry', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const retryPath = join(root, 'retry-close.md');
+    const slowPath = join(root, 'slow-close.md');
+    const manager = new DocumentSessionManager({ root, defaultContent: 'base\n' });
+    const session = manager.getSession('retry-close.md');
+    const slowSession = manager.getSession('slow-close.md');
+    await session.open();
+    await slowSession.open();
+    const originalClose = session.close.bind(session);
+    const originalSlowClose = slowSession.close.bind(slowSession);
+    let closeAttempts = 0;
+    let announceSlowCloseStarted: (() => void) | undefined;
+    const slowCloseStarted = new Promise<void>((resolve) => {
+      announceSlowCloseStarted = resolve;
+    });
+    let releaseSlowClose: (() => void) | undefined;
+    const slowCloseReleased = new Promise<void>((resolve) => {
+      releaseSlowClose = resolve;
+    });
+    session.close = async () => {
+      closeAttempts += 1;
+      await originalClose();
+      if (closeAttempts === 1) {
+        throw new Error('transient close failure');
+      }
+    };
+    slowSession.close = async () => {
+      announceSlowCloseStarted?.();
+      await slowCloseReleased;
+      await originalSlowClose();
+    };
+
+    let closeSettled = false;
+    const close = manager.close().then(
+      () => {
+        closeSettled = true;
+      },
+      (error: unknown) => {
+        closeSettled = true;
+        throw error;
+      }
+    );
+    await slowCloseStarted;
+    await Promise.resolve();
+    expect(closeSettled).toBe(false);
+    releaseSlowClose?.();
+    await expect(close).rejects.toThrow('transient close failure');
+    expect(manager.getOpenSession('retry-close.md')).toBe(session);
+    expect(manager.getOpenSession('slow-close.md')).toBe(slowSession);
+    session.ydoc.getText('markdown').insert(session.ydoc.getText('markdown').length, 'after retry\n');
+    slowSession.ydoc.getText('markdown').insert(slowSession.ydoc.getText('markdown').length, 'also recovered\n');
+    await expect(manager.flushDirtySessions()).resolves.toEqual({ flushed: 2 });
+    await expect(readFile(retryPath, 'utf8')).resolves.toBe('base\nafter retry\n');
+    await expect(readFile(slowPath, 'utf8')).resolves.toBe('base\nalso recovered\n');
+
+    await expect(manager.close()).resolves.toBeUndefined();
+    expect(closeAttempts).toBe(2);
+  });
+
   it('rekeys every live session under a moved folder subtree', async () => {
     const manager = new DocumentSessionManager({ root: join(kb1Home, 'demo-vault'), defaultContent: '' });
     const first = manager.getSession('folder/a.md');
@@ -709,7 +1237,8 @@ describe('OneFileDocumentSession', () => {
     await expect(manager.moveSession('missing.md', 'renamed.md', async () => {
       moved = true;
     })).resolves.toBe(false);
-    expect(moved).toBe(false);
+    expect(moved).toBe(true);
+    moved = false;
     await expect(manager.moveSessionSubtree('folder', 'moved/folder', async () => {
       moved = true;
     })).resolves.toEqual([]);
@@ -718,7 +1247,8 @@ describe('OneFileDocumentSession', () => {
     await expect(manager.deleteSession('missing.md', async () => {
       deleted = true;
     })).resolves.toBe(false);
-    expect(deleted).toBe(false);
+    expect(deleted).toBe(true);
+    deleted = false;
     await expect(manager.deleteSessionSubtree('folder', async () => {
       deleted = true;
     })).resolves.toEqual([]);
@@ -732,11 +1262,11 @@ describe('OneFileDocumentSession', () => {
       defaultContent: 'base\n',
       idleSessionGraceMs: 80
     });
-    const first = manager.attachClientSession('idle.md');
+    const first = await manager.attachClientSession('idle.md');
     await first.session.open();
     first.release();
 
-    const second = manager.attachClientSession('idle.md');
+    const second = await manager.attachClientSession('idle.md');
     expect(second.session).toBe(first.session);
     second.release();
 
@@ -751,7 +1281,7 @@ describe('OneFileDocumentSession', () => {
       root: join(kb1Home, 'demo-vault'),
       idleSessionGraceMs: 80
     });
-    const lease = manager.attachClientSession('typo/missing.md');
+    const lease = await manager.attachClientSession('typo/missing.md');
 
     await expect(lease.session.open({ createIfMissing: false })).rejects.toMatchObject({
       failure: {
@@ -776,8 +1306,8 @@ describe('OneFileDocumentSession', () => {
       defaultContent: '',
       idleSessionGraceMs: 30
     });
-    const first = manager.attachClientSession('leased.md');
-    const second = manager.attachClientSession('leased.md');
+    const first = await manager.attachClientSession('leased.md');
+    const second = await manager.attachClientSession('leased.md');
     await first.session.open();
 
     try {
@@ -801,7 +1331,7 @@ describe('OneFileDocumentSession', () => {
       defaultContent: '',
       idleSessionGraceMs: 1
     });
-    const lease = manager.attachClientSession('flush-before-close.md');
+    const lease = await manager.attachClientSession('flush-before-close.md');
     await lease.session.open();
     lease.session.ydoc.getText('markdown').insert(0, 'pending before close\n');
     lease.release();
@@ -820,7 +1350,7 @@ describe('OneFileDocumentSession', () => {
       defaultContent: 'base\n',
       idleSessionGraceMs: 20
     });
-    const lease = manager.attachClientSession('readonly.md');
+    const lease = await manager.attachClientSession('readonly.md');
     await lease.session.open();
     const vaultDir = join(kb1Home, 'demo-vault');
 
@@ -901,7 +1431,7 @@ describe('OneFileDocumentSession', () => {
       defaultContent: 'client\n',
       idleSessionGraceMs: 10
     });
-    const lease = manager.attachClientSession('client-held.md');
+    const lease = await manager.attachClientSession('client-held.md');
     await lease.session.open();
 
     await manager.withSession('client-held.md', async (session) => {
@@ -917,7 +1447,7 @@ describe('OneFileDocumentSession', () => {
     await manager.close();
   });
 
-  it('hydrates a fresh session when a client attaches while idle close is in flight', async () => {
+  it('keeps the path reserved while idle close drains before hydrating a fresh session', async () => {
     const manager = new DocumentSessionManager({
       root: join(kb1Home, 'demo-vault'),
       defaultContent: 'base\n',
@@ -945,13 +1475,20 @@ describe('OneFileDocumentSession', () => {
     });
     await closeStartedPromise;
 
-    const attachedDuringClose = manager.attachClientSession('closing.md');
+    let attachSettled = false;
+    const attachedDuringClosePromise = manager.attachClientSession('closing.md').then((lease) => {
+      attachSettled = true;
+      return lease;
+    });
+    await Promise.resolve();
+    expect(attachSettled).toBe(false);
+    allowClose();
+    const attachedDuringClose = await attachedDuringClosePromise;
     try {
       expect(attachedDuringClose.session).not.toBe(original);
       await attachedDuringClose.session.open();
       expect(manager.getOpenSession('closing.md')).toBe(attachedDuringClose.session);
     } finally {
-      allowClose();
       attachedDuringClose.release();
       await waitUntil(() => manager.getOpenSessionCount() === 0, () =>
         `Timed out waiting for fresh attached session to close; count=${manager.getOpenSessionCount()}`
@@ -1047,6 +1584,68 @@ describe('OneFileDocumentSession', () => {
     await manager.close();
   });
 
+  it('keeps a rekeyed session open until its active manager operation finishes', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const targetPath = join(root, 'active-operation-moved.md');
+    const manager = new DocumentSessionManager({
+      root,
+      defaultContent: 'base\n',
+      idleSessionGraceMs: 1
+    });
+    const session = manager.getSession('hello-world.md');
+    await session.open();
+    let announceOperationStarted: (() => void) | undefined;
+    const operationStarted = new Promise<void>((resolve) => {
+      announceOperationStarted = resolve;
+    });
+    let releaseOperation: (() => void) | undefined;
+    const operationReleased = new Promise<void>((resolve) => {
+      releaseOperation = resolve;
+    });
+    const operation = manager.withSession('hello-world.md', async (active) => {
+      announceOperationStarted?.();
+      await operationReleased;
+      await active.applyContent('late operation content\n');
+    });
+    await operationStarted;
+
+    await expect(manager.moveSession('hello-world.md', 'active-operation-moved.md', async () => {
+      await rename(filePath, targetPath);
+    })).resolves.toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(manager.getOpenSession('active-operation-moved.md')).toBe(session);
+
+    releaseOperation?.();
+    await operation;
+    await waitUntil(() => manager.getOpenSessionCount() === 0, () =>
+      `Timed out waiting for completed operation session to close; count=${manager.getOpenSessionCount()}`
+    );
+    await expect(readFile(targetPath, 'utf8')).resolves.toBe('late operation content\n');
+    await manager.close();
+  });
+
+  it('rejects a move whose destination is owned by another registered session', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const manager = new DocumentSessionManager({ root, defaultContent: '' });
+    const source = manager.getSession('hello-world.md');
+    await source.open();
+    const originalDiskContent = await readFile(filePath, 'utf8');
+    const destinationLease = await manager.attachClientSession('occupied.md');
+    const moveOnDisk = vi.fn(async () => {
+      await rename(filePath, join(root, 'occupied.md'));
+    });
+
+    await expect(manager.moveSession('hello-world.md', 'occupied.md', moveOnDisk))
+      .rejects.toThrow('destination is already active');
+    expect(moveOnDisk).not.toHaveBeenCalled();
+    expect(manager.getSession('hello-world.md')).toBe(source);
+    expect(manager.getSession('occupied.md')).toBe(destinationLease.session);
+    await expect(readFile(filePath, 'utf8')).resolves.toBe(originalDiskContent);
+
+    destinationLease.release();
+    await manager.close();
+  });
+
   it('clears pending idle timers when the manager closes', async () => {
     const manager = new DocumentSessionManager({
       root: join(kb1Home, 'demo-vault'),
@@ -1082,6 +1681,82 @@ describe('OneFileDocumentSession', () => {
     expect(deleteCalls).toBe(1);
     expect(manager.getOpenSession('folder/a.md')).toBeUndefined();
     expect(manager.getOpenSession('folder/deep/b.md')).toBeUndefined();
+    await manager.close();
+  });
+
+  it('rejects a folder move when its destination subtree contains another session', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const manager = new DocumentSessionManager({ root, defaultContent: '' });
+    const source = manager.getSession('folder/a.md');
+    await source.open();
+    const destinationLease = await manager.attachClientSession('moved/folder/occupied.md');
+    const moveOnDisk = vi.fn(async () => {
+      await rename(join(root, 'folder'), join(root, 'moved', 'folder'));
+    });
+
+    await expect(manager.moveSessionSubtree('folder', 'moved/folder', moveOnDisk))
+      .rejects.toThrow('destination is already active');
+    expect(moveOnDisk).not.toHaveBeenCalled();
+    expect(manager.getSession('folder/a.md')).toBe(source);
+    expect(manager.getSession('moved/folder/occupied.md')).toBe(destinationLease.session);
+
+    destinationLease.release();
+    await manager.close();
+  });
+
+  it('fences content-bearing operations on a retained deleted session', async () => {
+    const root = join(kb1Home, 'demo-vault');
+    const originalPath = join(root, 'retired.md');
+    const movedPath = join(root, 'must-not-exist.md');
+    const manager = new DocumentSessionManager({ root, defaultContent: 'retired content\n' });
+    const session = manager.getSession('retired.md');
+    await session.open();
+    const baseline = (await session.readWithBaseline()).baseline;
+
+    await expect(manager.deleteSession('retired.md', () => rm(originalPath))).resolves.toBe(true);
+    await writeFile(originalPath, 'replacement content\n', 'utf8');
+
+    const baselineEdit = vi.fn(() => ({ ok: true as const, content: 'must not escape\n' }));
+    const contentEdit = vi.fn(() => 'must not escape\n');
+    const moveOnDisk = vi.fn(async () => undefined);
+    const deleteOnDisk = vi.fn(async () => undefined);
+
+    expect(() => session.ydoc).toThrow(DocumentSessionNotFoundError);
+    expect(session.isOpened()).toBe(false);
+    expect(session.hasNonEmptyMaterializedContent()).toBe(false);
+    expect(session.getActivePersistFailureEvent()).toBeUndefined();
+    expect(session.hasActivePersistFailure()).toBe(false);
+    expect(session.hasUnsettledPersist()).toBe(false);
+    await expect(session.open()).rejects.toBeInstanceOf(DocumentSessionNotFoundError);
+    await expect(session.getContent()).rejects.toBeInstanceOf(DocumentSessionNotFoundError);
+    await expect(session.readWithBaseline()).rejects.toBeInstanceOf(DocumentSessionNotFoundError);
+    await expect(session.reset('must not escape\n')).rejects.toBeInstanceOf(DocumentSessionNotFoundError);
+    await expect(session.applyContent('must not escape\n')).rejects.toBeInstanceOf(DocumentSessionNotFoundError);
+    await expect(session.applyBaselineEdit(baseline, baselineEdit)).rejects.toBeInstanceOf(
+      DocumentSessionNotFoundError,
+    );
+    await expect(session.applyContentEdit(contentEdit)).rejects.toBeInstanceOf(
+      DocumentSessionNotFoundError,
+    );
+    await expect(session.moveTo(movedPath, 'must-not-exist.md', moveOnDisk)).rejects.toBeInstanceOf(
+      DocumentSessionNotFoundError,
+    );
+    await expect(session.prepareForPathTransition()).rejects.toBeInstanceOf(
+      DocumentSessionNotFoundError,
+    );
+    await expect(
+      session.completeMoveAfterTransition(movedPath, 'must-not-exist.md', Promise.resolve()),
+    ).rejects.toBeInstanceOf(DocumentSessionNotFoundError);
+    await expect(session.flush()).resolves.toBeUndefined();
+    await expect(session.deleteWith(deleteOnDisk)).resolves.toBeUndefined();
+    await expect(session.close()).resolves.toBeUndefined();
+
+    expect(baselineEdit).not.toHaveBeenCalled();
+    expect(contentEdit).not.toHaveBeenCalled();
+    expect(moveOnDisk).not.toHaveBeenCalled();
+    expect(deleteOnDisk).not.toHaveBeenCalled();
+    await expect(readFile(originalPath, 'utf8')).resolves.toBe('replacement content\n');
+    await expect(readFile(movedPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     await manager.close();
   });
 });

--- a/packages/doc-session/src/session.ts
+++ b/packages/doc-session/src/session.ts
@@ -100,6 +100,11 @@ interface TimingCycle {
   handlerReferences: Map<DocumentSessionTimingHandler, number>;
 }
 
+interface StableOpenStateReservation {
+  run<T>(operation: (opened: boolean) => Promise<T>): Promise<T>;
+  release(): void;
+}
+
 export type DocumentSessionEventHandler = (event: DocumentSessionEvent) => void;
 
 export interface DocumentSessionMutationOptions {
@@ -200,6 +205,7 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
   private readonly eventHandlers = new Set<DocumentSessionEventHandler>();
   private opened = false;
   private openPromise: Promise<void> | undefined;
+  private stableOpenTail: Promise<void> = Promise.resolve();
   private openTimingCycle: TimingCycle | undefined;
   private lastWrittenHash: string | undefined;
   private lastWrittenContent: string | undefined;
@@ -218,6 +224,7 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
   private watchPollTimer: NodeJS.Timeout | undefined;
   private externalCheckPromise: Promise<void> | undefined;
   private pathTransitionPromise: Promise<void> | undefined;
+  private pathMutationTail: Promise<void> = Promise.resolve();
   private deleted = false;
 
   constructor(filePath: string, options: OneFileDocumentSessionOptions = {}) {
@@ -234,6 +241,7 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
   }
 
   get ydoc(): Y.Doc {
+    this.assertNotDeleted();
     return this.doc;
   }
 
@@ -242,10 +250,20 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
   }
 
   hasNonEmptyMaterializedContent(): boolean {
-    return this.nonEmptyMaterializedContent;
+    return !this.deleted && this.nonEmptyMaterializedContent;
   }
 
   async open(options: DocumentSessionOpenOptions = {}): Promise<void> {
+    this.assertNotDeleted();
+    if (this.opened) {
+      return;
+    }
+
+    // Stable-path operations install a barrier before inspecting the current
+    // open attempt. Opens that start afterward must observe the filesystem only
+    // once that operation has finished.
+    await this.stableOpenTail;
+    this.assertNotDeleted();
     if (this.opened) {
       return;
     }
@@ -268,6 +286,56 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
       this.openTimingCycle,
       options.onTiming,
     );
+  }
+
+  async withStableOpenState<T>(operation: (opened: boolean) => Promise<T>): Promise<T> {
+    return this.reserveStableOpenState().run(operation);
+  }
+
+  reserveStableOpenState(): StableOpenStateReservation {
+    let releaseBarrier: (() => void) | undefined;
+    const barrier = new Promise<void>((resolve) => {
+      releaseBarrier = resolve;
+    });
+    const previous = this.stableOpenTail;
+    this.stableOpenTail = previous.then(() => barrier);
+    let released = false;
+    let consumed = false;
+    const release = (): void => {
+      if (released) return;
+      released = true;
+      releaseBarrier?.();
+    };
+
+    return {
+      run: async <T>(operation: (opened: boolean) => Promise<T>): Promise<T> => {
+        if (consumed) throw new Error('Stable open-state reservation has already been consumed.');
+        consumed = true;
+        await previous;
+        try {
+          const pendingOpen = this.openPromise;
+          if (pendingOpen) {
+            try {
+              await pendingOpen;
+            } catch (error) {
+              // A client may be probing a missing path while a create is queued.
+              // Once that attempt settles, the stable operation may safely take the
+              // cold path while later opens remain behind this barrier.
+              if (!(error instanceof DocumentSessionNotFoundError)) {
+                throw error;
+              }
+            }
+          }
+          return await operation(this.isOpened());
+        } finally {
+          release();
+        }
+      },
+      release: () => {
+        consumed = true;
+        release();
+      }
+    };
   }
 
   private async loadFromFile(
@@ -336,9 +404,7 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
 
   async reset(content = this.defaultContent): Promise<string> {
     await this.open();
-    if (this.deleted) {
-      throw new Error(`Document session for ${this.eventPath} has been deleted.`);
-    }
+    this.assertNotDeleted();
 
     this.doc.transact(() => {
       this.text.delete(0, this.text.length);
@@ -351,9 +417,7 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
 
   async applyContent(content: string, options: DocumentSessionMutationOptions = {}): Promise<string> {
     await this.open();
-    if (this.deleted) {
-      throw new Error(`Document session for ${this.eventPath} has been deleted.`);
-    }
+    this.assertNotDeleted();
 
     const current = this.currentContent();
     if (current !== content) {
@@ -372,9 +436,7 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
     options: DocumentSessionMutationOptions = {},
   ): Promise<SessionSpliceResult> {
     await this.open();
-    if (this.deleted) {
-      throw new Error(`Document session for ${this.eventPath} has been deleted.`);
-    }
+    this.assertNotDeleted();
 
     const currentBaseline = this.currentBaseline();
     if (baseline !== currentBaseline) {
@@ -422,24 +484,48 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
     this.stopWatching();
   }
 
+  resumeAfterCloseFailure(): void {
+    if (!this.opened || this.deleted) return;
+    this.doc.off('update', this.handleDocumentUpdate);
+    this.doc.on('update', this.handleDocumentUpdate);
+    this.startWatching();
+  }
+
   async moveTo(
     filePath: string,
     eventPath: string,
     moveOnDisk: () => Promise<void>,
     stateFilePath = this.stateFilePath
   ): Promise<void> {
-    await this.prepareForPathTransition();
-    await this.completeMoveAfterTransition(filePath, eventPath, Promise.resolve().then(moveOnDisk), stateFilePath);
+    await this.runPathMutation(async () => {
+      await this.prepareForPathTransition();
+      await this.completeMoveAfterTransitionInternal(
+        filePath,
+        eventPath,
+        Promise.resolve().then(moveOnDisk),
+        stateFilePath
+      );
+    });
   }
 
   // Path transitions are two-phase: flush and stop watching first, then every caller awaits the same disk move before rebinding paths.
   async prepareForPathTransition(): Promise<void> {
     await this.open();
-    if (this.deleted) {
-      throw new Error(`Document session for ${this.eventPath} has been deleted.`);
-    }
-    await this.flush();
+    this.assertNotDeleted();
     this.stopWatching();
+    try {
+      const externalCheck = this.externalCheckPromise;
+      if (externalCheck) {
+        await externalCheck;
+      }
+      this.assertNotDeleted();
+      await this.flush();
+    } catch (error) {
+      if (!this.deleted) {
+        this.startWatching();
+      }
+      throw error;
+    }
   }
 
   async completeMoveAfterTransition(
@@ -448,11 +534,24 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
     transition: Promise<void>,
     stateFilePath = this.stateFilePath
   ): Promise<void> {
+    await this.runPathMutation(() => (
+      this.completeMoveAfterTransitionInternal(filePath, eventPath, transition, stateFilePath)
+    ));
+  }
+
+  private async completeMoveAfterTransitionInternal(
+    filePath: string,
+    eventPath: string,
+    transition: Promise<void>,
+    stateFilePath = this.stateFilePath
+  ): Promise<void> {
+    this.assertNotDeleted();
     const fromPath = this.eventPath;
     const previousStateFilePath = this.stateFilePath;
     let moved = false;
     const completion = (async () => {
       await transition;
+      this.assertNotDeleted();
       moved = true;
       this.filePath = filePath;
       this.eventPath = eventPath;
@@ -493,14 +592,16 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
   }
 
   async deleteWith(deleteOnDisk: () => Promise<void>): Promise<void> {
-    await this.open();
+    await this.runPathMutation(() => this.deleteWithInternal(deleteOnDisk));
+  }
+
+  private async deleteWithInternal(deleteOnDisk: () => Promise<void>): Promise<void> {
     if (this.deleted) {
       return;
     }
-    await this.flush();
+    await this.prepareForPathTransition();
 
     const transition = (async () => {
-      this.stopWatching();
       await deleteOnDisk();
       await this.deleteStateSnapshot();
       this.markDeleted();
@@ -519,6 +620,15 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
         this.pathTransitionPromise = undefined;
       }
     }
+  }
+
+  private async runPathMutation<T>(mutation: () => Promise<T>): Promise<T> {
+    const result = this.pathMutationTail.then(mutation);
+    this.pathMutationTail = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
   }
 
   private readonly handleDocumentUpdate = (_update: Uint8Array, origin: unknown): void => {
@@ -654,6 +764,12 @@ export class OneFileDocumentSession implements OneFileDocumentSessionRuntimeSurf
       throw new Error(`Document session for ${this.eventPath} is not open.`);
     }
     return this.currentContent();
+  }
+
+  private assertNotDeleted(): void {
+    if (this.deleted) {
+      throw new DocumentSessionNotFoundError(this.filePath);
+    }
   }
 
   private async applyPositionedContent(

--- a/packages/doc-session/src/websocket.test.ts
+++ b/packages/doc-session/src/websocket.test.ts
@@ -12,6 +12,7 @@ import * as Y from 'yjs';
 
 import {
   DOCUMENT_SESSION_FAILURE_CLOSE_CODE,
+  DOCUMENT_SESSION_NOT_FOUND_FAILURE,
   DOCUMENT_SESSION_UNSAFE_DIVERGENCE_FAILURE,
   LOCAL_AGENT_DOCUMENT_UPDATE_ATTRIBUTION,
   LOCAL_USER_DOCUMENT_UPDATE_ATTRIBUTION,
@@ -21,6 +22,7 @@ import {
   MESSAGE_SYNC,
   MESSAGE_SYNC_UPDATE_ACK,
   OneFileDocumentSession,
+  PersistFailedError,
   UNKNOWN_DOCUMENT_UPDATE_ATTRIBUTION,
   decodeAttributedSyncUpdate,
   decodeSyncUpdateAck,
@@ -324,6 +326,88 @@ describe('Yjs WebSocket session', () => {
     await session.close();
   });
 
+  it('does not install document listeners when the socket closes during session open', async () => {
+    const filePath = join(kb1Home, 'demo-vault', 'closed-during-open.md');
+    const session = new OneFileDocumentSession(filePath, { defaultContent: 'durable\n' });
+    const originalOpen = session.open.bind(session);
+    let releaseOpen: (() => void) | undefined;
+    const openReleased = new Promise<void>((resolve) => {
+      releaseOpen = resolve;
+    });
+    session.open = async (options) => {
+      await openReleased;
+      await originalOpen(options);
+    };
+    const onEvent = vi.spyOn(session, 'onEvent');
+    const socket = new FakeSocket();
+
+    const bindingPromise = bindYjsWebSocket(session, socket);
+    socket.readyState = WebSocket.CLOSED;
+    socket.emitClose();
+    releaseOpen?.();
+
+    const binding = await bindingPromise;
+    await binding.closed;
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(socket.sent).toEqual([]);
+    onEvent.mockRestore();
+    await session.close();
+  });
+
+  it('settles socket cleanup when the latest document persist is already failed', async () => {
+    const filePath = join(kb1Home, 'demo-vault', 'cleanup-persist-failed.md');
+    const session = new OneFileDocumentSession(filePath, { defaultContent: 'durable\n' });
+    await session.open();
+    const socket = new FakeSocket();
+    const binding = await bindYjsWebSocket(session, socket);
+    const originalFlush = session.flush.bind(session);
+    session.flush = vi.fn(async () => {
+      throw new PersistFailedError(filePath, new Error('persist unavailable'));
+    });
+
+    socket.emitClose();
+    await expect(binding.closed).resolves.toBeUndefined();
+
+    session.flush = originalFlush;
+    await session.close();
+  });
+
+  it('rejects socket cleanup when an unexpected flush failure occurs', async () => {
+    const filePath = join(kb1Home, 'demo-vault', 'cleanup-unexpected-failure.md');
+    const session = new OneFileDocumentSession(filePath, { defaultContent: 'durable\n' });
+    await session.open();
+    const socket = new FakeSocket();
+    const binding = await bindYjsWebSocket(session, socket);
+    const originalFlush = session.flush.bind(session);
+    const cleanupFailure = new Error('unexpected cleanup failure');
+    session.flush = vi.fn(async () => {
+      throw cleanupFailure;
+    });
+
+    socket.emitClose();
+    await expect(binding.closed).rejects.toBe(cleanupFailure);
+
+    session.flush = originalFlush;
+    await session.close();
+  });
+
+  it('ignores unsupported non-binary socket frames', async () => {
+    const filePath = join(kb1Home, 'demo-vault', 'unsupported-frame.md');
+    const session = new OneFileDocumentSession(filePath, { defaultContent: 'durable\n' });
+    await session.open();
+    const socket = new FakeSocket();
+    const binding = await bindYjsWebSocket(session, socket);
+    const sentBeforeUnsupportedFrame = socket.sent.length;
+
+    socket.emitMessage({ unsupported: true });
+
+    expect(socket.sent).toHaveLength(sentBeforeUnsupportedFrame);
+    expect(socket.closed).toEqual([]);
+    socket.emitClose();
+    await binding.closed;
+    await session.close();
+  });
+
   it('persists the first edit from a freshly synced client after loading durable content', async () => {
     const vaultDir = join(kb1Home, 'demo-vault');
     const filePath = join(vaultDir, 'hello-world.md');
@@ -397,6 +481,7 @@ describe('Yjs WebSocket session', () => {
     await waitUntil(
       () => staleSocket.closed.length > 0,
       () => 'Timed out waiting for the divergent stale socket to close',
+      10_000,
     );
 
     expect(staleSocket.closed).toEqual([{
@@ -413,7 +498,7 @@ describe('Yjs WebSocket session', () => {
     await closeServer(server);
     await session.close();
     stalePeer.destroy();
-  });
+  }, 15_000);
 
   it('serves durable content after a daemon restart from filesystem truth', async () => {
     const vaultDir = join(kb1Home, 'demo-vault');
@@ -840,6 +925,30 @@ describe('Yjs WebSocket session', () => {
     await session.close();
   });
 
+  it('sends the terminal event and closes a socket bound to a deleted session', async () => {
+    const filePath = join(kb1Home, 'demo-vault', 'deleted.md');
+    await mkdir(join(kb1Home, 'demo-vault'), { recursive: true });
+    await writeFile(filePath, 'retired content\n', 'utf8');
+    const session = new OneFileDocumentSession(filePath, { eventPath: 'deleted.md' });
+    const socket = new FakeSocket();
+    const binding = await bindYjsWebSocket(session, socket);
+
+    await session.deleteWith(() => rm(filePath));
+
+    expect(socket.sent.map(sessionEventKind)).toContain('doc-deleted');
+    expect(socket.closed).toEqual([
+      {
+        code: DOCUMENT_SESSION_FAILURE_CLOSE_CODE,
+        reason: JSON.stringify(DOCUMENT_SESSION_NOT_FOUND_FAILURE),
+      },
+    ]);
+    expect(() => session.ydoc).toThrow('file not found');
+
+    socket.emitClose();
+    await binding.closed;
+    await session.close();
+  });
+
   it('handles alternate message payload shapes and skips sends to closed sockets', async () => {
     const filePath = join(kb1Home, 'demo-vault', 'hello-world.md');
     await mkdir(join(kb1Home, 'demo-vault'), { recursive: true });
@@ -1150,8 +1259,9 @@ async function waitForDiskContent(
 async function waitUntil(
   predicate: () => boolean | Promise<boolean>,
   errorMessage: () => string,
+  timeoutMs = 3000,
 ): Promise<void> {
-  const deadline = Date.now() + 3000;
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (await predicate()) return;
     await new Promise((resolve) => setTimeout(resolve, 25));

--- a/packages/doc-session/src/websocket.ts
+++ b/packages/doc-session/src/websocket.ts
@@ -5,6 +5,7 @@ import * as Y from 'yjs';
 
 import {
   DOCUMENT_SESSION_FAILURE_CLOSE_CODE,
+  DOCUMENT_SESSION_NOT_FOUND_FAILURE,
   DOCUMENT_SESSION_UNSAFE_DIVERGENCE_FAILURE,
   DocumentSessionNotFoundError,
   PersistFailedError,
@@ -71,6 +72,7 @@ export async function bindYjsWebSocket(
   const bindingStartedAt = performance.now();
   let cleanupStarted = false;
   let sessionReady = false;
+  let sessionDoc: Y.Doc | undefined;
   const pendingMessages: unknown[] = [];
   let syncedMessageSent = false;
   let resolveClosed!: () => void;
@@ -106,7 +108,7 @@ export async function bindYjsWebSocket(
 
     cleanupStarted = true;
     unsubscribeSessionEvents();
-    session.ydoc.off('update', updateHandler);
+    sessionDoc?.off('update', updateHandler);
     session.flush().then(resolveClosed, (error: unknown) => {
       if (error instanceof PersistFailedError) {
         resolveClosed();
@@ -147,17 +149,22 @@ export async function bindYjsWebSocket(
       const decoder = decoding.createDecoder(message);
       const encoder = encoding.createEncoder();
       const messageType = decoding.readVarUint(decoder);
+      const activeDoc = sessionDoc;
+      if (!activeDoc || !session.isOpened()) {
+        closeDeletedDocument(socket);
+        return;
+      }
 
       if (messageType === MESSAGE_ACKED_SYNC_UPDATE) {
         const ackedUpdate = decodeAckedSyncUpdate(decoder);
         if (!ackedUpdate) {
           return;
         }
-        if (hasUnsafeIndependentUpdate(session, ackedUpdate.update)) {
+        if (hasUnsafeIndependentUpdate(session, activeDoc, ackedUpdate.update)) {
           closeUnsafeDivergence(socket);
           return;
         }
-        Y.applyUpdate(session.ydoc, ackedUpdate.update, socketUpdateOrigin);
+        Y.applyUpdate(activeDoc, ackedUpdate.update, socketUpdateOrigin);
         const saveStartedAt = performance.now();
         void session.flush({ onTiming: options.onTiming as DocumentSessionTimingHandler | undefined }).then(() => {
           sendBytes(socket, encodeSyncUpdateAck({ ackId: ackedUpdate.ackId, ts: Date.now() }));
@@ -181,7 +188,14 @@ export async function bindYjsWebSocket(
       }
 
       encoding.writeVarUint(encoder, MESSAGE_SYNC);
-      const syncResult = processYjsSyncPayload(session, socket, socketUpdateOrigin, decoder, encoder);
+      const syncResult = processYjsSyncPayload(
+        session,
+        activeDoc,
+        socket,
+        socketUpdateOrigin,
+        decoder,
+        encoder,
+      );
       if (syncResult === 'closed') {
         return;
       }
@@ -219,11 +233,22 @@ export async function bindYjsWebSocket(
     }
     throw error;
   }
+  if (cleanupStarted || socket.readyState !== socketOpen) {
+    cleanup();
+    return { closed };
+  }
   sessionReady = true;
+  const openedDoc = session.ydoc;
+  sessionDoc = openedDoc;
 
-  session.ydoc.on('update', updateHandler);
+  openedDoc.on('update', updateHandler);
   unsubscribeSessionEvents = session.onEvent((event) => {
     sendBytes(socket, encodeSessionEvent(event));
+    if (event.kind === 'doc-deleted') {
+      deferredPersistedAckIds.clear();
+      closeDeletedDocument(socket);
+      return;
+    }
     if (event.kind === 'content-persisted' && deferredPersistedAckIds.size > 0) {
       for (const ackId of deferredPersistedAckIds) {
         sendBytes(socket, encodeSyncUpdateAck({ ackId, ts: event.ts }));
@@ -242,7 +267,7 @@ export async function bindYjsWebSocket(
   }
 
   sendSync(socket, (encoder) => {
-    syncProtocol.writeSyncStep1(encoder, session.ydoc);
+    syncProtocol.writeSyncStep1(encoder, openedDoc);
   });
   emitTiming(options.onTiming, {
     stage: 'initial_sync.emitted',
@@ -275,6 +300,7 @@ type SyncMessageResult = 'answered-sync-step1' | 'processed' | 'closed';
 
 function processYjsSyncPayload(
   session: OneFileDocumentSession,
+  doc: Y.Doc,
   socket: YjsWebSocketLike,
   origin: unknown,
   decoder: decoding.Decoder,
@@ -283,29 +309,32 @@ function processYjsSyncPayload(
   const syncMessageType = decoding.readVarUint(decoder);
   if (syncMessageType === syncProtocol.messageYjsSyncStep1) {
     const remoteStateVector = decoding.readVarUint8Array(decoder);
-    syncProtocol.writeSyncStep2(encoder, session.ydoc, remoteStateVector);
+    syncProtocol.writeSyncStep2(encoder, doc, remoteStateVector);
     return 'answered-sync-step1';
   }
 
   if (syncMessageType === syncProtocol.messageYjsSyncStep2 || syncMessageType === syncProtocol.messageYjsUpdate) {
     const update = decoding.readVarUint8Array(decoder);
-    if (hasUnsafeIndependentUpdate(session, update)) {
+    if (hasUnsafeIndependentUpdate(session, doc, update)) {
       closeUnsafeDivergence(socket);
       return 'closed';
     }
-    Y.applyUpdate(session.ydoc, update, origin);
+    Y.applyUpdate(doc, update, origin);
     return 'processed';
   }
 
   throw new Error('Unknown Yjs sync message type');
 }
 
-function hasUnsafeIndependentUpdate(session: OneFileDocumentSession, update: Uint8Array): boolean {
+function hasUnsafeIndependentUpdate(
+  session: OneFileDocumentSession,
+  localDoc: Y.Doc,
+  update: Uint8Array,
+): boolean {
   if (!session.hasNonEmptyMaterializedContent()) {
     return false;
   }
 
-  const localDoc = session.ydoc;
   const localText = localDoc.getText(Y_TEXT_NAME).toString();
   if (localText.length === 0) {
     return false;
@@ -340,6 +369,13 @@ function stateVectorsShareClient(left: Map<number, number>, right: Map<number, n
 
 function closeUnsafeDivergence(socket: YjsWebSocketLike): void {
   socket.close(DOCUMENT_SESSION_FAILURE_CLOSE_CODE, JSON.stringify(DOCUMENT_SESSION_UNSAFE_DIVERGENCE_FAILURE));
+}
+
+function closeDeletedDocument(socket: YjsWebSocketLike): void {
+  socket.close(
+    DOCUMENT_SESSION_FAILURE_CLOSE_CODE,
+    JSON.stringify(DOCUMENT_SESSION_NOT_FOUND_FAILURE),
+  );
 }
 
 function elapsedMs(startedAt: number): number {

--- a/packages/vault-service/src/index.test.ts
+++ b/packages/vault-service/src/index.test.ts
@@ -4,11 +4,15 @@ import {
   mkdtemp,
   readFile,
   readdir,
+  rename,
   rm,
   stat,
   writeFile,
 } from "node:fs/promises";
-import { DocumentSessionManager } from "@kb-1/doc-session";
+import {
+  DocumentSessionManager,
+  DocumentSessionNotFoundError,
+} from "@kb-1/doc-session";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -290,6 +294,248 @@ describe("vault service failure mapping", () => {
     });
     if (!flushed.ok) throw new Error("expected flushed history");
     expect(flushed.entries[0]).not.toHaveProperty("pending");
+  });
+
+  it("waits for a live path transition before overwriting the source path", async () => {
+    await writeFileWithParents(join(root, "notes", "moving.md"), "live content\n");
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const session = sessions.getSession("notes/moving.md");
+    await session.open();
+
+    let announceMoveStarted: (() => void) | undefined;
+    const moveStarted = new Promise<void>((resolve) => {
+      announceMoveStarted = resolve;
+    });
+    let releaseMove: (() => void) | undefined;
+    const moveReleased = new Promise<void>((resolve) => {
+      releaseMove = resolve;
+    });
+    const move = sessions.moveSession(
+      "notes/moving.md",
+      "notes/moved.md",
+      async () => {
+        announceMoveStarted?.();
+        await moveReleased;
+        await rename(
+          join(root, "notes", "moving.md"),
+          join(root, "notes", "moved.md"),
+        );
+      },
+    );
+    await moveStarted;
+
+    let overwriteSettled = false;
+    const overwrite = service.createNote({
+      path: "notes/moving.md",
+      content: "replacement content\n",
+      overwrite: true,
+      actor: { kind: "user" },
+    }).then((result) => {
+      overwriteSettled = true;
+      return result;
+    });
+    await Promise.resolve();
+    expect(overwriteSettled).toBe(false);
+
+    releaseMove?.();
+    await expect(move).resolves.toBe(true);
+    await expect(overwrite).resolves.toMatchObject({
+      ok: true,
+      path: "notes/moving.md",
+    });
+    await expect(readFile(join(root, "notes", "moved.md"), "utf8"))
+      .resolves.toBe("live content\n");
+    await expect(readFile(join(root, "notes", "moving.md"), "utf8"))
+      .resolves.toBe("replacement content\n");
+    await sessions.close();
+  });
+
+  it("installs the retained-session open barrier in the same turn as a cold create", async () => {
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const retainedSession = sessions.getSession("notes/same-turn-create.md");
+
+    const creation = service.createNote({
+      path: "notes/same-turn-create.md",
+      content: "requested content\n",
+      overwrite: false,
+      actor: { kind: "user" },
+    });
+    const opening = retainedSession.open();
+
+    await expect(creation).resolves.toMatchObject({
+      ok: true,
+      path: "notes/same-turn-create.md",
+    });
+    await opening;
+    await expect(retainedSession.getContent()).resolves.toBe("requested content\n");
+    await expect(readFile(join(root, "notes", "same-turn-create.md"), "utf8"))
+      .resolves.toBe("requested content\n");
+    await sessions.close();
+  });
+
+  it("maps an active destination-session move conflict to already_exists", async () => {
+    await writeFileWithParents(join(root, "notes", "source.md"), "source content\n");
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const source = sessions.getSession("notes/source.md");
+    await source.open();
+    const destinationLease = await sessions.attachClientSession("notes/destination.md");
+
+    await expect(service.moveNote({
+      fromPath: "notes/source.md",
+      toPath: "notes/destination.md",
+      actor: { kind: "user" },
+    })).resolves.toEqual({
+      ok: false,
+      error: "already_exists",
+      message: "destination already has an active document session",
+    });
+    await expect(readFile(join(root, "notes", "source.md"), "utf8"))
+      .resolves.toBe("source content\n");
+    expect(sessions.getSession("notes/source.md")).toBe(source);
+    expect(sessions.getSession("notes/destination.md")).toBe(destinationLease.session);
+
+    destinationLease.release();
+    await sessions.close();
+  });
+
+  it("reports a missing file source before an active destination-session conflict", async () => {
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const destinationLease = await sessions.attachClientSession("notes/destination.md");
+
+    await expect(service.moveNote({
+      fromPath: "notes/missing.md",
+      toPath: "notes/destination.md",
+      actor: { kind: "user" },
+    })).resolves.toEqual({
+      ok: false,
+      error: "not_found",
+      message: "file not found",
+    });
+    expect(sessions.getSession("notes/destination.md")).toBe(destinationLease.session);
+
+    destinationLease.release();
+    await sessions.close();
+  });
+
+  it("reports a missing folder source before an active destination-subtree conflict", async () => {
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const destinationLease = await sessions.attachClientSession("moved/folder/occupied.md");
+
+    await expect(service.moveFolder({
+      fromPath: "folder",
+      toPath: "moved/folder",
+      actor: { kind: "user" },
+    })).resolves.toEqual({
+      ok: false,
+      error: "not_found",
+      message: "folder not found",
+    });
+    expect(sessions.getSession("moved/folder/occupied.md")).toBe(destinationLease.session);
+
+    destinationLease.release();
+    await sessions.close();
+  });
+
+  it("maps a document deleted while preparing a move to not_found", async () => {
+    await writeFileWithParents(join(root, "notes", "deleted-during-move.md"), "source\n");
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const move = vi.spyOn(sessions, "moveSession").mockRejectedValue(
+      new DocumentSessionNotFoundError(join(root, "notes", "deleted-during-move.md")),
+    );
+
+    await expect(service.moveNote({
+      fromPath: "notes/deleted-during-move.md",
+      toPath: "notes/destination.md",
+      actor: { kind: "user" },
+    })).resolves.toEqual({
+      ok: false,
+      error: "not_found",
+      message: "file not found",
+    });
+
+    move.mockRestore();
+    await sessions.close();
+  });
+
+  it("holds a live overwrite path stable through audit and history before a move", async () => {
+    await writeFileWithParents(join(root, "notes", "stable.md"), "initial content\n");
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const session = sessions.getSession("notes/stable.md");
+    await session.open();
+    const originalApplyContent = session.applyContent.bind(session);
+    let announceOverwriteStarted: (() => void) | undefined;
+    const overwriteStarted = new Promise<void>((resolve) => {
+      announceOverwriteStarted = resolve;
+    });
+    let releaseOverwrite: (() => void) | undefined;
+    const overwriteReleased = new Promise<void>((resolve) => {
+      releaseOverwrite = resolve;
+    });
+    session.applyContent = async (...args) => {
+      announceOverwriteStarted?.();
+      await overwriteReleased;
+      return originalApplyContent(...args);
+    };
+
+    const overwrite = service.createNote({
+      path: "notes/stable.md",
+      content: "replacement content\n",
+      overwrite: true,
+      actor: { kind: "user" },
+    });
+    await overwriteStarted;
+    let moveSettled = false;
+    const move = service.moveNote({
+      fromPath: "notes/stable.md",
+      toPath: "notes/moved-stable.md",
+      actor: { kind: "user" },
+    }).then((result) => {
+      moveSettled = true;
+      return result;
+    });
+    await Promise.resolve();
+    expect(moveSettled).toBe(false);
+
+    releaseOverwrite?.();
+    await expect(overwrite).resolves.toMatchObject({
+      ok: true,
+      path: "notes/stable.md",
+      content: "replacement content\n",
+      live: true,
+      audit: { operation: "write", path: "notes/stable.md" },
+    });
+    await expect(move).resolves.toMatchObject({
+      ok: true,
+      fromPath: "notes/stable.md",
+      toPath: "notes/moved-stable.md",
+      live: true,
+    });
+    await expect(readFile(join(root, "notes", "moved-stable.md"), "utf8"))
+      .resolves.toBe("replacement content\n");
+    await expect(readFile(join(root, "notes", "stable.md"), "utf8"))
+      .rejects.toMatchObject({ code: "ENOENT" });
+    await sessions.close();
   });
 
   it("carries note history across cold and live note moves", async () => {

--- a/packages/vault-service/src/index.ts
+++ b/packages/vault-service/src/index.ts
@@ -1,4 +1,6 @@
 import {
+  DocumentSessionNotFoundError,
+  DocumentSessionPathConflictError,
   PersistFailedError,
   type DocumentSessionEvent,
   type DocumentSessionManager,
@@ -455,44 +457,45 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       invalidateTreeReads();
       const validPath = validateServiceFilePath(input.path);
       if (!validPath.ok) return validPath;
-      const liveSession = options.documentSessions.getOpenSession(input.path);
-      if (liveSession) {
-        if (!input.overwrite) {
-          return failure('already_exists', 'file already exists');
+      return options.documentSessions.withStablePath(input.path, async (liveSession) => {
+        if (liveSession) {
+          if (!input.overwrite) {
+            return failure('already_exists', 'file already exists');
+          }
+          const applied = await mapWriteFailure(() => liveSession.applyContent(
+            input.content,
+            { attribution: documentUpdateAttribution(input.actor, 'write', input.path) }
+          ));
+          if (!applied.ok) return applied;
+          const audit = await emitVaultAudit({
+            root: options.vaultRoot,
+            actor: input.actor,
+            operation: 'write',
+            entityKind: 'file',
+            path: input.path,
+            summary: `Wrote ${input.path}`,
+            changeEvent: { skipContentPersisted: true }
+          });
+          await recordServiceHistoryFromAudit(audit, applied.value);
+          return finishTreeMutation({
+            ok: true,
+            path: input.path,
+            content: applied.value,
+            live: true,
+            audit
+          });
         }
-        const applied = await mapWriteFailure(() => liveSession.applyContent(
-          input.content,
-          { attribution: documentUpdateAttribution(input.actor, 'write', input.path) }
-        ));
-        if (!applied.ok) return applied;
-        const audit = await emitVaultAudit({
-          root: options.vaultRoot,
-          actor: input.actor,
-          operation: 'write',
-          entityKind: 'file',
-          path: input.path,
-          summary: `Wrote ${input.path}`,
-          changeEvent: { skipContentPersisted: true }
-        });
-        await recordServiceHistoryFromAudit(audit, applied.value);
-        return finishTreeMutation({
-          ok: true,
-          path: input.path,
-          content: applied.value,
-          live: true,
-          audit
-        });
-      }
 
-      const result = serviceResult(await writeVaultFile(ctx(input.actor), {
-        path: input.path,
-        content: input.content,
-        overwrite: input.overwrite
-      }));
-      if (result.ok) {
-        await recordServiceHistoryFromAudit(result.audit, input.content);
-      }
-      return finishTreeMutation(result);
+        const result = serviceResult(await writeVaultFile(ctx(input.actor), {
+          path: input.path,
+          content: input.content,
+          overwrite: input.overwrite
+        }));
+        if (result.ok) {
+          await recordServiceHistoryFromAudit(result.audit, input.content);
+        }
+        return finishTreeMutation(result);
+      });
     },
 
     async editNote(input) {
@@ -608,14 +611,11 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       };
       const deletedLive = await mapVaultFailure(() => options.documentSessions.deleteSession(input.path, deleteOnDisk));
       if (!deletedLive.ok) return finishTreeMutation(deletedLive);
-      if (deletedLive.value) {
-        return finishTreeMutation({ ok: true, ...deleted!, live: true });
-      }
-      const result = serviceResult(await deleteVaultFile(ctx(input.actor), {
-        path: input.path,
-        permanent: input.permanent
-      }));
-      return finishTreeMutation(result);
+      return finishTreeMutation({
+        ok: true,
+        ...deleted!,
+        ...(deletedLive.value ? { live: true } : {})
+      });
     },
 
     async moveNote(input) {
@@ -631,19 +631,12 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
       };
       const movedLive = await mapVaultFailure(() => options.documentSessions.moveSession(input.fromPath, input.toPath, moveOnDisk));
       if (!movedLive.ok) return finishTreeMutation(movedLive);
-      if (movedLive.value) {
-        await carryHistoryAfterFileMove(moved!);
-        return finishTreeMutation({ ok: true, ...moved!, live: true });
-      }
-      const result = serviceResult(await moveVaultPath(ctx(input.actor), {
-        kind: 'file',
-        fromPath: input.fromPath,
-        toPath: input.toPath
-      }));
-      if (result.ok) {
-        await carryHistoryAfterFileMove(result);
-      }
-      return finishTreeMutation(result);
+      await carryHistoryAfterFileMove(moved!);
+      return finishTreeMutation({
+        ok: true,
+        ...moved!,
+        ...(movedLive.value ? { live: true } : {})
+      });
     },
 
     async createFolder(input) {
@@ -884,6 +877,12 @@ async function mapVaultFailure<T>(operation: () => T | Promise<T>): Promise<{ ok
   } catch (error) {
     if (error instanceof VaultResultFailure) {
       return vaultFailureResult(error.result);
+    }
+    if (error instanceof DocumentSessionPathConflictError) {
+      return failure('already_exists', 'destination already has an active document session');
+    }
+    if (error instanceof DocumentSessionNotFoundError) {
+      return failure('not_found', 'file not found');
     }
     /* v8 ignore next -- Non-vault exceptions must propagate; callers only synthesize VaultResultFailure in tests and live disk callbacks. */
     throw error;


### PR DESCRIPTION
## Summary

- Retain terminal document-session tombstones and reject public operations after terminal deletion.
- Serialize path mutations and leases while coordinating watcher drains and stable path barriers.
- Add composed lifecycle and race coverage across the daemon, document session, websocket, and vault service.

## Why

Retained session references could continue exposing retired Yjs state after terminal deletion, while overlapping lifecycle and path operations could race watcher and filesystem transitions. This change makes terminal state final and orders the related mutation boundaries.

## Impact

Deleted or otherwise terminal sessions now fail closed through retained references. Concurrent rename, delete, lease, and watcher activity is serialized so callers do not observe retired document state or partially transitioned paths.

## Verification

- `pnpm check`
- Focused daemon, document-session, websocket, and vault-service regressions
- `$autoreview --mode local --thinking high`: clean, no accepted/actionable findings
- `git diff --check`
