### PR TITLE
feat(relay): advertise vault content invalidation

### DIFF
--- a/packages/tunnel-client/src/heartbeat.test.ts
+++ b/packages/tunnel-client/src/heartbeat.test.ts
@@ -90,6 +90,7 @@ describe('TunnelClient control heartbeat', () => {
       token: 'token-1',
       features: [
         TUNNEL_FEATURES.RELAY_FRAMES_V1,
+        TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V1,
         TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
       ],
     }));
@@ -202,6 +203,7 @@ describe('TunnelClient control heartbeat', () => {
       daemonBuild: 'registry.fly.io/kb1@sha256:abc123',
       features: [
         TUNNEL_FEATURES.RELAY_FRAMES_V1,
+        TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V1,
         TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
       ],
     }));

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -842,6 +842,12 @@ describe('TunnelClient typed relay RPC', () => {
     );
   });
 
+  it('advertises vault content invalidation support as a control feature', () => {
+    expect(TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V1).toBe(
+      'relay.vault-content-events.v1',
+    );
+  });
+
   it('rejects unknown typed relay RPC capabilities without proxying arbitrary paths', async () => {
     const fetchImpl = vi.fn();
     const client = new TunnelClient({

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -218,6 +218,7 @@ export class TunnelClient {
         ...(this.config.daemonBuild ? { daemonBuild: this.config.daemonBuild } : {}),
         features: [
           TUNNEL_FEATURES.RELAY_FRAMES_V1,
+          TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V1,
           TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
         ],
       }));

--- a/packages/tunnel-protocol/src/index.test.ts
+++ b/packages/tunnel-protocol/src/index.test.ts
@@ -50,6 +50,7 @@ it("round-trips control hello feature advertisement", () => {
     daemonBuild: "registry.example/kb1d@sha256:abc123",
     features: [
       TUNNEL_FEATURES.RELAY_FRAMES_V1,
+      TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V1,
       TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1
     ]
   } as const;

--- a/packages/tunnel-protocol/src/index.ts
+++ b/packages/tunnel-protocol/src/index.ts
@@ -23,6 +23,7 @@ export const RELAY_DEFAULT_REQUEST_TIMEOUT_MS = 15_000 as const;
 
 export const TUNNEL_FEATURES = {
   RELAY_FRAMES_V1: "relay.frame.v1",
+  VAULT_CONTENT_EVENTS_V1: "relay.vault-content-events.v1",
   MCP_TOOL_CALL_BOUNDED_RESULTS_V1:
     "relay.mcp-tool-call.bounded-results.v1"
 } as const;


### PR DESCRIPTION
## Summary
- add an explicit `relay.vault-content-events.v1` tunnel capability
- advertise it from the daemon control handshake
- cover protocol and heartbeat advertisement

## Why
KB-1 Cloud's hosted raw-asset cache must only activate for daemon builds that emit path-specific `vault.content.changed` events. Capability negotiation keeps older running managed daemons on the uncached correctness path during rollout.

## Validation
- `pnpm check`
- `autoreview --mode local --thinking high` (clean)