### PR TITLE
ci: run Windows lifecycle smoke only when needed

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,8 @@ name: Check
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 permissions:
@@ -30,34 +32,3 @@ jobs:
 
       - name: Run checks
         run: pnpm check
-
-  windows-smoke:
-    runs-on: windows-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-
-      - name: Enable package manager
-        run: |
-          corepack enable
-          corepack install
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Verify Windows source support
-        run: |
-          pnpm test:scripts
-          pnpm typecheck
-          pnpm build
-          pnpm smoke:windows
-
-      - name: Verify Windows background task lifecycle
-        shell: powershell
-        run: .\scripts\windows-task-smoke.ps1

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -1,0 +1,48 @@
+name: Windows lifecycle smoke
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/windows-smoke.yml
+      - scripts/windows-smoke.mjs
+      - scripts/windows-task-smoke.ps1
+      - skills/kb-1-daemon-setup/scripts/install_kb1_daemon_user_task.ps1
+      - skills/kb-1-daemon-setup/scripts/run_kb1_daemon_user_task.ps1
+  schedule:
+    - cron: "17 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  windows-smoke:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Enable package manager
+        run: |
+          corepack enable
+          corepack install
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify Windows source support
+        run: |
+          pnpm test:scripts
+          pnpm typecheck
+          pnpm build
+          pnpm smoke:windows
+
+      - name: Verify Windows background task lifecycle
+        shell: powershell
+        run: .\scripts\windows-task-smoke.ps1


### PR DESCRIPTION
## Summary

- run the normal `Check` workflow on pull requests and pushes to `main`, avoiding duplicate feature-branch `push` and `pull_request` runs
- move the full Windows lifecycle smoke into its own workflow
- run that smoke only for Windows workflow/smoke/installer script changes, nightly, or by manual dispatch

## Behavior

- the Windows smoke steps themselves are unchanged
- the required `check` job remains present on every pull request
- unrelated pull requests no longer spend roughly 10 minutes on the Windows lifecycle job

## Verification

- parsed both workflow files with the repository's YAML 2.9.0 dependency and confirmed their trigger/job structure
- confirmed `check` is the only required branch status context
- `pnpm --filter @kb-1/vault-core exec vitest run src/index.test.ts -t "caps the searchable file walk before unbounded scans"` (1 passed)
- `NX_PARALLEL=3 pnpm check`
