### PR TITLE
fix(relay): fence cached vault mutations across gaps

### DIFF
--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -410,6 +410,23 @@ describe('relay vault change events', () => {
       }
     ]);
   });
+
+  it('uses the vault-scoped tree event when the cold watcher cannot name a path', () => {
+    expect(relayEventsForVaultChange({
+      vaultSlug: 'demo',
+      event: {
+        kind: 'external_change_detected',
+        path: '',
+        actor,
+        ts: '2026-08-04T00:00:00.000Z'
+      }
+    })).toEqual([
+      {
+        topic: 'vault.tree.changed',
+        resource: { vaultSlug: 'demo', cause: 'external_change_detected' }
+      }
+    ]);
+  });
 });
 
 describe('daemon boot migration', () => {

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -440,26 +440,26 @@ export function relayEventsForVaultChange(event: VaultRegistryChangeEvent): Arra
   topic: string;
   resource: Record<string, string>;
 }> {
+  const relayEvents: Array<{
+    topic: string;
+    resource: Record<string, string>;
+  }> = [];
   if (isTreeDirtyVaultEvent(event)) {
-    return [
-      {
-        topic: VAULT_TREE_CHANGED_TOPIC,
-        resource: { vaultSlug: event.vaultSlug, cause: event.event.kind }
-      }
-    ];
+    relayEvents.push({
+      topic: VAULT_TREE_CHANGED_TOPIC,
+      resource: { vaultSlug: event.vaultSlug, cause: event.event.kind }
+    });
   }
   if (
     event.event.kind === 'content_persisted'
     || (event.event.kind === 'external_change_detected' && event.event.path !== '')
   ) {
-    return [
-      {
-        topic: VAULT_CONTENT_CHANGED_TOPIC,
-        resource: { vaultSlug: event.vaultSlug, path: event.event.path }
-      }
-    ];
+    relayEvents.push({
+      topic: VAULT_CONTENT_CHANGED_TOPIC,
+      resource: { vaultSlug: event.vaultSlug, path: event.event.path }
+    });
   }
-  return [];
+  return relayEvents;
 }
 
 const daemonRelayLogger: TunnelClientLogger = {

--- a/packages/tunnel-client/src/heartbeat.test.ts
+++ b/packages/tunnel-client/src/heartbeat.test.ts
@@ -73,6 +73,7 @@ describe('TunnelClient control heartbeat', () => {
       relayUrl: new URL('http://relay.example/t/dev1'),
       daemonUrl: new URL('http://127.0.0.1:9891'),
       token: 'token-1',
+      daemonInstanceId: 'instance-1',
       logger,
       random: () => 0,
     });
@@ -88,9 +89,12 @@ describe('TunnelClient control heartbeat', () => {
       type: 'control.hello',
       version: 2,
       token: 'token-1',
+      daemonInstanceId: 'instance-1',
+      vaultMutationEpoch: 0,
       features: [
         TUNNEL_FEATURES.RELAY_FRAMES_V1,
         TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V1,
+        TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V2,
         TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
       ],
     }));
@@ -188,6 +192,7 @@ describe('TunnelClient control heartbeat', () => {
       token: 'token-1',
       daemonVersion: '0.1.0',
       daemonBuild: 'registry.fly.io/kb1@sha256:abc123',
+      daemonInstanceId: 'instance-1',
       logger: { log: vi.fn() },
     });
 
@@ -201,12 +206,89 @@ describe('TunnelClient control heartbeat', () => {
       token: 'token-1',
       daemonVersion: '0.1.0',
       daemonBuild: 'registry.fly.io/kb1@sha256:abc123',
+      daemonInstanceId: 'instance-1',
+      vaultMutationEpoch: 0,
       features: [
         TUNNEL_FEATURES.RELAY_FRAMES_V1,
         TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V1,
+        TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V2,
         TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
       ],
     }));
