### PR TITLE
feat(daemon): add document durability telemetry

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -7,7 +7,7 @@ regenerated and reviewed for every release.
 Platform-specific optional native build bindings are excluded because they are not
 copied into the shipped runtime; their platform-neutral parent packages remain listed.
 
-Inventory count: **196 packages**.
+Inventory count: **197 packages**.
 
 | Package | Declared license | Source | Included notice files |
 | --- | --- | --- | --- |
@@ -46,6 +46,7 @@ Inventory count: **196 packages**.
 | @lezer/python 1.1.19 | MIT | [source](https://code.haverbeke.berlin/lezer/python) | LICENSE (fc70f93929c5) |
 | @marijn/find-cluster-break 1.0.2 | MIT | [source](https://github.com/marijnh/find-cluster-break) | LICENSE (081220319c27) |
 | @modelcontextprotocol/sdk 1.29.0 | MIT | [source](https://github.com/modelcontextprotocol/typescript-sdk) | LICENSE (8694aa57bec3) |
+| @noble/hashes 2.2.0 | MIT | [source](https://github.com/paulmillr/noble-hashes) | LICENSE (4f221aee6e07) |
 | @oxc-project/types 0.133.0 | MIT | [source](https://github.com/oxc-project/oxc) | LICENSE (5b0650b07830) |
 | @polka/url 1.0.0-next.29 | MIT | [source](https://github.com/lukeed/polka) | None included |
 | @rolldown/pluginutils 1.0.1 | MIT | [source](https://github.com/rolldown/plugins) | LICENSE (3a2bf91a2d98) |
@@ -882,6 +883,36 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+```
+
+### 4f221aee6e072336700c408c68ab3b96a3fc09f6aebe6f48f1bd99e5ef13faec
+
+Packages: @noble/hashes@2.2.0
+
+Files: @noble/hashes@2.2.0/LICENSE
+
+```text
+The MIT License (MIT)
+
+Copyright (c) 2022 Paul Miller (https://paulmillr.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 ```
 
 ### 5b0650b078309ba2772569bb419e40e6883874af64d21bd9c27b44cc1a8e46ff

--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -800,7 +800,7 @@ describe('daemon vault management API', () => {
     await opened;
     await vi.waitUntil(
       () => timingLogs.some((entry) =>
-        (entry as { stage?: unknown }).stage === 'initial_sync.emitted'
+        (entry as { stage?: unknown }).stage === 'initial_state_vector.observed'
       ),
       { timeout: 1_000 }
     );
@@ -809,7 +809,14 @@ describe('daemon vault management API', () => {
       expect.objectContaining({ component: 'daemon', traceId, stage: 'websocket.accepted' }),
       expect.objectContaining({ component: 'daemon', traceId, stage: 'document_session.attached' }),
       expect.objectContaining({ component: 'daemon', traceId, stage: 'markdown.read' }),
-      expect.objectContaining({ component: 'daemon', traceId, stage: 'initial_sync.emitted' })
+      expect.objectContaining({
+        component: 'daemon',
+        traceId,
+        stage: 'initial_state_vector.observed',
+        documentChars: expect.any(Number),
+        stateVectorBytes: expect.any(Number),
+        stateVectorFingerprint: expect.stringMatching(/^sha256:[0-9a-f]{64}$/)
+      })
     ]));
     expect(JSON.stringify(timingLogs)).not.toContain('doc.md');
 

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -524,23 +524,37 @@ function logDocumentTiming(
   event: {
     stage: string;
     durationMs: number;
+    observedAtMs?: number;
     outcome?: string;
     ackId?: string;
+    documentChars?: number;
+    stateVectorBytes?: number;
+    stateVectorFingerprint?: string;
+    updateBytes?: number;
+    updateFingerprint?: string;
   }
 ): void {
   console.log('[document timing]', {
     component: 'daemon',
     traceId,
     stage: event.stage,
-    elapsedMs: elapsedDocumentTimingMs(startedAt),
+    elapsedMs:
+      event.observedAtMs === undefined
+        ? elapsedDocumentTimingMs(startedAt)
+        : elapsedDocumentTimingMs(startedAt, event.observedAtMs),
     durationMs: event.durationMs,
     ...(event.outcome ? { outcome: event.outcome } : {}),
-    ...(event.ackId ? { ackId: event.ackId } : {})
+    ...(event.ackId ? { ackId: event.ackId } : {}),
+    ...(event.documentChars !== undefined ? { documentChars: event.documentChars } : {}),
+    ...(event.stateVectorBytes !== undefined ? { stateVectorBytes: event.stateVectorBytes } : {}),
+    ...(event.stateVectorFingerprint ? { stateVectorFingerprint: event.stateVectorFingerprint } : {}),
+    ...(event.updateBytes !== undefined ? { updateBytes: event.updateBytes } : {}),
+    ...(event.updateFingerprint ? { updateFingerprint: event.updateFingerprint } : {})
   });
 }
 
-function elapsedDocumentTimingMs(startedAt: number): number {
-  return Math.max(0, Math.round((performance.now() - startedAt) * 100) / 100);
+function elapsedDocumentTimingMs(startedAt: number, observedAtMs = performance.now()): number {
+  return Math.max(0, Math.round((observedAtMs - startedAt) * 100) / 100);
 }
 
 /** Parse `/api/vaults/<id>/files/<rawPath>` into its id and raw file path. */

--- a/packages/doc-session/package.json
+++ b/packages/doc-session/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@kb-1/vault-core": "workspace:*",
+    "@noble/hashes": "catalog:",
     "fast-diff": "1.3.0",
     "lib0": "0.2.117",
     "y-protocols": "1.0.7",

--- a/packages/doc-session/src/fingerprint.test.ts
+++ b/packages/doc-session/src/fingerprint.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { fingerprintDocumentBytes } from './fingerprint.js';
+
+describe('document fingerprints', () => {
+  it.each([
+    [new Uint8Array(), 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'],
+    [
+      new TextEncoder().encode('abc'),
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+    ],
+  ])('uses the standard SHA-256 vector %#', (bytes, digest) => {
+    expect(fingerprintDocumentBytes(bytes)).toBe(`sha256:${digest}`);
+  });
+});

--- a/packages/doc-session/src/fingerprint.ts
+++ b/packages/doc-session/src/fingerprint.ts
@@ -1,0 +1,6 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
+
+export function fingerprintDocumentBytes(bytes: Uint8Array): string {
+  return `sha256:${bytesToHex(sha256(bytes))}`;
+}

--- a/packages/doc-session/src/websocket.test.ts
+++ b/packages/doc-session/src/websocket.test.ts
@@ -33,7 +33,8 @@ import {
   type YjsWebSocketTimingEvent,
   type YjsWebSocketLike
 } from './index.js';
-import { bindYjsWebSocket } from './websocket.js';
+import { bindYjsWebSocket, documentStateVectorTimingFields } from './websocket.js';
+import { fingerprintDocumentBytes } from './fingerprint.js';
 
 const DEMO_DOCUMENT_YJS_PATH = '/api/demo-document/yjs';
 
@@ -103,6 +104,10 @@ describe('Yjs WebSocket session', () => {
     const binding = await bindYjsWebSocket(session, socket, {
       onTiming: (event) => timings.push(event)
     });
+    const delayStartedAt = performance.now();
+    while (performance.now() - delayStartedAt < 15) {
+      // Keep deferred fingerprint work waiting so timestamp drift is observable.
+    }
     const clientDoc = new Y.Doc();
     clientDoc.getText('markdown').insert(0, 'acked browser edit\n');
 
@@ -123,6 +128,7 @@ describe('Yjs WebSocket session', () => {
     expect(timings.map((event) => event.stage)).toEqual(expect.arrayContaining([
       'document_session.open',
       'initial_sync.emitted',
+      'initial_state_vector.observed',
       'markdown.read',
       'markdown.atomic_write_fsync',
       'yjs_state.atomic_write_fsync',
@@ -132,11 +138,225 @@ describe('Yjs WebSocket session', () => {
     expect(timingStages.lastIndexOf('save_ack.emitted')).toBeGreaterThan(
       timingStages.lastIndexOf('yjs_state.atomic_write_fsync')
     );
+    const initialStateVector = findInitialStateVector(socket.sent);
+    expect(initialStateVector).toBeDefined();
+    const initialSyncTiming = timings.find((event) => event.stage === 'initial_sync.emitted');
+    const initialStateVectorTiming = timings.find(
+      (event) => event.stage === 'initial_state_vector.observed'
+    );
+    expect(initialStateVectorTiming).toMatchObject({
+      documentChars: expect.any(Number),
+      observedAtMs: expect.any(Number),
+      stateVectorBytes: initialStateVector?.byteLength,
+      stateVectorFingerprint: fingerprintDocumentBytes(initialStateVector ?? new Uint8Array()),
+    });
+    expect(initialStateVectorTiming?.durationMs).toBe(initialSyncTiming?.durationMs);
+    const initialStateVectorObservedAtMs = initialStateVectorTiming
+      && 'observedAtMs' in initialStateVectorTiming
+      ? initialStateVectorTiming.observedAtMs
+      : undefined;
+    const initialSyncObservedAtMs = initialSyncTiming
+      && 'observedAtMs' in initialSyncTiming
+      ? initialSyncTiming.observedAtMs
+      : undefined;
+    expect(initialStateVectorObservedAtMs).toBe(initialSyncObservedAtMs);
+    expect(timings.find((event) => event.stage === 'save_ack.emitted')).toMatchObject({
+      ackId: 'update-1',
+      observedAtMs: expect.any(Number),
+      updateBytes: expect.any(Number),
+      updateFingerprint: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+      stateVectorFingerprint: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+    });
 
     socket.emitClose();
     await binding.closed;
     await session.close();
     clientDoc.destroy();
+  });
+
+  it('dispatches burst save acknowledgements before collecting their shared state timing', async () => {
+    await mkdir(join(kb1Home, 'demo-vault'), { recursive: true });
+    const filePath = join(kb1Home, 'demo-vault', 'burst-acked.md');
+    const session = new OneFileDocumentSession(filePath, { defaultContent: '' });
+    await session.open();
+    const socket = new FakeSocket();
+    const ackCountsAtSaveTiming: number[] = [];
+    const timings: YjsWebSocketTimingEvent[] = [];
+    const binding = await bindYjsWebSocket(session, socket, {
+      onTiming: (event) => {
+        timings.push(event);
+        if (event.stage === 'save_ack.emitted') {
+          ackCountsAtSaveTiming.push([
+            findSyncUpdateAck(socket.sent, 'burst-1'),
+            findSyncUpdateAck(socket.sent, 'burst-2'),
+          ].filter(Boolean).length);
+        }
+      }
+    });
+    const clientDoc = new Y.Doc();
+    clientDoc.getText('markdown').insert(0, 'first');
+    const firstUpdate = Y.encodeStateAsUpdate(clientDoc);
+    clientDoc.getText('markdown').insert(clientDoc.getText('markdown').length, ' second');
+    const secondUpdate = Y.encodeStateAsUpdate(clientDoc);
+
+    socket.emitMessage(encodeAckedSyncUpdate({ ackId: 'burst-1', update: firstUpdate }));
+    socket.emitMessage(encodeAckedSyncUpdate({ ackId: 'burst-2', update: secondUpdate }));
+
+    await waitUntil(
+      () => timings.filter((event) => event.stage === 'save_ack.emitted').length === 2,
+      () => `Timed out waiting for burst save timings; sent=${describeMessages(socket.sent)}`
+    );
+    expect(ackCountsAtSaveTiming).toEqual([2, 2]);
+    const saveTimings = timings.filter((event) => event.stage === 'save_ack.emitted');
+    expect(saveTimings.map((event) => 'ackId' in event ? event.ackId : undefined).sort())
+      .toEqual(['burst-1', 'burst-2']);
+    expect(saveTimings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        ackId: 'burst-1',
+        updateBytes: firstUpdate.byteLength,
+        updateFingerprint: fingerprintDocumentBytes(firstUpdate),
+      }),
+      expect.objectContaining({
+        ackId: 'burst-2',
+        updateBytes: secondUpdate.byteLength,
+        updateFingerprint: fingerprintDocumentBytes(secondUpdate),
+      }),
+    ]));
+    expect(saveTimings.every((event) => (
+      'observedAtMs' in event && typeof event.observedAtMs === 'number'
+    ))).toBe(true);
+    expect(new Set(saveTimings.map((event) => (
+      'stateVectorFingerprint' in event ? event.stateVectorFingerprint : undefined
+    ))).size).toBe(1);
+
+    socket.emitClose();
+    await binding.closed;
+    await session.close();
+    clientDoc.destroy();
+  });
+
+  it('emits save acknowledgement telemetry when the session becomes terminal after the ack', async () => {
+    const filePath = join(kb1Home, 'demo-vault', 'terminal-after-ack.md');
+    const session = new OneFileDocumentSession(filePath, { defaultContent: '' });
+    await session.open();
+    const activeDoc = session.ydoc;
+    let sessionTerminal = false;
+    Object.defineProperty(session, 'ydoc', {
+      configurable: true,
+      get: () => {
+        if (sessionTerminal) throw new Error('file not found');
+        return activeDoc;
+      },
+    });
+    const socket = new FakeSocket();
+    const originalSend = socket.send.bind(socket);
+    socket.send = (data: Uint8Array) => {
+      originalSend(data);
+      if (messageType(data) === MESSAGE_SYNC_UPDATE_ACK) sessionTerminal = true;
+    };
+    const timings: YjsWebSocketTimingEvent[] = [];
+    const binding = await bindYjsWebSocket(session, socket, {
+      onTiming: (event) => timings.push(event)
+    });
+    const clientDoc = new Y.Doc();
+    clientDoc.getText('markdown').insert(0, 'durable before terminal state\n');
+
+    socket.emitMessage(encodeAckedSyncUpdate({
+      ackId: 'terminal-after-ack',
+      update: Y.encodeStateAsUpdate(clientDoc)
+    }));
+
+    await waitUntil(
+      () => timings.some((event) => (
+        event.stage === 'save_ack.emitted' && event.ackId === 'terminal-after-ack'
+      )),
+      () => `Timed out waiting for terminal save timing; sent=${describeMessages(socket.sent)}`
+    );
+    expect(timings.find((event) => (
+      event.stage === 'save_ack.emitted' && event.ackId === 'terminal-after-ack'
+    ))).toMatchObject({
+      stateVectorFingerprint: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+    });
+
+    socket.emitClose();
+    await binding.closed;
+    delete (session as unknown as Record<string, unknown>).ydoc;
+    await session.close();
+    clientDoc.destroy();
+  });
+
+  it('emits save acknowledgement telemetry after persistence recovers', async () => {
+    const vaultDir = join(kb1Home, 'demo-vault');
+    const filePath = join(vaultDir, 'recovered-ack.md');
+    const session = new OneFileDocumentSession(filePath, { defaultContent: '' });
+    await session.open();
+    const socket = new FakeSocket();
+    const timings: YjsWebSocketTimingEvent[] = [];
+    const binding = await bindYjsWebSocket(session, socket, {
+      onTiming: (event) => timings.push(event)
+    });
+    const clientDoc = new Y.Doc();
+    clientDoc.getText('markdown').insert(0, 'persist after recovery\n');
+    const update = Y.encodeStateAsUpdate(clientDoc);
+
+    try {
+      await chmod(vaultDir, 0o500);
+      socket.emitMessage(encodeAckedSyncUpdate({ ackId: 'recovered-1', update }));
+      await waitUntil(
+        () => socket.sent.some((message) => sessionEventKind(message) === 'persist-failure'),
+        () => `Timed out waiting for persist failure; sent=${describeMessages(socket.sent)}`
+      );
+      expect(findSyncUpdateAck(socket.sent, 'recovered-1')).toBeUndefined();
+
+      await chmod(vaultDir, 0o700);
+      await session.flush();
+      await waitUntil(
+        () => timings.some((event) => (
+          event.stage === 'save_ack.emitted' && event.ackId === 'recovered-1'
+        )),
+        () => `Timed out waiting for recovered save timing; sent=${describeMessages(socket.sent)}`
+      );
+
+      expect(findSyncUpdateAck(socket.sent, 'recovered-1')).toBeDefined();
+      expect(timings.find((event) => (
+        event.stage === 'save_ack.emitted' && event.ackId === 'recovered-1'
+      ))).toMatchObject({
+        observedAtMs: expect.any(Number),
+        updateBytes: update.byteLength,
+        updateFingerprint: fingerprintDocumentBytes(update),
+        stateVectorFingerprint: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+      });
+    } finally {
+      await chmod(vaultDir, 0o700).catch(() => undefined);
+      socket.emitClose();
+      await binding.closed;
+      await session.close();
+      clientDoc.destroy();
+    }
+  });
+
+  it('emits captured initial state telemetry after a fast socket close', async () => {
+    const filePath = join(kb1Home, 'demo-vault', 'fast-close.md');
+    const session = new OneFileDocumentSession(filePath, { defaultContent: 'durable\n' });
+    await session.open();
+    const socket = new FakeSocket();
+    const timings: YjsWebSocketTimingEvent[] = [];
+    const binding = await bindYjsWebSocket(session, socket, {
+      onTiming: (event) => timings.push(event)
+    });
+
+    socket.readyState = WebSocket.CLOSED;
+    socket.emitClose();
+    await binding.closed;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(timings.find((event) => event.stage === 'initial_state_vector.observed')).toMatchObject({
+      documentChars: 'durable\n'.length,
+      observedAtMs: expect.any(Number),
+      stateVectorBytes: expect.any(Number),
+      stateVectorFingerprint: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+    });
+    await session.close();
   });
 
   it('sends opaque attribution sidecars for attributed session mutations', async () => {
@@ -208,6 +428,16 @@ describe('Yjs WebSocket session', () => {
     socket.emitClose();
     await binding.closed;
     await session.close();
+  });
+
+  it('does not inspect Yjs state when no timing observer is configured', () => {
+    const inaccessibleDoc = {
+      getText: () => {
+        throw new Error('timing fields must stay lazy');
+      },
+    } as unknown as Y.Doc;
+
+    expect(documentStateVectorTimingFields(undefined, inaccessibleDoc)).toEqual({});
   });
 
   it('labels socket-origin Yjs updates with the socket binding attribution', async () => {
@@ -1165,6 +1395,16 @@ function describeMessages(messages: Uint8Array[]): string {
 function messageType(message: Uint8Array): number {
   const decoder = decoding.createDecoder(message);
   return decoding.readVarUint(decoder);
+}
+
+function findInitialStateVector(messages: Uint8Array[]): Uint8Array | undefined {
+  for (const message of messages) {
+    const decoder = decoding.createDecoder(message);
+    if (decoding.readVarUint(decoder) !== MESSAGE_SYNC) continue;
+    if (decoding.readVarUint(decoder) !== syncProtocol.messageYjsSyncStep1) continue;
+    return decoding.readVarUint8Array(decoder);
+  }
+  return undefined;
 }
 
 function receiveSyncMessage(doc: Y.Doc, message: Uint8Array): Uint8Array | undefined {

--- a/packages/doc-session/src/websocket.ts
+++ b/packages/doc-session/src/websocket.ts
@@ -3,6 +3,8 @@ import * as encoding from 'lib0/encoding';
 import * as syncProtocol from 'y-protocols/sync';
 import * as Y from 'yjs';
 
+import { fingerprintDocumentBytes } from './fingerprint.js';
+
 import {
   DOCUMENT_SESSION_FAILURE_CLOSE_CODE,
   DOCUMENT_SESSION_NOT_FOUND_FAILURE,
@@ -56,13 +58,34 @@ export type YjsWebSocketTimingEvent =
       stage:
         | 'document_session.open'
         | 'initial_sync.emitted'
+        | 'initial_state_vector.observed'
         | 'synced_marker.emitted'
         | 'save_ack.emitted';
       durationMs: number;
+      observedAtMs?: number;
       ackId?: string;
+      documentChars?: number;
+      stateVectorBytes?: number;
+      stateVectorFingerprint?: string;
+      updateBytes?: number;
+      updateFingerprint?: string;
     };
 
 export type YjsWebSocketTimingHandler = (event: YjsWebSocketTimingEvent) => void;
+
+interface PendingSaveAckTiming {
+  durationMs: number;
+  observedAtMs: number;
+  ackId: string;
+  updateBytes: number;
+  updateFingerprint: string;
+}
+
+interface DeferredPersistedAck {
+  saveStartedAt: number;
+  updateBytes: number;
+  updateFingerprint: string;
+}
 
 export async function bindYjsWebSocket(
   session: OneFileDocumentSession,
@@ -82,7 +105,9 @@ export async function bindYjsWebSocket(
     rejectClosed = reject;
   });
   let unsubscribeSessionEvents: () => void = () => {};
-  const deferredPersistedAckIds = new Set<string>();
+  const deferredPersistedAcks = new Map<string, DeferredPersistedAck | undefined>();
+  const pendingSaveAckTimings: PendingSaveAckTiming[] = [];
+  let saveAckTimingScheduled = false;
   const socketUpdateOrigin = createDocumentUpdateAttributionOrigin(
     options.attribution ?? LOCAL_USER_DOCUMENT_UPDATE_ATTRIBUTION,
     socket
@@ -109,6 +134,7 @@ export async function bindYjsWebSocket(
     cleanupStarted = true;
     unsubscribeSessionEvents();
     sessionDoc?.off('update', updateHandler);
+    deferredPersistedAcks.clear();
     session.flush().then(resolveClosed, (error: unknown) => {
       if (error instanceof PersistFailedError) {
         resolveClosed();
@@ -136,6 +162,31 @@ export async function bindYjsWebSocket(
     emitTiming(options.onTiming, {
       stage: 'synced_marker.emitted',
       durationMs: elapsedMs(bindingStartedAt),
+    });
+  };
+
+  const queueSaveAckTiming = (timing: PendingSaveAckTiming) => {
+    pendingSaveAckTimings.push(timing);
+    if (saveAckTimingScheduled) return;
+    saveAckTimingScheduled = true;
+    queueMicrotask(() => {
+      saveAckTimingScheduled = false;
+      const batch = pendingSaveAckTimings.splice(0);
+      const activeDoc = sessionDoc;
+      const stateFields = activeDoc
+        ? documentStateVectorTimingFields(options.onTiming, activeDoc)
+        : {};
+      for (const event of batch) {
+        emitTiming(options.onTiming, {
+          stage: 'save_ack.emitted',
+          durationMs: event.durationMs,
+          observedAtMs: event.observedAtMs,
+          ackId: event.ackId,
+          updateBytes: event.updateBytes,
+          updateFingerprint: event.updateFingerprint,
+          ...stateFields,
+        });
+      }
     });
   };
 
@@ -168,14 +219,28 @@ export async function bindYjsWebSocket(
         const saveStartedAt = performance.now();
         void session.flush({ onTiming: options.onTiming as DocumentSessionTimingHandler | undefined }).then(() => {
           sendBytes(socket, encodeSyncUpdateAck({ ackId: ackedUpdate.ackId, ts: Date.now() }));
-          emitTiming(options.onTiming, {
-            stage: 'save_ack.emitted',
-            durationMs: elapsedMs(saveStartedAt),
-            ackId: ackedUpdate.ackId,
-          });
+          const observedAtMs = performance.now();
+          if (options.onTiming) {
+            queueSaveAckTiming({
+              durationMs: elapsedMs(saveStartedAt, observedAtMs),
+              observedAtMs,
+              ackId: ackedUpdate.ackId,
+              updateBytes: ackedUpdate.update.byteLength,
+              updateFingerprint: fingerprintDocumentBytes(ackedUpdate.update),
+            });
+          }
         }, (error: unknown) => {
           if (error instanceof PersistFailedError) {
-            deferredPersistedAckIds.add(ackedUpdate.ackId);
+            deferredPersistedAcks.set(
+              ackedUpdate.ackId,
+              options.onTiming
+                ? {
+                    saveStartedAt,
+                    updateBytes: ackedUpdate.update.byteLength,
+                    updateFingerprint: fingerprintDocumentBytes(ackedUpdate.update),
+                  }
+                : undefined,
+            );
             return;
           }
           console.warn('KB-1 failed to acknowledge persisted Yjs update.', error);
@@ -245,15 +310,25 @@ export async function bindYjsWebSocket(
   unsubscribeSessionEvents = session.onEvent((event) => {
     sendBytes(socket, encodeSessionEvent(event));
     if (event.kind === 'doc-deleted') {
-      deferredPersistedAckIds.clear();
+      deferredPersistedAcks.clear();
       closeDeletedDocument(socket);
       return;
     }
-    if (event.kind === 'content-persisted' && deferredPersistedAckIds.size > 0) {
-      for (const ackId of deferredPersistedAckIds) {
+    if (event.kind === 'content-persisted' && deferredPersistedAcks.size > 0) {
+      for (const [ackId, deferredAck] of deferredPersistedAcks) {
         sendBytes(socket, encodeSyncUpdateAck({ ackId, ts: event.ts }));
+        const observedAtMs = performance.now();
+        if (options.onTiming && deferredAck) {
+          queueSaveAckTiming({
+            durationMs: elapsedMs(deferredAck.saveStartedAt, observedAtMs),
+            observedAtMs,
+            ackId,
+            updateBytes: deferredAck.updateBytes,
+            updateFingerprint: deferredAck.updateFingerprint,
+          });
+        }
       }
-      deferredPersistedAckIds.clear();
+      deferredPersistedAcks.clear();
     }
   });
 
@@ -266,15 +341,53 @@ export async function bindYjsWebSocket(
     processSyncMessage(data);
   }
 
+  const initialStateVector = options.onTiming ? Y.encodeStateVector(openedDoc) : undefined;
+  const initialDocumentChars = options.onTiming ? openedDoc.getText(Y_TEXT_NAME).length : undefined;
   sendSync(socket, (encoder) => {
+    if (initialStateVector) {
+      encoding.writeVarUint(encoder, syncProtocol.messageYjsSyncStep1);
+      encoding.writeVarUint8Array(encoder, initialStateVector);
+      return;
+    }
     syncProtocol.writeSyncStep1(encoder, openedDoc);
   });
+  const initialSyncObservedAtMs = performance.now();
   emitTiming(options.onTiming, {
     stage: 'initial_sync.emitted',
-    durationMs: elapsedMs(bindingStartedAt),
+    durationMs: elapsedMs(bindingStartedAt, initialSyncObservedAtMs),
+    observedAtMs: initialSyncObservedAtMs,
   });
+  if (options.onTiming && initialStateVector) {
+    setImmediate(() => {
+      emitTiming(options.onTiming, {
+        stage: 'initial_state_vector.observed',
+        durationMs: elapsedMs(bindingStartedAt, initialSyncObservedAtMs),
+        observedAtMs: initialSyncObservedAtMs,
+        documentChars: initialDocumentChars,
+        stateVectorBytes: initialStateVector.byteLength,
+        stateVectorFingerprint: fingerprintDocumentBytes(initialStateVector),
+      });
+    });
+  }
 
   return { closed };
+}
+
+export function documentStateVectorTimingFields(
+  handler: YjsWebSocketTimingHandler | undefined,
+  doc: Y.Doc,
+): Partial<{
+  documentChars: number;
+  stateVectorBytes: number;
+  stateVectorFingerprint: string;
+}> {
+  if (!handler) return {};
+  const stateVector = Y.encodeStateVector(doc);
+  return {
+    documentChars: doc.getText(Y_TEXT_NAME).length,
+    stateVectorBytes: stateVector.byteLength,
+    stateVectorFingerprint: fingerprintDocumentBytes(stateVector),
+  };
 }
 
 function sendSync(socket: YjsWebSocketLike, write: (encoder: encoding.Encoder) => void): void {
@@ -378,8 +491,8 @@ function closeDeletedDocument(socket: YjsWebSocketLike): void {
   );
 }
 
-function elapsedMs(startedAt: number): number {
-  return Math.max(0, Math.round((performance.now() - startedAt) * 100) / 100);
+function elapsedMs(startedAt: number, observedAtMs = performance.now()): number {
+  return Math.max(0, Math.round((observedAtMs - startedAt) * 100) / 100);
 }
 
 function emitTiming(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@noble/hashes':
+      specifier: 2.2.0
+      version: 2.2.0
     '@storybook/addon-docs':
       specifier: 10.4.6
       version: 10.4.6
@@ -234,6 +237,9 @@ importers:
       '@kb-1/vault-core':
         specifier: workspace:*
         version: link:../vault-core
+      '@noble/hashes':
+        specifier: 'catalog:'
+        version: 2.2.0
       fast-diff:
         specifier: 1.3.0
         version: 1.3.0
@@ -836,6 +842,10 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nx/nx-darwin-arm64@22.7.6':
     resolution: {integrity: sha512-FBKG9Tqrl8H0A4oIekVTJNNq+tRMrkyF0fLBV4Cpi9Hm1ejA8dl5gpEG/o5V7MwiClVddDwtXp1ymdCa2qSoyg==}
@@ -3599,6 +3609,8 @@ snapshots:
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.3
     optional: true
+
+  '@noble/hashes@2.2.0': {}
 
   '@nx/nx-darwin-arm64@22.7.6':
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ overrides:
   form-data: 4.0.6
 
 catalog:
+  '@noble/hashes': 2.2.0
   '@storybook/addon-docs': 10.4.6
   '@storybook/addon-svelte-csf': 5.1.2
   '@storybook/svelte': 10.4.6


### PR DESCRIPTION
## Summary

- acknowledge tagged updates only after Markdown and Yjs state are durable
- emit document-session stage timing and reconnect diagnostics
- add opt-in, privacy-safe SHA-256 state and update fingerprints
- correlate recovery ACKs without retaining raw failed update buffers

## Why

Saved-state and latency investigations need exact daemon-durability visibility without changing write authority or logging document content.

## Impact

- observability and ACK semantics only; no document payload logging
- does not enable write-capable hot documents
- does not deploy or change production configuration

## Verification

- `pnpm --filter @kb-1/doc-session test` (120 tests)
- `pnpm check`
