### PR TITLE
Restore per-document dial-back transport

### DIFF
--- a/packages/tunnel-client/src/heartbeat.test.ts
+++ b/packages/tunnel-client/src/heartbeat.test.ts
@@ -84,18 +84,15 @@ describe('TunnelClient control heartbeat', () => {
     });
     firstControl.open();
 
-    expect(sentText(firstControl, 0)).toBe(
-      encodeTunnelMessage({
-        type: 'control.hello',
-        version: 2,
-        token: 'token-1',
-        features: [
-          TUNNEL_FEATURES.RELAY_FRAMES_V1,
-          TUNNEL_FEATURES.WEBSOCKET_STREAMS_V1,
-          TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
-        ],
-      }),
-    );
+    expect(sentText(firstControl, 0)).toBe(encodeTunnelMessage({
+      type: 'control.hello',
+      version: 2,
+      token: 'token-1',
+      features: [
+        TUNNEL_FEATURES.RELAY_FRAMES_V1,
+        TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
+      ],
+    }));
 
     await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_INTERVAL_MS);
     expect(sentText(firstControl, 1)).toBe(encodeTunnelMessage({ type: 'control.ping' }));
@@ -197,20 +194,17 @@ describe('TunnelClient control heartbeat', () => {
     const firstControl = MockWebSocket.instances[0];
     firstControl.open();
 
-    expect(sentText(firstControl, 0)).toBe(
-      encodeTunnelMessage({
-        type: 'control.hello',
-        version: 2,
-        token: 'token-1',
-        daemonVersion: '0.1.0',
-        daemonBuild: 'registry.fly.io/kb1@sha256:abc123',
-        features: [
-          TUNNEL_FEATURES.RELAY_FRAMES_V1,
-          TUNNEL_FEATURES.WEBSOCKET_STREAMS_V1,
-          TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
-        ],
-      }),
-    );
+    expect(sentText(firstControl, 0)).toBe(encodeTunnelMessage({
+      type: 'control.hello',
+      version: 2,
+      token: 'token-1',
+      daemonVersion: '0.1.0',
+      daemonBuild: 'registry.fly.io/kb1@sha256:abc123',
+      features: [
+        TUNNEL_FEATURES.RELAY_FRAMES_V1,
+        TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
+      ],
+    }));
   });
 
   it('keeps connect and disconnect idempotent for lifecycle callers', async () => {

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -7,15 +7,12 @@ import {
   TUNNEL_CLOSE_CODES,
   TUNNEL_FEATURES,
   TUNNEL_PENDING_STREAM_FRAME_LIMIT,
-  TUNNEL_PENDING_STREAM_PAIR_TIMEOUT_MS,
-  TUNNEL_WEBSOCKET_STREAM_CAPABILITY,
   TUNNEL_WS_FRAME_BYTE_LIMIT,
   encodeTunnelMessage,
   type RelayFrame,
 } from '@kb-1/tunnel-protocol';
 import {
   ChunkedHttpRequestAssembler,
-  ControlWebSocketBridge,
   DialbackBridge,
   TunnelClient,
   createBackoffDelay,
@@ -23,7 +20,6 @@ import {
   relayInternalUrl,
   serializableResponseHeaders,
   sendableCloseCode,
-  sendableCloseReason,
   withoutHopByHop,
   type BridgeSocket,
 } from './index.js';
@@ -33,7 +29,6 @@ class FakeSocket extends EventEmitter implements BridgeSocket {
   readonly sent: Array<{ data: unknown; options?: { binary?: boolean } }> = [];
   readonly closes: Array<{ code?: number; reason?: string }> = [];
   sendError: Error | undefined;
-  closeError: Error | undefined;
 
   send(data: unknown, options?: { binary?: boolean }): void {
     if (this.sendError) throw this.sendError;
@@ -41,9 +36,8 @@ class FakeSocket extends EventEmitter implements BridgeSocket {
   }
 
   close(code?: number, reason?: string): void {
-    this.closes.push({ code, reason });
-    if (this.closeError) throw this.closeError;
     this.readyState = 3;
+    this.closes.push({ code, reason });
     this.emit('close', code ?? 1000, Buffer.from(reason ?? ''));
   }
 
@@ -76,11 +70,6 @@ describe('tunnel-client helpers', () => {
     expect(sendableCloseCode(3000)).toBe(3000);
     expect(sendableCloseCode(999)).toBe(1011);
     expect(sendableCloseCode(5000)).toBe(1011);
-  });
-
-  it('caps close reasons at the websocket UTF-8 byte limit', () => {
-    expect(Buffer.byteLength(sendableCloseReason('x'.repeat(200)), 'utf8')).toBe(123);
-    expect(sendableCloseReason('🙂'.repeat(31))).toBe('🙂'.repeat(30));
   });
 
   it('preserves the stable tunnel path when building internal relay URLs', () => {
@@ -181,312 +170,6 @@ describe('ChunkedHttpRequestAssembler', () => {
   });
 });
 
-describe('ControlWebSocketBridge', () => {
-  it('carries document websocket frames over the existing control socket', () => {
-    const controlSocket = new FakeSocket();
-    const daemonSocket = new FakeSocket();
-    controlSocket.open();
-    const bridge = new ControlWebSocketBridge({
-      streamId: 'stream-1',
-      controlSocket,
-      daemonSocket,
-    });
-    bridge.start();
-
-    daemonSocket.open();
-    expect(JSON.parse(Buffer.from(controlSocket.sent[0].data as Uint8Array).toString('utf8'))).toEqual({
-      type: 'relay.frame',
-      frame: {
-        type: 'stream.open',
-        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
-        streamId: 'stream-1',
-        capability: TUNNEL_WEBSOCKET_STREAM_CAPABILITY,
-      },
-    });
-
-    bridge.receive({
-      type: 'stream.data',
-      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
-      streamId: 'stream-1',
-      sequence: 0,
-      payload: {
-        encoding: 'base64',
-        dataB64: Buffer.from([1, 2, 3]).toString('base64'),
-      },
-    });
-    expect(daemonSocket.sent).toEqual([{ data: Buffer.from([1, 2, 3]), options: { binary: true } }]);
-
-    daemonSocket.message(Buffer.from([4, 5, 6]));
-    expect(JSON.parse(Buffer.from(controlSocket.sent[1].data as Uint8Array).toString('utf8'))).toEqual({
-      type: 'relay.frame',
-      frame: {
-        type: 'stream.data',
-        version: RELAY_TRANSPORT_PROTOCOL_VERSION,
-        streamId: 'stream-1',
-        sequence: 0,
-        payload: {
-          encoding: 'base64',
-          dataB64: Buffer.from([4, 5, 6]).toString('base64'),
-        },
-      },
-    });
-
-    bridge.closeFromControl(1000, 'done');
-    expect(daemonSocket.closes[0]).toEqual({ code: 1000, reason: 'done' });
-  });
-
-  it('propagates daemon close and oversized frames to the control stream', () => {
-    const controlSocket = new FakeSocket();
-    const daemonSocket = new FakeSocket();
-    const onClosed = vi.fn();
-    controlSocket.open();
-    const bridge = new ControlWebSocketBridge({
-      streamId: 'stream-close',
-      controlSocket,
-      daemonSocket,
-      logger: { log: vi.fn() },
-      onClosed,
-    });
-    bridge.start();
-    daemonSocket.open();
-    daemonSocket.message(Buffer.alloc(TUNNEL_WS_FRAME_BYTE_LIMIT + 1));
-
-    expect(JSON.parse(Buffer.from(controlSocket.sent[1].data as Uint8Array).toString('utf8'))).toMatchObject({
-      type: 'ws.close',
-      streamId: 'stream-close',
-      code: TUNNEL_CLOSE_CODES.OVERSIZED_WS_FRAME,
-    });
-    expect(daemonSocket.closes[0]?.code).toBe(TUNNEL_CLOSE_CODES.OVERSIZED_WS_FRAME);
-    expect(onClosed).toHaveBeenCalledOnce();
-
-    const secondControl = new FakeSocket();
-    const secondDaemon = new FakeSocket();
-    secondControl.open();
-    const secondBridge = new ControlWebSocketBridge({
-      streamId: 'stream-daemon-close',
-      controlSocket: secondControl,
-      daemonSocket: secondDaemon,
-      logger: { log: vi.fn() },
-    });
-    secondBridge.start();
-    secondDaemon.open();
-    secondDaemon.close(1000, 'daemon done');
-    expect(JSON.parse(Buffer.from(secondControl.sent[1].data as Uint8Array).toString('utf8'))).toEqual({
-      type: 'ws.close',
-      streamId: 'stream-daemon-close',
-      code: 1000,
-      reason: 'daemon done',
-    });
-  });
-
-  it('fails closed for invalid, oversized, or premature relay frames', () => {
-    const cases: Array<{
-      name: string;
-      prepare?: (daemon: FakeSocket) => void;
-      payload: RelayFrame;
-      code: number;
-    }> = [
-      {
-        name: 'invalid payload',
-        prepare: (daemon) => daemon.open(),
-        payload: {
-          type: 'stream.data',
-          version: RELAY_TRANSPORT_PROTOCOL_VERSION,
-          streamId: 'stream-invalid',
-          sequence: 0,
-          payload: { encoding: 'json', value: null },
-        },
-        code: TUNNEL_CLOSE_CODES.BAD_PROTOCOL,
-      },
-      {
-        name: 'oversized payload',
-        prepare: (daemon) => daemon.open(),
-        payload: {
-          type: 'stream.data',
-          version: RELAY_TRANSPORT_PROTOCOL_VERSION,
-          streamId: 'stream-invalid',
-          sequence: 0,
-          payload: {
-            encoding: 'base64',
-            dataB64: Buffer.alloc(TUNNEL_WS_FRAME_BYTE_LIMIT + 1).toString('base64'),
-          },
-        },
-        code: TUNNEL_CLOSE_CODES.OVERSIZED_WS_FRAME,
-      },
-      {
-        name: 'premature payload',
-        payload: {
-          type: 'stream.data',
-          version: RELAY_TRANSPORT_PROTOCOL_VERSION,
-          streamId: 'stream-invalid',
-          sequence: 0,
-          payload: { encoding: 'base64', dataB64: 'AQ==' },
-        },
-        code: TUNNEL_CLOSE_CODES.STREAM_RETRY_SAFE,
-      },
-    ];
-
-    for (const testCase of cases) {
-      const controlSocket = new FakeSocket();
-      const daemonSocket = new FakeSocket();
-      controlSocket.open();
-      const bridge = new ControlWebSocketBridge({
-        streamId: 'stream-invalid',
-        controlSocket,
-        daemonSocket,
-        logger: { log: vi.fn() },
-      });
-      bridge.start();
-      testCase.prepare?.(daemonSocket);
-      bridge.receive(testCase.payload as Extract<RelayFrame, { type: 'stream.data' }>);
-      const close = JSON.parse(Buffer.from(controlSocket.sent.at(-1)?.data as Uint8Array).toString('utf8')) as {
-        type: string;
-        code: number;
-      };
-      expect(close, testCase.name).toMatchObject({
-        type: 'ws.close',
-        code: testCase.code,
-      });
-    }
-  });
-
-  it('cleans up when daemon or control sends fail', () => {
-    const controlSocket = new FakeSocket();
-    const daemonSocket = new FakeSocket();
-    const logger = { log: vi.fn() };
-    controlSocket.open();
-    const bridge = new ControlWebSocketBridge({
-      streamId: 'stream-errors',
-      controlSocket,
-      daemonSocket,
-      logger,
-    });
-    bridge.start();
-    daemonSocket.open();
-    daemonSocket.sendError = new Error('daemon send failed');
-    bridge.receive({
-      type: 'stream.data',
-      version: RELAY_TRANSPORT_PROTOCOL_VERSION,
-      streamId: 'stream-errors',
-      sequence: 0,
-      payload: { encoding: 'base64', dataB64: 'AQ==' },
-    });
-    expect(logger.log).toHaveBeenCalledWith(
-      'warn',
-      'multiplexed daemon websocket send failed',
-      expect.objectContaining({ streamId: 'stream-errors' }),
-    );
-
-    const failingControl = new FakeSocket();
-    const secondDaemon = new FakeSocket();
-    failingControl.open();
-    failingControl.sendError = new Error('control send failed');
-    const secondBridge = new ControlWebSocketBridge({
-      streamId: 'stream-control-error',
-      controlSocket: failingControl,
-      daemonSocket: secondDaemon,
-      logger,
-    });
-    secondBridge.start();
-    secondDaemon.open();
-    expect(secondDaemon.closes[0]?.code).toBe(TUNNEL_CLOSE_CODES.STREAM_RETRY_SAFE);
-
-    const thirdControl = new FakeSocket();
-    const thirdDaemon = new FakeSocket();
-    thirdControl.open();
-    const thirdBridge = new ControlWebSocketBridge({
-      streamId: 'stream-daemon-error',
-      controlSocket: thirdControl,
-      daemonSocket: thirdDaemon,
-      logger,
-    });
-    thirdBridge.start();
-    thirdDaemon.open();
-    thirdDaemon.emit('error', new Error('socket failed'));
-    expect(thirdDaemon.closes[0]?.code).toBe(1011);
-  });
-
-  it('times out a daemon websocket that never completes its handshake', async () => {
-    vi.useFakeTimers();
-    try {
-      const controlSocket = new FakeSocket();
-      const daemonSocket = new FakeSocket();
-      const onClosed = vi.fn();
-      controlSocket.open();
-      const bridge = new ControlWebSocketBridge({
-        streamId: 'stream-timeout',
-        controlSocket,
-        daemonSocket,
-        logger: { log: vi.fn() },
-        onClosed,
-      });
-      bridge.start();
-
-      await vi.advanceTimersByTimeAsync(TUNNEL_PENDING_STREAM_PAIR_TIMEOUT_MS);
-
-      expect(JSON.parse(Buffer.from(controlSocket.sent[0].data as Uint8Array).toString('utf8'))).toMatchObject({
-        type: 'ws.close',
-        streamId: 'stream-timeout',
-        code: TUNNEL_CLOSE_CODES.PENDING_STREAM_TIMEOUT,
-      });
-      expect(daemonSocket.closes[0]?.code).toBe(TUNNEL_CLOSE_CODES.PENDING_STREAM_TIMEOUT);
-      expect(onClosed).toHaveBeenCalledOnce();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('sanitizes control close metadata and cleans up when daemon close throws', () => {
-    const controlSocket = new FakeSocket();
-    const daemonSocket = new FakeSocket();
-    const logger = { log: vi.fn() };
-    const onClosed = vi.fn();
-    controlSocket.open();
-    const bridge = new ControlWebSocketBridge({
-      streamId: 'stream-close-metadata',
-      controlSocket,
-      daemonSocket,
-      logger,
-      onClosed,
-    });
-    bridge.start();
-    daemonSocket.open();
-    daemonSocket.closeError = new Error('invalid close metadata');
-
-    bridge.closeFromControl(1004, '🙂'.repeat(100));
-
-    expect(daemonSocket.closes[0]?.code).toBe(1011);
-    expect(daemonSocket.closes[0]?.reason).toBe('🙂'.repeat(30));
-    expect(onClosed).toHaveBeenCalledOnce();
-    expect(logger.log).toHaveBeenCalledWith(
-      'warn',
-      'multiplexed websocket close failed',
-      expect.objectContaining({ streamId: 'stream-close-metadata' }),
-    );
-  });
-
-  it('aborts locally without writing to a dead control socket', () => {
-    const controlSocket = new FakeSocket();
-    const daemonSocket = new FakeSocket();
-    const onClosed = vi.fn();
-    const bridge = new ControlWebSocketBridge({
-      streamId: 'stream-abort',
-      controlSocket,
-      daemonSocket,
-      logger: { log: vi.fn() },
-      onClosed,
-    });
-    bridge.start();
-    expect(bridge.belongsTo(controlSocket)).toBe(true);
-    expect(bridge.belongsTo(new FakeSocket())).toBe(false);
-    bridge.abort('control disconnected');
-    bridge.abort('already closed');
-    expect(controlSocket.sent).toEqual([]);
-    expect(daemonSocket.closes[0]?.code).toBe(TUNNEL_CLOSE_CODES.STREAM_RETRY_SAFE);
-    expect(onClosed).toHaveBeenCalledOnce();
-  });
-});
-
 describe('TunnelClient typed relay RPC', () => {
   it('sends daemon-origin relay event frames over the control socket', () => {
     const control = new FakeSocket();
@@ -519,10 +202,7 @@ describe('TunnelClient typed relay RPC', () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       expect(String(input)).toBe('http://daemon.test/api/vaults');
       expect(init?.method).toBe('GET');
-      return Response.json({
-        ok: true,
-        vaults: [{ id: 'ledger', displayName: 'Ledger' }],
-      });
+      return Response.json({ ok: true, vaults: [{ id: 'ledger', displayName: 'Ledger' }] });
     });
     const client = new TunnelClient({
       relayUrl: new URL('ws://relay.test/t/demo'),
@@ -896,7 +576,11 @@ describe('TunnelClient typed relay RPC', () => {
         throw signal.reason;
       }
       return new Promise<Response>((_resolve, reject) => {
-        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        signal.addEventListener(
+          'abort',
+          () => reject(signal.reason),
+          { once: true },
+        );
       });
     });
     const client = new TunnelClient({
@@ -1090,7 +774,11 @@ describe('TunnelClient typed relay RPC', () => {
       const signal = init?.signal;
       if (!signal) throw new Error('Expected the relay cancellation signal');
       return new Promise<Response>((_resolve, reject) => {
-        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        signal.addEventListener(
+          'abort',
+          () => reject(signal.reason),
+          { once: true },
+        );
       });
     });
     const client = new TunnelClient({
@@ -1242,9 +930,7 @@ describe('TunnelClient HTTP proxy cancellation', () => {
     const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       observedSignal = init?.signal as AbortSignal | undefined;
       await new Promise((_resolve, reject) => {
-        observedSignal?.addEventListener('abort', () => reject(new Error('aborted')), {
-          once: true,
-        });
+        observedSignal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
       });
       return new Response('late');
     });
@@ -1395,33 +1081,30 @@ describe('DialbackBridge', () => {
     expect(daemonSocket.sent).toEqual([{ data: Buffer.from([9]), options: { binary: true } }]);
   });
 
-  it.each([2, 3])(
-    'closes both sockets when relay frames arrive while the daemon websocket state is %i',
-    (readyState) => {
-      const relaySocket = new FakeSocket();
-      const daemonSocket = new FakeSocket();
-      const logger = { log: vi.fn() };
-      new DialbackBridge({ streamId: 'stream-1', relaySocket, daemonSocket, logger }).start();
+  it.each([2, 3])('closes both sockets when relay frames arrive while the daemon websocket state is %i', (readyState) => {
+    const relaySocket = new FakeSocket();
+    const daemonSocket = new FakeSocket();
+    const logger = { log: vi.fn() };
+    new DialbackBridge({ streamId: 'stream-1', relaySocket, daemonSocket, logger }).start();
 
-      relaySocket.open();
-      daemonSocket.readyState = readyState;
-      relaySocket.message(Buffer.from([9]));
+    relaySocket.open();
+    daemonSocket.readyState = readyState;
+    relaySocket.message(Buffer.from([9]));
 
-      expect(daemonSocket.sent).toEqual([]);
-      expect(relaySocket.closes[0]).toEqual({
-        code: TUNNEL_CLOSE_CODES.STREAM_RETRY_SAFE,
-        reason: 'Daemon websocket was not open for relay frame',
-      });
-      expect(daemonSocket.closes[0]).toEqual({
-        code: TUNNEL_CLOSE_CODES.STREAM_RETRY_SAFE,
-        reason: 'Daemon websocket was not open for relay frame',
-      });
-      expect(logger.log).toHaveBeenCalledWith('warn', 'relay frame arrived while daemon websocket was not open', {
-        streamId: 'stream-1',
-        daemonReadyState: readyState,
-      });
-    },
-  );
+    expect(daemonSocket.sent).toEqual([]);
+    expect(relaySocket.closes[0]).toEqual({
+      code: TUNNEL_CLOSE_CODES.STREAM_RETRY_SAFE,
+      reason: 'Daemon websocket was not open for relay frame',
+    });
+    expect(daemonSocket.closes[0]).toEqual({
+      code: TUNNEL_CLOSE_CODES.STREAM_RETRY_SAFE,
+      reason: 'Daemon websocket was not open for relay frame',
+    });
+    expect(logger.log).toHaveBeenCalledWith('warn', 'relay frame arrived while daemon websocket was not open', {
+      streamId: 'stream-1',
+      daemonReadyState: readyState,
+    });
+  });
 
   it('closes both sockets when sending relay frames to the daemon fails', () => {
     const relaySocket = new FakeSocket();
@@ -1672,10 +1355,7 @@ describe('DialbackBridge', () => {
 
     relaySocket.emit('error', new Error('relay down'));
 
-    expect(daemonSocket.closes[0]).toEqual({
-      code: 1011,
-      reason: 'Relay dial-back failed',
-    });
+    expect(daemonSocket.closes[0]).toEqual({ code: 1011, reason: 'Relay dial-back failed' });
     expect(logger.log).toHaveBeenCalledWith('warn', 'relay dial-back socket error', {
       streamId: 'stream-1',
       error: 'Error: relay down',
@@ -1690,10 +1370,7 @@ describe('DialbackBridge', () => {
 
     daemonSocket.emit('error', new Error('daemon down'));
 
-    expect(relaySocket.closes[0]).toEqual({
-      code: 1011,
-      reason: 'Daemon websocket failed',
-    });
+    expect(relaySocket.closes[0]).toEqual({ code: 1011, reason: 'Daemon websocket failed' });
     expect(logger.log).toHaveBeenCalledWith('warn', 'daemon websocket error', {
       streamId: 'stream-1',
       error: 'Error: daemon down',

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -11,7 +11,6 @@ import {
   TUNNEL_WS_FRAME_BYTE_LIMIT,
   TUNNEL_PROTOCOL_VERSION,
   TUNNEL_PENDING_STREAM_PAIR_TIMEOUT_MS,
-  TUNNEL_WEBSOCKET_STREAM_CAPABILITY,
   decodeTunnelMessage,
   encodeTunnelMessage,
   parseRelayFrame,
@@ -20,8 +19,6 @@ import {
   type RelayJsonValue,
   type RelayRpcRequestFrame,
   type RelayRpcResponseFrame,
-  type RelayStreamDataFrame,
-  type RelayStreamOpenFrame,
   type TunnelControlServerMessage,
   type TunnelHttpCancelEnvelope,
   type TunnelHttpRequestChunkEnvelope,
@@ -132,7 +129,6 @@ export class TunnelClient {
   private readonly httpAssembler = new ChunkedHttpRequestAssembler();
   private readonly pendingHttpRequests = new Map<string, PendingDaemonHttpRequest>();
   private readonly pendingRelayRpcRequests = new Map<string, AbortController>();
-  private readonly controlWebSocketStreams = new Map<string, ControlWebSocketBridge>();
   private stopped = true;
   private reconnectAttempt = 0;
 
@@ -159,7 +155,6 @@ export class TunnelClient {
     this.clearControlHeartbeat();
     this.abortPendingHttpRequests();
     this.abortPendingRelayRpcRequests('Tunnel client stopping');
-    this.abortControlWebSocketStreams(undefined, 'Tunnel client stopping');
     this.control?.close(1001, 'Tunnel client stopping');
     this.control = undefined;
   }
@@ -215,20 +210,17 @@ export class TunnelClient {
     this.control = control;
 
     control.on('open', () => {
-      control.send(
-        encodeJsonBytes({
-          type: 'control.hello',
-          version: TUNNEL_PROTOCOL_VERSION,
-          token: this.config.token,
-          ...(this.config.daemonVersion ? { daemonVersion: this.config.daemonVersion } : {}),
-          ...(this.config.daemonBuild ? { daemonBuild: this.config.daemonBuild } : {}),
-          features: [
-            TUNNEL_FEATURES.RELAY_FRAMES_V1,
-            TUNNEL_FEATURES.WEBSOCKET_STREAMS_V1,
-            TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
-          ],
-        }),
-      );
+      control.send(encodeJsonBytes({
+        type: 'control.hello',
+        version: TUNNEL_PROTOCOL_VERSION,
+        token: this.config.token,
+        ...(this.config.daemonVersion ? { daemonVersion: this.config.daemonVersion } : {}),
+        ...(this.config.daemonBuild ? { daemonBuild: this.config.daemonBuild } : {}),
+        features: [
+          TUNNEL_FEATURES.RELAY_FRAMES_V1,
+          TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
+        ],
+      }));
       this.startControlHeartbeat(control);
       this.logger.log('info', 'relay control connected', {
         relayHost: controlUrl.host,
@@ -248,7 +240,6 @@ export class TunnelClient {
         this.clearControlHeartbeat();
         this.abortPendingHttpRequests();
         this.abortPendingRelayRpcRequests('Relay control disconnected');
-        this.abortControlWebSocketStreams(control, 'Relay control disconnected');
       }
 
       if (this.stopped) return;
@@ -327,23 +318,10 @@ export class TunnelClient {
       case 'ws.open':
         this.openDialback(message);
         return;
-      case 'ws.close':
-        this.controlWebSocketStreams.get(message.streamId)?.closeFromControl(message.code, message.reason);
-        return;
     }
   }
 
   private async handleRelayFrame(control: WebSocket, frame: RelayFrame): Promise<void> {
-    if (frame.type === 'stream.open' && frame.capability === TUNNEL_WEBSOCKET_STREAM_CAPABILITY) {
-      this.openControlWebSocketStream(control, frame);
-      return;
-    }
-
-    if (frame.type === 'stream.data') {
-      this.handleControlWebSocketData(control, frame);
-      return;
-    }
-
     if (frame.type === 'cancel' && frame.target.kind === 'rpc') {
       this.pendingRelayRpcRequests
         .get(frame.target.id)
@@ -811,76 +789,6 @@ export class TunnelClient {
     bridge.start();
   }
 
-  private openControlWebSocketStream(control: WebSocket, frame: RelayStreamOpenFrame): void {
-    const open = controlWebSocketOpenPayload(frame);
-    if (!open) {
-      this.sendControlStreamClose({
-        type: 'ws.close',
-        streamId: frame.streamId,
-        code: TUNNEL_CLOSE_CODES.BAD_PROTOCOL,
-        reason: 'Invalid multiplexed websocket open request',
-      });
-      return;
-    }
-    if (this.controlWebSocketStreams.has(frame.streamId)) {
-      this.sendControlStreamClose({
-        type: 'ws.close',
-        streamId: frame.streamId,
-        code: TUNNEL_CLOSE_CODES.BAD_PROTOCOL,
-        reason: 'Multiplexed websocket stream already exists',
-      });
-      return;
-    }
-    if (this.controlWebSocketStreams.size >= RELAY_PENDING_REQUEST_LIMIT) {
-      this.sendControlStreamClose({
-        type: 'ws.close',
-        streamId: frame.streamId,
-        code: TUNNEL_CLOSE_CODES.PENDING_STREAM_OVERFLOW,
-        reason: 'Multiplexed websocket stream limit reached',
-      });
-      return;
-    }
-
-    const daemonWsUrl = new URL(open.path, this.config.daemonUrl);
-    daemonWsUrl.protocol = daemonWsUrl.protocol === 'https:' ? 'wss:' : 'ws:';
-    const daemonSocket = new WebSocket(daemonWsUrl, {
-      headers: withoutHopByHop(open.headers),
-    });
-    const bridge = new ControlWebSocketBridge({
-      streamId: frame.streamId,
-      controlSocket: control,
-      daemonSocket,
-      logger: this.logger,
-      onClosed: () => {
-        if (this.controlWebSocketStreams.get(frame.streamId) === bridge) {
-          this.controlWebSocketStreams.delete(frame.streamId);
-        }
-      },
-    });
-    this.controlWebSocketStreams.set(frame.streamId, bridge);
-    bridge.start();
-  }
-
-  private handleControlWebSocketData(control: WebSocket, frame: RelayStreamDataFrame): void {
-    const bridge = this.controlWebSocketStreams.get(frame.streamId);
-    if (!bridge || !bridge.belongsTo(control)) {
-      this.sendControlStreamClose({
-        type: 'ws.close',
-        streamId: frame.streamId,
-        code: TUNNEL_CLOSE_CODES.UNKNOWN_STREAM,
-        reason: 'Unknown multiplexed websocket stream',
-      });
-      return;
-    }
-    bridge.receive(frame);
-  }
-
-  private abortControlWebSocketStreams(control: WebSocket | undefined, reason: string): void {
-    for (const bridge of this.controlWebSocketStreams.values()) {
-      if (!control || bridge.belongsTo(control)) bridge.abort(reason);
-    }
-  }
-
   private sendControlStreamClose(message: TunnelWebSocketCloseEnvelope): void {
     if (!this.control || this.control.readyState !== WebSocket.OPEN) {
       this.logger.log('warn', 'cannot notify relay about stale stream because control is not open', {
@@ -893,175 +801,6 @@ export class TunnelClient {
   }
 }
 /* v8 ignore stop */
-
-export type ControlWebSocketBridgeOptions = {
-  streamId: string;
-  controlSocket: BridgeSocket;
-  daemonSocket: BridgeSocket;
-  logger?: TunnelClientLogger;
-  onClosed?: () => void;
-};
-
-export class ControlWebSocketBridge {
-  private readonly logger: TunnelClientLogger;
-  private readonly pairTimeout: ReturnType<typeof setTimeout>;
-  private nextDaemonSequence = 0;
-  private closed = false;
-
-  constructor(private readonly options: ControlWebSocketBridgeOptions) {
-    this.logger = options.logger ?? consoleLogger;
-    this.pairTimeout = setTimeout(() => {
-      this.finish(
-        TUNNEL_CLOSE_CODES.PENDING_STREAM_TIMEOUT,
-        'Timed out waiting for daemon websocket',
-        true,
-      );
-    }, TUNNEL_PENDING_STREAM_PAIR_TIMEOUT_MS);
-  }
-
-  belongsTo(control: unknown): boolean {
-    return this.options.controlSocket === control;
-  }
-
-  start(): void {
-    this.options.daemonSocket.on('open', () => {
-      if (this.closed) return;
-      clearTimeout(this.pairTimeout);
-      this.sendControl({
-        type: 'relay.frame',
-        frame: {
-          type: 'stream.open',
-          version: RELAY_TRANSPORT_PROTOCOL_VERSION,
-          streamId: this.options.streamId,
-          capability: TUNNEL_WEBSOCKET_STREAM_CAPABILITY,
-        },
-      });
-    });
-
-    this.options.daemonSocket.on('message', (data) => {
-      if (this.closed) return;
-      const frame = rawDataToBytes(data);
-      if (frame.byteLength > TUNNEL_WS_FRAME_BYTE_LIMIT) {
-        this.finish(TUNNEL_CLOSE_CODES.OVERSIZED_WS_FRAME, 'Daemon websocket frame exceeded tunnel cap', true);
-        return;
-      }
-      this.sendControl({
-        type: 'relay.frame',
-        frame: {
-          type: 'stream.data',
-          version: RELAY_TRANSPORT_PROTOCOL_VERSION,
-          streamId: this.options.streamId,
-          sequence: this.nextDaemonSequence++,
-          payload: {
-            encoding: 'base64',
-            dataB64: Buffer.from(frame).toString('base64'),
-          },
-        },
-      });
-    });
-
-    this.options.daemonSocket.on('close', (code, reason) => {
-      this.finish(sendableCloseCode(code), reason.toString(), true, false);
-    });
-
-    this.options.daemonSocket.on('error', (error) => {
-      this.logger.log('warn', 'multiplexed daemon websocket error', {
-        streamId: this.options.streamId,
-        error: String(error),
-      });
-      this.finish(1011, 'Daemon websocket failed', true);
-    });
-  }
-
-  receive(frame: RelayStreamDataFrame): void {
-    if (this.closed) return;
-    if (frame.payload.encoding !== 'base64') {
-      this.finish(TUNNEL_CLOSE_CODES.BAD_PROTOCOL, 'Websocket stream payload was not binary', true);
-      return;
-    }
-    const data = Buffer.from(frame.payload.dataB64, 'base64');
-    if (data.byteLength > TUNNEL_WS_FRAME_BYTE_LIMIT) {
-      this.finish(TUNNEL_CLOSE_CODES.OVERSIZED_WS_FRAME, 'Relay websocket frame exceeded tunnel cap', true);
-      return;
-    }
-    if (this.options.daemonSocket.readyState !== WebSocket.OPEN) {
-      this.finish(TUNNEL_CLOSE_CODES.STREAM_RETRY_SAFE, 'Daemon websocket was not open for relay frame', true);
-      return;
-    }
-    try {
-      this.options.daemonSocket.send(data, { binary: true });
-    } catch (error) {
-      this.logger.log('warn', 'multiplexed daemon websocket send failed', {
-        streamId: this.options.streamId,
-        error: String(error),
-      });
-      this.finish(TUNNEL_CLOSE_CODES.STREAM_RETRY_SAFE, 'Daemon websocket send failed', true);
-    }
-  }
-
-  closeFromControl(code: number, reason: string): void {
-    this.finish(sendableCloseCode(code), reason, false);
-  }
-
-  abort(reason: string): void {
-    this.finish(TUNNEL_CLOSE_CODES.STREAM_RETRY_SAFE, reason, false);
-  }
-
-  private sendControl(message: Parameters<typeof encodeTunnelMessage>[0]): void {
-    try {
-      this.options.controlSocket.send(encodeJsonBytes(message), {
-        binary: true,
-      });
-    } catch (error) {
-      this.logger.log('warn', 'multiplexed websocket control send failed', {
-        streamId: this.options.streamId,
-        error: String(error),
-      });
-      this.finish(TUNNEL_CLOSE_CODES.STREAM_RETRY_SAFE, 'Relay control send failed', false);
-    }
-  }
-
-  private finish(code: number, reason: string, notifyControl: boolean, closeDaemon = true): void {
-    if (this.closed) return;
-    this.closed = true;
-    clearTimeout(this.pairTimeout);
-    const closeCode = sendableCloseCode(code);
-    const closeReason = sendableCloseReason(reason);
-    try {
-      if (notifyControl && this.options.controlSocket.readyState === WebSocket.OPEN) {
-        try {
-          this.options.controlSocket.send(
-            encodeJsonBytes({
-              type: 'ws.close',
-              streamId: this.options.streamId,
-              code: closeCode,
-              reason: closeReason,
-            }),
-            { binary: true },
-          );
-        } catch {
-          // The control disconnect path is already authoritative for cleanup.
-        }
-      }
-      if (
-        closeDaemon &&
-        (this.options.daemonSocket.readyState === WebSocket.OPEN ||
-          this.options.daemonSocket.readyState === WebSocket.CONNECTING)
-      ) {
-        try {
-          this.options.daemonSocket.close(closeCode, closeReason);
-        } catch (error) {
-          this.logger.log('warn', 'multiplexed websocket close failed', {
-            streamId: this.options.streamId,
-            error: String(error),
-          });
-        }
-      }
-    } finally {
-      this.options.onClosed?.();
-    }
-  }
-}
 
 export type BridgeSocket = {
   readonly readyState: number;
@@ -1368,18 +1107,6 @@ export function sendableCloseCode(code: number): number {
     : 1011;
 }
 
-export function sendableCloseReason(reason: string): string {
-  let result = '';
-  let byteLength = 0;
-  for (const character of reason) {
-    const characterBytes = Buffer.byteLength(character, 'utf8');
-    if (byteLength + characterBytes > 123) break;
-    result += character;
-    byteLength += characterBytes;
-  }
-  return result;
-}
-
 function relayRpcError(
   id: string,
   code: (typeof RELAY_ERROR_CODES)[keyof typeof RELAY_ERROR_CODES],
@@ -1469,26 +1196,6 @@ function parseMcpToolCallRpcRequest(
 function isRelayJsonObject(value: unknown): value is RelayJsonObject {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
-
-/* v8 ignore start -- Valid opens construct the live daemon WebSocket inside TunnelClient; the bridge wire behavior is covered directly above. */
-function controlWebSocketOpenPayload(
-  frame: RelayStreamOpenFrame,
-): { path: string; headers: Record<string, string> } | null {
-  if (frame.payload?.encoding !== 'json' || !isRelayJsonObject(frame.payload.value)) {
-    return null;
-  }
-  const { path, headers } = frame.payload.value;
-  if (typeof path !== 'string' || !path.startsWith('/') || !isRelayJsonObject(headers)) {
-    return null;
-  }
-  const serializedHeaders: Record<string, string> = {};
-  for (const [name, value] of Object.entries(headers)) {
-    if (typeof value !== 'string') return null;
-    serializedHeaders[name] = value;
-  }
-  return { path, headers: serializedHeaders };
-}
-/* v8 ignore stop */
 
 export function relayInternalUrl(relayUrl: URL, internalPath: string): URL {
   const url = new URL(relayUrl.href);

--- a/packages/tunnel-protocol/src/index.test.ts
+++ b/packages/tunnel-protocol/src/index.test.ts
@@ -50,7 +50,6 @@ it("round-trips control hello feature advertisement", () => {
     daemonBuild: "registry.example/kb1d@sha256:abc123",
     features: [
       TUNNEL_FEATURES.RELAY_FRAMES_V1,
-      TUNNEL_FEATURES.WEBSOCKET_STREAMS_V1,
       TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1
     ]
   } as const;

--- a/packages/tunnel-protocol/src/index.ts
+++ b/packages/tunnel-protocol/src/index.ts
@@ -23,15 +23,11 @@ export const RELAY_DEFAULT_REQUEST_TIMEOUT_MS = 15_000 as const;
 
 export const TUNNEL_FEATURES = {
   RELAY_FRAMES_V1: "relay.frame.v1",
-  WEBSOCKET_STREAMS_V1: "relay.websocket-streams.v1",
-  MCP_TOOL_CALL_BOUNDED_RESULTS_V1: "relay.mcp-tool-call.bounded-results.v1"
+  MCP_TOOL_CALL_BOUNDED_RESULTS_V1:
+    "relay.mcp-tool-call.bounded-results.v1"
 } as const;
 
-export const TUNNEL_WEBSOCKET_STREAM_CAPABILITY =
-  "daemon.websocket.v1" as const;
-
-export type TunnelFeature =
-  (typeof TUNNEL_FEATURES)[keyof typeof TUNNEL_FEATURES];
+export type TunnelFeature = (typeof TUNNEL_FEATURES)[keyof typeof TUNNEL_FEATURES];
 
 export const RELAY_ERROR_CODES = {
   BAD_MESSAGE: "bad-message",
@@ -465,7 +461,7 @@ export type TunnelWebSocketDialbackHello = {
 export type TunnelWebSocketCloseEnvelope = {
   type: "ws.close";
   streamId: string;
-  code: number;
+  code: TunnelCloseCode;
   reason: string;
 };
 
@@ -489,7 +485,6 @@ export type TunnelControlServerMessage =
   | TunnelControlPong
   | TunnelControlServerError
   | TunnelRelayFrameEnvelope
-  | TunnelWebSocketCloseEnvelope
   | TunnelHttpRequestEnvelope
   | TunnelHttpRequestStartEnvelope
   | TunnelHttpRequestChunkEnvelope


### PR DESCRIPTION
## Summary

- remove the custom document-stream multiplexer from the daemon control WebSocket
- stop advertising the control-stream capability in the tunnel handshake
- restore the established per-document dial-back bridge
- retain later control heartbeat, bounded MCP relay, durability telemetry, retry behavior, and strict WebSocket close-code validation

## Why

The control-channel multiplexer deviated from the original mux-free relay architecture and coupled document traffic to the daemon control socket. Restoring per-document dial-back isolates document sessions from control/liveness traffic and returns the daemon to the established transport boundary.

## Validation

- focused tunnel-client tests: 47 passed
- tunnel-protocol tests: 24 passed
- daemon typecheck, all test suites, and all builds passed
- GPT-5.6-sol autoreview at high reasoning: clean after retaining reserved close-code hardening

The standalone license-inventory guard reads the parent Cloud worktree's shared pnpm store and reported a stale generated inventory. No dependency manifest or lockfile changed.
