### PR TITLE
fix(tunnel): bound encoded HTTP response frames

### DIFF
--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -9,6 +9,7 @@ import {
   TUNNEL_PENDING_STREAM_FRAME_LIMIT,
   TUNNEL_WS_FRAME_BYTE_LIMIT,
   encodeTunnelMessage,
+  type TunnelHttpResponseEnvelope,
   type RelayFrame,
 } from '@kb-1/tunnel-protocol';
 import {
@@ -171,6 +172,90 @@ describe('ChunkedHttpRequestAssembler', () => {
 });
 
 describe('TunnelClient typed relay RPC', () => {
+  it('keeps multi-megabyte HTTP response chunks below the websocket frame cap', () => {
+    const control = new FakeSocket();
+    control.open();
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+    });
+    const body = Buffer.alloc(3 * 1024 * 1024 + 17, 0xa5);
+
+    (
+      client as unknown as {
+        sendHttpResponse(
+          control: FakeSocket,
+          envelope: TunnelHttpResponseEnvelope,
+        ): void;
+      }
+    ).sendHttpResponse(control, {
+      type: 'http.response',
+      id: `response-${'x'.repeat(2048)}`,
+      status: 200,
+      headers: { 'content-type': 'image/png' },
+      bodyB64: body.toString('base64'),
+    });
+
+    const encodedFrames = control.sent.map(({ data }) => Buffer.from(data as Uint8Array));
+    expect(encodedFrames.every((frame) => frame.byteLength <= TUNNEL_WS_FRAME_BYTE_LIMIT)).toBe(true);
+
+    const frames = encodedFrames.map((frame) => JSON.parse(frame.toString('utf8')) as {
+      type: string;
+      totalBytes?: number;
+      sequence?: number;
+      bodyB64?: string;
+      chunks?: number;
+    });
+    expect(frames[0]).toMatchObject({
+      type: 'http.response.start',
+      totalBytes: body.byteLength,
+    });
+    expect(frames.at(-1)).toMatchObject({
+      type: 'http.response.end',
+      chunks: frames.length - 2,
+    });
+
+    const chunks = frames.slice(1, -1).map((frame, sequence) => {
+      expect(frame).toMatchObject({ type: 'http.response.chunk', sequence });
+      const chunk = Buffer.from(frame.bodyB64 ?? '', 'base64');
+      return chunk;
+    });
+    expect(Buffer.concat(chunks).equals(body)).toBe(true);
+  });
+
+  it('chunks a response when its encoded headers push it over the websocket frame cap', () => {
+    const control = new FakeSocket();
+    control.open();
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+    });
+
+    (
+      client as unknown as {
+        sendHttpResponse(
+          control: FakeSocket,
+          envelope: TunnelHttpResponseEnvelope,
+        ): void;
+      }
+    ).sendHttpResponse(control, {
+      type: 'http.response',
+      id: '00000000-0000-4000-8000-000000000000',
+      status: 200,
+      headers: { 'x-padding': 'x'.repeat(1024) },
+      bodyB64: Buffer.alloc(196 * 1024, 0xa5).toString('base64'),
+    });
+
+    const encodedFrames = control.sent.map(({ data }) => Buffer.from(data as Uint8Array));
+    expect(encodedFrames.every((frame) => frame.byteLength <= TUNNEL_WS_FRAME_BYTE_LIMIT)).toBe(true);
+    expect(JSON.parse(encodedFrames[0].toString('utf8'))).toMatchObject({
+      type: 'http.response.start',
+      totalBytes: 196 * 1024,
+    });
+  });
+
   it('sends daemon-origin relay event frames over the control socket', () => {
     const control = new FakeSocket();
     control.open();

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -753,12 +753,16 @@ export class TunnelClient {
       return;
     }
 
-    const body = Buffer.from(envelope.bodyB64, 'base64');
-    if (body.byteLength <= TUNNEL_HTTP_BODY_CHUNK_BYTES) {
+    const envelopeWithoutBody = encodeJsonBytes({ ...envelope, bodyB64: '' });
+    if (
+      envelopeWithoutBody.byteLength + envelope.bodyB64.length <=
+      TUNNEL_WS_FRAME_BYTE_LIMIT
+    ) {
       control.send(encodeJsonBytes(envelope));
       return;
     }
 
+    const body = Buffer.from(envelope.bodyB64, 'base64');
     control.send(encodeJsonBytes({
       type: 'http.response.start',
       id: envelope.id,
@@ -768,13 +772,27 @@ export class TunnelClient {
     }));
 
     let sequence = 0;
-    for (let offset = 0; offset < body.byteLength; offset += TUNNEL_HTTP_BODY_CHUNK_BYTES) {
+    let offset = 0;
+    while (offset < body.byteLength) {
+      const emptyChunk = encodeJsonBytes({
+        type: 'http.response.chunk',
+        id: envelope.id,
+        sequence,
+        bodyB64: '',
+      });
+      const chunkBytes =
+        Math.floor((TUNNEL_WS_FRAME_BYTE_LIMIT - emptyChunk.byteLength) / 4) * 3;
+      if (chunkBytes <= 0) {
+        throw new Error('HTTP response chunk metadata exceeded tunnel frame cap');
+      }
+      const chunk = body.subarray(offset, offset + chunkBytes);
       control.send(encodeJsonBytes({
         type: 'http.response.chunk',
         id: envelope.id,
         sequence,
-        bodyB64: body.subarray(offset, offset + TUNNEL_HTTP_BODY_CHUNK_BYTES).toString('base64'),
+        bodyB64: chunk.toString('base64'),
       }));
+      offset += chunk.byteLength;
       sequence += 1;
     }
 


### PR DESCRIPTION
## What changed

- Bound every encoded HTTP response WebSocket frame to the tunnel's 256 KiB cap.
- Size chunk payloads from the actual encoded metadata overhead for each request ID and sequence number.
- Preserve the single-frame response path when the complete encoded envelope fits.
- Add multi-megabyte, metadata-heavy, ordering, frame-size, and byte-reconstruction regression coverage.

## Root cause

The relay chunked raw response bytes without accounting for base64 and JSON expansion. A nominal 256 KiB raw chunk therefore produced an encoded WebSocket frame larger than the tunnel cap, causing large image responses to close the connection.

## Impact

Large binary responses such as images can traverse the daemon relay without exceeding the WebSocket frame limit. The change is isolated to HTTP response serialization in the tunnel client.

## Verification

- `pnpm --filter @kb-1/tunnel-client test` — 52 tests passed
- `pnpm --filter @kb-1/tunnel-client typecheck`
- daemon `pnpm check`
- composed KB-1 Cloud `pnpm check`
- final autoreview — clean, no actionable findings (0.96 confidence)
- `git diff --check`