+  });
+
+  it('carries vault mutations across a disconnected control as a new epoch', async () => {
+    const { TunnelClient } = await import('./index.js');
+    const client = new TunnelClient({
+      relayUrl: new URL('http://relay.example/t/dev1'),
+      daemonUrl: new URL('http://127.0.0.1:9891'),
+      token: 'token-1',
+      daemonInstanceId: 'instance-1',
+      logger: { log: vi.fn() },
+      random: () => 0,
+    });
+
+    client.start();
+    const firstControl = MockWebSocket.instances[0];
+    firstControl.open();
+    firstControl.close(1006, 'network gap');
+
+    expect(client.sendRelayEvent({
+      topic: 'vault.tree.changed',
+      resource: { vaultSlug: 'demo' },
+    })).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(250);
+    const secondControl = MockWebSocket.instances[1];
+    secondControl.open();
+    expect(JSON.parse(sentText(secondControl, 0))).toMatchObject({
+      type: 'control.hello',
+      daemonInstanceId: 'instance-1',
+      vaultMutationEpoch: 1,
+      features: expect.arrayContaining([
+        TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V2,
+      ]),
+    });
+  });
+
+  it('attaches the mutation epoch to delivered events for reconnect acknowledgement', async () => {
+    const { TunnelClient } = await import('./index.js');
+    const client = new TunnelClient({
+      relayUrl: new URL('http://relay.example/t/dev1'),
+      daemonUrl: new URL('http://127.0.0.1:9891'),
+      token: 'token-1',
+      daemonInstanceId: 'instance-1',
+      logger: { log: vi.fn() },
+      random: () => 0,
+    });
+
+    client.start();
+    const firstControl = MockWebSocket.instances[0];
+    firstControl.open();
+    expect(client.sendRelayEvent({
+      topic: 'vault.content.changed',
+      resource: { vaultSlug: 'demo', path: 'attachments/photo.png' },
+    })).toBe(true);
+    expect(JSON.parse(sentText(firstControl, 1))).toMatchObject({
+      type: 'relay.frame',
+      frame: {
+        topic: 'vault.content.changed',
+        resource: {
+          vaultSlug: 'demo',
+          path: 'attachments/photo.png',
+          vaultMutationEpoch: '1',
+        },
+      },
+    });
+
+    firstControl.close(1006, 'network gap');
+    await vi.advanceTimersByTimeAsync(250);
+    const secondControl = MockWebSocket.instances[1];
+    secondControl.open();
+    expect(JSON.parse(sentText(secondControl, 0))).toMatchObject({
+      type: 'control.hello',
+      vaultMutationEpoch: 1,
+    });
   });
 
   it('keeps connect and disconnect idempotent for lifecycle callers', async () => {
@@ -249,5 +331,13 @@ describe('TunnelClient control heartbeat', () => {
     });
     await vi.advanceTimersByTimeAsync(1_000);
     expect(MockWebSocket.instances).toHaveLength(1);
+
+    client.start();
+    const restartedControl = MockWebSocket.instances[1];
+    restartedControl.open();
+    expect(JSON.parse(sentText(restartedControl, 0))).toMatchObject({
+      type: 'control.hello',
+      vaultMutationEpoch: 1,
+    });
   });
 });

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -193,7 +193,10 @@ describe('TunnelClient typed relay RPC', () => {
         type: 'event',
         version: RELAY_TRANSPORT_PROTOCOL_VERSION,
         topic: 'vault.tree.changed',
-        resource: { vaultSlug: 'demo-vault' },
+        resource: {
+          vaultSlug: 'demo-vault',
+          vaultMutationEpoch: '1',
+        },
       },
     });
   });

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from '@kb-1/tunnel-protocol';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { randomUUID } from 'node:crypto';
 import { gunzipSync } from 'node:zlib';
 import { WebSocket } from 'ws';
 
