### PR TITLE
Emit path-specific vault content change events

### DIFF
--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -9,7 +9,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 import { DOCUMENT_SESSION_FAILURE_CLOSE_CODE } from '@kb-1/doc-session';
-import { isDaemonCliEntrypoint, startDaemon } from './main.js';
+import { isDaemonCliEntrypoint, relayEventsForVaultChange, startDaemon } from './main.js';
 import * as statusModule from './status.js';
 
 describe('daemon startup', () => {
@@ -314,6 +314,61 @@ describe('daemon startup', () => {
       releaseStatusWrite?.();
       statusSpy.mockRestore();
     }
+  });
+});
+
+describe('relay vault change events', () => {
+  const actor = { kind: 'system' as const, client: 'test' };
+
+  it('separates path-specific content invalidation from tree invalidation', () => {
+    expect(relayEventsForVaultChange({
+      vaultSlug: 'demo',
+      event: {
+        kind: 'content_persisted',
+        path: 'attachments/photo.png',
+        actor,
+        ts: '2026-08-04T00:00:00.000Z'
+      }
+    })).toEqual([
+      {
+        topic: 'vault.content.changed',
+        resource: { vaultSlug: 'demo', path: 'attachments/photo.png' }
+      }
+    ]);
+
+    expect(relayEventsForVaultChange({
+      vaultSlug: 'demo',
+      event: {
+        kind: 'file_moved',
+        path: 'attachments/photo-renamed.png',
+        fromPath: 'attachments/photo.png',
+        toPath: 'attachments/photo-renamed.png',
+        actor,
+        ts: '2026-08-04T00:00:00.000Z'
+      }
+    })).toEqual([
+      {
+        topic: 'vault.tree.changed',
+        resource: { vaultSlug: 'demo', cause: 'file_moved' }
+      }
+    ]);
+  });
+
+  it('invalidates a changed external path without turning it into a tree refresh', () => {
+    expect(relayEventsForVaultChange({
+      vaultSlug: 'demo',
+      event: {
+        kind: 'external_change_detected',
+        path: 'attachments/photo.png',
+        actor,
+        ts: '2026-08-04T00:00:00.000Z'
+      }
+    })).toEqual([
+      {
+        topic: 'vault.content.changed',
+        resource: { vaultSlug: 'demo', path: 'attachments/photo.png' }
+      }
+    ]);
   });
 });
 

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -38,6 +38,7 @@ import {
 } from './vault-registry.js';
 
 const VAULT_TREE_CHANGED_TOPIC = 'vault.tree.changed';
+const VAULT_CONTENT_CHANGED_TOPIC = 'vault.content.changed';
 const TREE_DIRTY_EVENT_KINDS = new Set<VaultChangeEventKind>([
   'file_created',
   'folder_created',
@@ -334,12 +335,9 @@ function createRelayLifecycleController(
   const ensureVaultEventSubscription = () => {
     if (unsubscribeVaultEvents) return;
     unsubscribeVaultEvents = registry.onVaultEvent((event) => {
-      if (!isTreeDirtyVaultEvent(event)) return;
-
-      client.sendRelayEvent({
-        topic: VAULT_TREE_CHANGED_TOPIC,
-        resource: { vaultSlug: event.vaultSlug, cause: event.event.kind },
-      });
+      for (const relayEvent of relayEventsForVaultChange(event)) {
+        client.sendRelayEvent(relayEvent);
+      }
     });
   };
   const releaseVaultEventSubscription = () => {
@@ -366,6 +364,32 @@ function createRelayLifecycleController(
 function isTreeDirtyVaultEvent(event: VaultRegistryChangeEvent): boolean {
   return TREE_DIRTY_EVENT_KINDS.has(event.event.kind)
     && (event.event.kind !== 'external_change_detected' || event.event.path === '');
+}
+
+export function relayEventsForVaultChange(event: VaultRegistryChangeEvent): Array<{
+  topic: string;
+  resource: Record<string, string>;
+}> {
+  if (isTreeDirtyVaultEvent(event)) {
+    return [
+      {
+        topic: VAULT_TREE_CHANGED_TOPIC,
+        resource: { vaultSlug: event.vaultSlug, cause: event.event.kind }
+      }
+    ];
+  }
+  if (
+    event.event.kind === 'content_persisted'
+    || (event.event.kind === 'external_change_detected' && event.event.path !== '')
+  ) {
+    return [
+      {
+        topic: VAULT_CONTENT_CHANGED_TOPIC,
+        resource: { vaultSlug: event.vaultSlug, path: event.event.path }
+      }
+    ];
+  }
+  return [];
 }
 
 const daemonRelayLogger: TunnelClientLogger = {


### PR DESCRIPTION
## Summary

- emit a path-specific `vault.content.changed` relay event after persisted content updates
- emit the same event for file-level external changes while preserving existing vault-tree invalidation semantics
- add focused tests covering content changes, file moves, and external path changes

## Why

Hosted raw assets can be cached in the org Durable Object, but the cloud needs an exact daemon-origin freshness signal when bytes at a stable vault path change. Previously the daemon emitted only tree-level relay events, which could not safely invalidate a single cached raw asset without evicting the whole vault.

## Impact

Cloud consumers can evict the exact changed raw path without treating an ordinary content overwrite as a file-tree refresh. Existing structural mutations continue to emit `vault.tree.changed`.

## Validation

- focused daemon relay-event tests: 2 passed
- full daemon suite through `pnpm check`: 163 passed
- full KB-1 Cloud workspace `pnpm check`: passed across 18 projects
- Cloud browser e2e: 25 passed, 1 intentional skip
