### PR TITLE
fix(web): retain retired document edits

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -417,6 +417,16 @@
     status = 'closed';
   }
 
+  function markDocumentRetired(path = documentPath): void {
+    if (!path) return;
+    notFoundPath = null;
+    docDeleted = true;
+    persistFailureActive = false;
+    externalChangeVisible = false;
+    externalMergeVisible = false;
+    status = 'closed';
+  }
+
   // The node the URL currently points at, resolved against the live
   // tree. Mirrors KB-1's selector resolution: the tree decides whether
   // a path is a folder or a note, and the route renders the matching
@@ -777,7 +787,7 @@
     }
 
     if (event.kind === 'doc-deleted') {
-      markDocumentNotFound(event.path);
+      markDocumentRetired(event.path);
       void refreshTree();
       return;
     }
@@ -846,6 +856,10 @@
       onError: (caught) => {
         if (generation !== providerGeneration) return;
         if (isLocalDocumentProviderOpenError(caught)) {
+          if (docDeleted && path === documentPath) {
+            error = null;
+            return;
+          }
           notFoundPath = path;
           providerSynced = false;
           error = null;

--- a/apps/web/src/test/local-editor-route.test.ts
+++ b/apps/web/src/test/local-editor-route.test.ts
@@ -16,7 +16,12 @@ import { setPageUrl } from "./page-state.svelte";
 const mocks = vi.hoisted(() => ({
   goto: vi.fn(),
   destroyProvider: vi.fn(),
-  providers: [] as Array<{ path: string; doc: Y.Doc; text: Y.Text }>,
+  providers: [] as Array<{
+    path: string;
+    doc: Y.Doc;
+    text: Y.Text;
+    retireAndClose: () => void;
+  }>,
   delayedSyncPaths: new Set<string>(),
   pendingSyncs: new Map<string, () => void>(),
 }));
@@ -88,7 +93,20 @@ vi.mock("$lib/yjs/local-document-provider", async () => {
           open();
         }
       }
-      mocks.providers.push({ path, doc, text });
+      mocks.providers.push({
+        path,
+        doc,
+        text,
+        retireAndClose: () => {
+          options.onSessionEvent?.({
+            kind: "doc-deleted",
+            path,
+            ts: Date.now(),
+          });
+          options.onStatus?.("closed");
+          options.onError?.(new TestLocalDocumentProviderOpenError());
+        },
+      });
       return {
         doc,
         text,
@@ -467,6 +485,28 @@ describe("local editor route", () => {
       "content:projects/active/editor-shell.md",
     );
     expect(editor.value).toBe("content:projects/active/editor-shell.md");
+  });
+
+  it("keeps retained edits visible and read-only when terminal deletion is followed by not_found", async () => {
+    render(AppStateHarness);
+
+    const editor = await waitForBoundEditor("content:hello-world.md");
+    await fireEvent.input(editor, {
+      target: { value: "retained local edit" },
+    });
+
+    mocks.providers.at(-1)?.retireAndClose();
+
+    await waitFor(() => {
+      const retainedEditor = screen.getByLabelText(
+        "Markdown editor",
+      ) as HTMLTextAreaElement;
+      expect(retainedEditor.value).toBe("retained local edit");
+      expect(retainedEditor.readOnly).toBe(true);
+    });
+    expect(screen.queryByText("Document not found")).toBeNull();
+    expect(await screen.findByText("Document deleted")).toBeTruthy();
+    expect(mocks.destroyProvider).not.toHaveBeenCalled();
   });
 
   it("opens note history from the byline and pages older entries", async () => {


### PR DESCRIPTION
## Summary

- keep the active Yjs document mounted after a terminal document event
- render the retained content read-only with the existing deletion warning
- ignore the ensuing `not_found` close only for that already-retired active session

## Behavior

A true missing-document open still renders the normal not-found state. This change only preserves content after the editor already received the terminal session event.

## Verification

- `pnpm --filter @kb-1/web exec vitest run src/test/local-editor-route.test.ts` (10 passed)
- `pnpm check`