@@ -46,6 +47,7 @@ export type TunnelClientConfig = {
   token: string;
   daemonVersion?: string;
   daemonBuild?: string;
+  daemonInstanceId?: string;
   logger?: TunnelClientLogger;
   fetch?: typeof fetch;
   random?: () => number;
@@ -130,17 +132,30 @@ export class TunnelClient {
   private readonly pendingHttpRequests = new Map<string, PendingDaemonHttpRequest>();
   private readonly pendingRelayRpcRequests = new Map<string, AbortController>();
   private stopped = true;
+  private hasStarted = false;
   private reconnectAttempt = 0;
+  private readonly daemonInstanceId: string;
+  private vaultMutationEpoch = 0;
 
   constructor(private readonly config: TunnelClientConfig) {
     this.logger = config.logger ?? consoleLogger;
     this.fetchImpl = config.fetch ?? fetch;
     this.random = config.random ?? Math.random;
+    this.daemonInstanceId = config.daemonInstanceId ?? randomUUID();
   }
 
   start(): void {
     if (!this.stopped) return;
 
+    // A deliberate stop releases the vault-event subscription in the daemon.
+    // Fence any cache retained across that unobserved interval before the
+    // client registers again. Transport-level reconnects do not call start(),
+    // so ordinary network churn can still retain cache when no mutation occurs.
+    if (this.hasStarted) {
+      this.vaultMutationEpoch += 1;
+    } else {
+      this.hasStarted = true;
+    }
     this.stopped = false;
     this.reconnectAttempt = 0;
     this.connectControl();
@@ -168,6 +183,17 @@ export class TunnelClient {
   }
 
   sendRelayEvent(event: TunnelRelayEventInput): boolean {
+    const isVaultMutation =
+      event.topic === 'vault.tree.changed' || event.topic === 'vault.content.changed';
+    if (isVaultMutation) {
+      this.vaultMutationEpoch += 1;
+    }
+    const resource = isVaultMutation
+      ? {
+          ...event.resource,
+          vaultMutationEpoch: String(this.vaultMutationEpoch),
+        }
+      : event.resource;
     const control = this.control;
     if (!control || control.readyState !== WebSocket.OPEN) {
       this.logger.log('debug', 'relay event skipped because control is not open', {
@@ -185,7 +211,7 @@ export class TunnelClient {
           topic: event.topic,
           ...(event.id !== undefined ? { id: event.id } : {}),
           ...(event.payload !== undefined ? { payload: { encoding: 'json', value: event.payload } } : {}),
-          ...(event.resource !== undefined ? { resource: event.resource } : {}),
+          ...(resource !== undefined ? { resource } : {}),
         },
       }));
       return true;
@@ -216,9 +242,12 @@ export class TunnelClient {
         token: this.config.token,
         ...(this.config.daemonVersion ? { daemonVersion: this.config.daemonVersion } : {}),
         ...(this.config.daemonBuild ? { daemonBuild: this.config.daemonBuild } : {}),
+        daemonInstanceId: this.daemonInstanceId,
+        vaultMutationEpoch: this.vaultMutationEpoch,
         features: [
           TUNNEL_FEATURES.RELAY_FRAMES_V1,
           TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V1,
+          TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V2,
           TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
         ],
       }));

--- a/packages/tunnel-protocol/src/index.test.ts
+++ b/packages/tunnel-protocol/src/index.test.ts
@@ -48,9 +48,12 @@ it("round-trips control hello feature advertisement", () => {
     token: "test-token",
     daemonVersion: "0.1.0",
     daemonBuild: "registry.example/kb1d@sha256:abc123",
+    daemonInstanceId: "instance-1",
+    vaultMutationEpoch: 7,
     features: [
       TUNNEL_FEATURES.RELAY_FRAMES_V1,
       TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V1,
+      TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V2,
       TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1
     ]
   } as const;

--- a/packages/tunnel-protocol/src/index.ts
+++ b/packages/tunnel-protocol/src/index.ts
@@ -24,6 +24,7 @@ export const RELAY_DEFAULT_REQUEST_TIMEOUT_MS = 15_000 as const;
 export const TUNNEL_FEATURES = {
   RELAY_FRAMES_V1: "relay.frame.v1",
   VAULT_CONTENT_EVENTS_V1: "relay.vault-content-events.v1",
+  VAULT_CONTENT_EVENTS_V2: "relay.vault-content-events.v2",
   MCP_TOOL_CALL_BOUNDED_RESULTS_V1:
     "relay.mcp-tool-call.bounded-results.v1"
 } as const;
@@ -357,6 +358,8 @@ export type TunnelControlClientHello = {
   token: string;
   daemonVersion?: string;
   daemonBuild?: string;
+  daemonInstanceId?: string;
+  vaultMutationEpoch?: number;
   features?: readonly TunnelFeature[];
 };
 

--- a/packages/vault-core/src/vault-ops.ts
+++ b/packages/vault-core/src/vault-ops.ts
@@ -54,6 +54,10 @@ export interface VaultEntry {
   mtimeMs: number;
   artifact?: ArtifactInfo;
   metadata?: FolderMetadata;
+  /** Internal watcher identity; deliberately non-enumerable in tree responses. */
+  watchCtimeMs?: number;
+  /** Internal watcher identity; deliberately non-enumerable in tree responses. */
+  watchIno?: number;
 }
 
 export interface VaultInfo {
@@ -354,13 +358,18 @@ async function walkEntries(
           entries,
         );
       } else if (row.dirent.isFile()) {
-        entries.push({
+        const entry: VaultEntry = {
           path: row.rel,
           kind: "file",
           size: row.stat.size,
           mtimeMs: row.stat.mtimeMs,
           artifact: classifyArtifactPath(row.rel),
+        };
+        Object.defineProperties(entry, {
+          watchCtimeMs: { value: row.stat.ctimeMs },
+          watchIno: { value: row.stat.ino },
         });
+        entries.push(entry);
         if (entries.length >= cap) throw new EntryCapExceededError();
       }
     }

--- a/packages/vault-service/src/index.test.ts
+++ b/packages/vault-service/src/index.test.ts
@@ -7,6 +7,7 @@ import {
   rename,
   rm,
   stat,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import {
@@ -1083,6 +1084,117 @@ describe("vault service failure mapping", () => {
         ),
       () =>
         `Timed out waiting for external tree event; events=${JSON.stringify(events)}`,
+    );
+    unsubscribe();
+  });
+
+  it("emits a root-level external event when a cold file is overwritten in place", async () => {
+    const photoPath = join(root, "attachments", "photo.png");
+    await writeFileWithParents(photoPath, "before");
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const events: VaultChangeEvent[] = [];
+    const unsubscribe = service.onEvent((event) => events.push(event));
+
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    const before = await stat(photoPath);
+    await writeFile(photoPath, "after!", "utf8");
+    await utimes(photoPath, before.atime, before.mtime);
+
+    await waitUntil(
+      () =>
+        events.some(
+          (event) =>
+            event.kind === "external_change_detected" && event.path === "",
+        ),
+      () =>
+        `Timed out waiting for overwritten cold file event; events=${JSON.stringify(events)}`,
+    );
+    unsubscribe();
+  });
+
+  it("does not let an unrelated known mutation hide a cold-file overwrite", async () => {
+    await writeFileWithParents(join(root, "attachments", "photo.png"), "before");
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const events: VaultChangeEvent[] = [];
+    const unsubscribe = service.onEvent((event) => events.push(event));
+
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await writeFile(join(root, "attachments", "photo.png"), "after-content", "utf8");
+    await service.createFolder({
+      path: "known-folder",
+      actor: { kind: "user" },
+    });
+
+    await waitUntil(
+      () =>
+        events.some(
+          (event) =>
+            event.kind === "external_change_detected" && event.path === "",
+        ),
+      () =>
+        `Timed out waiting for cold overwrite after known mutation; events=${JSON.stringify(events)}`,
+    );
+    unsubscribe();
+  });
+
+  it("does not absorb an external overwrite of the same known path", async () => {
+    const photoPath = join(root, "attachments", "photo.png");
+    await writeFileWithParents(photoPath, "before");
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const events: VaultChangeEvent[] = [];
+    const unsubscribe = service.onEvent((event) => events.push(event));
+
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await service.writeRawFile({
+      path: "attachments/photo.png",
+      bytes: new TextEncoder().encode("known!"),
+      overwrite: true,
+      actor: { kind: "user" },
+    });
+    await writeFile(photoPath, "outside", "utf8");
+
+    await waitUntil(
+      () =>
+        events.some(
+          (event) =>
+            event.kind === "external_change_detected" &&
+            event.path === "attachments/photo.png",
+        ),
+      () =>
+        `Timed out waiting for same-path external overwrite; events=${JSON.stringify(events)}`,
+    );
+    unsubscribe();
+  });
+
+  it("reconciles a known tree mutation without a broad external event", async () => {
+    const service = createVaultService({
+      vaultRoot: root,
+      documentSessions: sessions,
+    });
+    const events: VaultChangeEvent[] = [];
+    const unsubscribe = service.onEvent((event) => events.push(event));
+
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    await service.createFolder({
+      path: "known-folder",
+      actor: { kind: "user" },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 2200));
+
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        kind: "external_change_detected",
+        path: "",
+      }),
     );
     unsubscribe();
   });

--- a/packages/vault-service/src/index.ts
+++ b/packages/vault-service/src/index.ts
@@ -160,10 +160,19 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
     invalidateTreeReads();
     return result;
   };
+  const treeWatchKnownPaths = new Set<string>();
   const emitChange = (event: VaultChangeEvent) => {
     invalidateTreeReads();
-    if (event.kind !== 'external_change_detected') {
-      treeWatchSnapshot = undefined;
+    // Known-path reconciliation only has meaning while a tree watcher can
+    // consume it. Document sessions outlive relay subscriptions, so retaining
+    // their paths with no handlers would grow this set until the next connect.
+    if (
+      event.kind !== 'external_change_detected' &&
+      eventHandlers.size > 0
+    ) {
+      for (const path of [event.path, event.fromPath, event.toPath]) {
+        if (path !== undefined) treeWatchKnownPaths.add(path);
+      }
     }
     for (const handler of eventHandlers) {
       try {
@@ -175,7 +184,7 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
   };
   let unsubscribeAudit: (() => void) | undefined;
   let treeWatchTimer: ReturnType<typeof setInterval> | undefined;
-  let treeWatchSnapshot: string | undefined;
+  let treeWatchSnapshot: Map<string, string> | undefined;
   let treeWatchInFlight = false;
   type TreeReadResult = Awaited<ReturnType<typeof listVaultTree>>;
   const treeReadInFlight = new Map<
@@ -212,6 +221,7 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
     if (treeWatchInFlight) return;
 
     treeWatchInFlight = true;
+    const knownPathsAtPollStart = new Set(treeWatchKnownPaths);
     try {
       const result = await listVaultTree(ctx(), {
         depth: Number.MAX_SAFE_INTEGER,
@@ -224,9 +234,31 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
         return;
       }
 
-      if (treeWatchSnapshot === nextSnapshot) return;
+      const changedPaths = changedTreeSnapshotPaths(
+        treeWatchSnapshot,
+        nextSnapshot,
+      );
+      if (changedPaths.length === 0) return;
 
       treeWatchSnapshot = nextSnapshot;
+      const unknownPaths = changedPaths.filter(
+        (path) => !knownPathsAtPollStart.has(path),
+      );
+      if (unknownPaths.length === 0) {
+        // Never silently absorb a covered difference: an external overwrite
+        // can overlap the same interval as the known write. Exact-path events
+        // keep reconciliation targeted without turning every save into a
+        // vault-wide invalidation.
+        for (const path of changedPaths) {
+          emitChange({
+            kind: 'external_change_detected',
+            path,
+            actor: { kind: 'system' },
+            ts: new Date().toISOString()
+          });
+        }
+        return;
+      }
       emitChange({
         kind: 'external_change_detected',
         path: '',
@@ -236,6 +268,9 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
     } catch (error) {
       console.warn('KB-1 vault tree watch failed.', error);
     } finally {
+      for (const path of knownPathsAtPollStart) {
+        treeWatchKnownPaths.delete(path);
+      }
       treeWatchInFlight = false;
     }
   };
@@ -243,6 +278,7 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
     if (treeWatchTimer) return;
 
     treeWatchSnapshot = undefined;
+    treeWatchKnownPaths.clear();
     void pollTreeWatch();
     treeWatchTimer = setInterval(() => {
       void pollTreeWatch();
@@ -254,6 +290,7 @@ export function createVaultService(options: VaultServiceOptions): VaultService {
     clearInterval(treeWatchTimer);
     treeWatchTimer = undefined;
     treeWatchSnapshot = undefined;
+    treeWatchKnownPaths.clear();
     treeWatchInFlight = false;
     invalidateTreeReads();
   };
@@ -829,16 +866,32 @@ function auditChangeEventKind(
   return assertNever(audit.operation);
 }
 
-function treeSnapshot(entries: VaultEntry[]): string {
-  return JSON.stringify(
-    entries
-      .map((entry) => ({
-        path: entry.path,
+function treeSnapshot(entries: VaultEntry[]): Map<string, string> {
+  return new Map(
+    entries.map((entry) => [
+      entry.path,
+      JSON.stringify({
         kind: entry.kind,
+        ...(entry.kind === 'file'
+          ? {
+              size: entry.size,
+              mtimeMs: entry.mtimeMs,
+              ctimeMs: entry.watchCtimeMs,
+              ino: entry.watchIno,
+            }
+          : {}),
         ...(entry.metadata !== undefined ? { metadata: entry.metadata } : {})
-      }))
-      .sort((a, b) => a.path.localeCompare(b.path) || a.kind.localeCompare(b.kind))
+      })
+    ])
   );
+}
+
+function changedTreeSnapshotPaths(
+  previous: Map<string, string>,
+  next: Map<string, string>,
+): string[] {
+  const paths = new Set([...previous.keys(), ...next.keys()]);
+  return [...paths].filter((path) => previous.get(path) !== next.get(path));
 }
 
 /* v8 ignore next -- Called only by exhaustive guards when a future union member is missing above. */


### PR DESCRIPTION
## Summary
- add a V2 vault-content event capability with stable daemon instance IDs and monotonic mutation epochs
- fence disconnected, deliberately stopped, and replay-gap mutations so Cloud can retain caches only when continuity is proven
- detect cold filesystem changes with path-aware reconciliation while keeping watcher-only metadata out of public tree serialization
- keep broad invalidation vault-scoped so unrelated hosted-vault image caches remain warm

## Verification
- `env CI=true pnpm check`
- focused daemon tests: 165 passed
- focused vault-service tests: 26 passed
- autoreview: clean, no actionable findings