### PR TITLE
refactor(vault-core): expose browser-safe artifact classifier

### DIFF
--- a/packages/vault-core/package.json
+++ b/packages/vault-core/package.json
@@ -9,6 +9,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./artifact": {
+      "types": "./dist/artifact.d.ts",
+      "import": "./dist/artifact.js"
     }
   },
   "files": [

--- a/packages/vault-core/src/artifact.test.ts
+++ b/packages/vault-core/src/artifact.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyArtifactPath } from "./artifact.js";
+
+describe("classifyArtifactPath", () => {
+  it.each(["photo.png", "nested/PHOTO.JPEG", "still.avif", "anim.apng"])(
+    "classifies %s as an image without Node path helpers",
+    (path) => {
+      expect(classifyArtifactPath(path)).toMatchObject({
+        kind: "attachment",
+        editable: false,
+        preview: "image",
+      });
+    },
+  );
+
+  it.each([".env", "folder/.hidden", "extensionless", "folder/name."])(
+    "keeps %s as an unknown download",
+    (path) => {
+      expect(classifyArtifactPath(path)).toEqual({
+        kind: "attachment",
+        contentType: "application/octet-stream",
+        editable: false,
+        preview: "download",
+      });
+    },
+  );
+});

--- a/packages/vault-core/src/artifact.ts
+++ b/packages/vault-core/src/artifact.ts
@@ -1,0 +1,119 @@
+export type ArtifactKind = "text" | "attachment";
+
+export type ArtifactPreview =
+  | "markdown"
+  | "text"
+  | "image"
+  | "audio"
+  | "video"
+  | "pdf"
+  | "download";
+
+export interface ArtifactInfo {
+  kind: ArtifactKind;
+  contentType: string;
+  editable: boolean;
+  preview: ArtifactPreview;
+}
+
+const TEXT_ARTIFACT_EXTENSIONS: Record<
+  string,
+  { contentType: string; preview: ArtifactPreview }
+> = {
+  ".md": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
+  ".markdown": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
+  ".mdown": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
+  ".mkdn": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
+  ".txt": { contentType: "text/plain; charset=utf-8", preview: "text" },
+  ".log": { contentType: "text/plain; charset=utf-8", preview: "text" },
+  ".csv": { contentType: "text/csv; charset=utf-8", preview: "text" },
+  ".tsv": { contentType: "text/tab-separated-values; charset=utf-8", preview: "text" },
+  ".html": { contentType: "text/html; charset=utf-8", preview: "text" },
+  ".htm": { contentType: "text/html; charset=utf-8", preview: "text" },
+  ".css": { contentType: "text/css; charset=utf-8", preview: "text" },
+  ".js": { contentType: "text/javascript; charset=utf-8", preview: "text" },
+  ".jsx": { contentType: "text/javascript; charset=utf-8", preview: "text" },
+  ".ts": { contentType: "text/typescript; charset=utf-8", preview: "text" },
+  ".tsx": { contentType: "text/typescript; charset=utf-8", preview: "text" },
+  ".json": { contentType: "application/json; charset=utf-8", preview: "text" },
+  ".yml": { contentType: "application/yaml; charset=utf-8", preview: "text" },
+  ".yaml": { contentType: "application/yaml; charset=utf-8", preview: "text" },
+  ".xml": { contentType: "application/xml; charset=utf-8", preview: "text" },
+  ".toml": { contentType: "application/toml; charset=utf-8", preview: "text" },
+  ".ini": { contentType: "text/plain; charset=utf-8", preview: "text" },
+  ".sh": { contentType: "text/x-shellscript; charset=utf-8", preview: "text" },
+  ".py": { contentType: "text/x-python; charset=utf-8", preview: "text" },
+  ".rb": { contentType: "text/x-ruby; charset=utf-8", preview: "text" },
+  ".go": { contentType: "text/x-go; charset=utf-8", preview: "text" },
+  ".rs": { contentType: "text/x-rust; charset=utf-8", preview: "text" },
+  ".java": { contentType: "text/x-java-source; charset=utf-8", preview: "text" },
+  ".c": { contentType: "text/x-c; charset=utf-8", preview: "text" },
+  ".cpp": { contentType: "text/x-c++; charset=utf-8", preview: "text" },
+  ".h": { contentType: "text/x-c; charset=utf-8", preview: "text" },
+  ".hpp": { contentType: "text/x-c++; charset=utf-8", preview: "text" },
+};
+
+const ATTACHMENT_ARTIFACT_EXTENSIONS: Record<
+  string,
+  { contentType: string; preview: ArtifactPreview }
+> = {
+  ".png": { contentType: "image/png", preview: "image" },
+  ".jpg": { contentType: "image/jpeg", preview: "image" },
+  ".jpeg": { contentType: "image/jpeg", preview: "image" },
+  ".gif": { contentType: "image/gif", preview: "image" },
+  ".webp": { contentType: "image/webp", preview: "image" },
+  ".avif": { contentType: "image/avif", preview: "image" },
+  ".apng": { contentType: "image/apng", preview: "image" },
+  ".svg": { contentType: "application/octet-stream", preview: "download" },
+  ".mp3": { contentType: "audio/mpeg", preview: "audio" },
+  ".wav": { contentType: "audio/wav", preview: "audio" },
+  ".ogg": { contentType: "audio/ogg", preview: "audio" },
+  ".flac": { contentType: "audio/flac", preview: "audio" },
+  ".m4a": { contentType: "audio/mp4", preview: "audio" },
+  ".aac": { contentType: "audio/aac", preview: "audio" },
+  ".mp4": { contentType: "video/mp4", preview: "video" },
+  ".webm": { contentType: "video/webm", preview: "video" },
+  ".mov": { contentType: "video/quicktime", preview: "video" },
+  ".m4v": { contentType: "video/x-m4v", preview: "video" },
+  ".pdf": { contentType: "application/pdf", preview: "pdf" },
+  ".zip": { contentType: "application/zip", preview: "download" },
+  ".gz": { contentType: "application/gzip", preview: "download" },
+  ".tgz": { contentType: "application/gzip", preview: "download" },
+  ".tar": { contentType: "application/x-tar", preview: "download" },
+};
+
+function artifactExtension(relPath: string): string {
+  const leaf = relPath.slice(relPath.lastIndexOf("/") + 1);
+  const dot = leaf.lastIndexOf(".");
+  return dot <= 0 ? "" : leaf.slice(dot).toLowerCase();
+}
+
+export function classifyArtifactPath(relPath: string): ArtifactInfo {
+  const extension = artifactExtension(relPath);
+  const text = TEXT_ARTIFACT_EXTENSIONS[extension];
+  if (text) {
+    return {
+      kind: "text",
+      contentType: text.contentType,
+      editable: true,
+      preview: text.preview,
+    };
+  }
+
+  const attachment = ATTACHMENT_ARTIFACT_EXTENSIONS[extension];
+  if (attachment) {
+    return {
+      kind: "attachment",
+      contentType: attachment.contentType,
+      editable: false,
+      preview: attachment.preview,
+    };
+  }
+
+  return {
+    kind: "attachment",
+    contentType: "application/octet-stream",
+    editable: false,
+    preview: "download",
+  };
+}

--- a/packages/vault-core/src/index.ts
+++ b/packages/vault-core/src/index.ts
@@ -54,6 +54,11 @@ export {
 } from "./search.js";
 export {
   classifyArtifactPath,
+  type ArtifactInfo,
+  type ArtifactKind,
+  type ArtifactPreview,
+} from "./artifact.js";
+export {
   deleteVaultFile,
   deleteVaultFolder,
   getFolderMetadata,
@@ -67,9 +72,6 @@ export {
   setFolderMetadata,
   writeVaultRawFile,
   writeVaultFile,
-  type ArtifactInfo,
-  type ArtifactKind,
-  type ArtifactPreview,
   type DeleteValue,
   type FolderMetadata,
   type FolderMetadataInput,

--- a/packages/vault-core/src/vault-ops.ts
+++ b/packages/vault-core/src/vault-ops.ts
@@ -13,6 +13,8 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { emitVaultAudit, type AuditEntry, type VaultActor } from "./audit.js";
+import { classifyArtifactPath, type ArtifactInfo } from "./artifact.js";
+export { classifyArtifactPath } from "./artifact.js";
 import {
   normalizeFolderMetadataColor,
   type FolderMetadataColor,
@@ -78,24 +80,6 @@ export interface WriteFileValue {
   size: number;
   mtimeMs: number;
   audit: AuditEntry;
-}
-
-export type ArtifactKind = "text" | "attachment";
-
-export type ArtifactPreview =
-  | "markdown"
-  | "text"
-  | "image"
-  | "audio"
-  | "video"
-  | "pdf"
-  | "download";
-
-export interface ArtifactInfo {
-  kind: ArtifactKind;
-  contentType: string;
-  editable: boolean;
-  preview: ArtifactPreview;
 }
 
 export interface ReadRawFileValue {
@@ -211,96 +195,6 @@ function trashRelativePath(originalPath: string): string {
     batchId,
     originalPath,
   );
-}
-
-const TEXT_ARTIFACT_EXTENSIONS: Record<string, { contentType: string; preview: ArtifactPreview }> = {
-  ".md": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
-  ".markdown": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
-  ".mdown": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
-  ".mkdn": { contentType: "text/markdown; charset=utf-8", preview: "markdown" },
-  ".txt": { contentType: "text/plain; charset=utf-8", preview: "text" },
-  ".log": { contentType: "text/plain; charset=utf-8", preview: "text" },
-  ".csv": { contentType: "text/csv; charset=utf-8", preview: "text" },
-  ".tsv": { contentType: "text/tab-separated-values; charset=utf-8", preview: "text" },
-  ".html": { contentType: "text/html; charset=utf-8", preview: "text" },
-  ".htm": { contentType: "text/html; charset=utf-8", preview: "text" },
-  ".css": { contentType: "text/css; charset=utf-8", preview: "text" },
-  ".js": { contentType: "text/javascript; charset=utf-8", preview: "text" },
-  ".jsx": { contentType: "text/javascript; charset=utf-8", preview: "text" },
-  ".ts": { contentType: "text/typescript; charset=utf-8", preview: "text" },
-  ".tsx": { contentType: "text/typescript; charset=utf-8", preview: "text" },
-  ".json": { contentType: "application/json; charset=utf-8", preview: "text" },
-  ".yml": { contentType: "application/yaml; charset=utf-8", preview: "text" },
-  ".yaml": { contentType: "application/yaml; charset=utf-8", preview: "text" },
-  ".xml": { contentType: "application/xml; charset=utf-8", preview: "text" },
-  ".toml": { contentType: "application/toml; charset=utf-8", preview: "text" },
-  ".ini": { contentType: "text/plain; charset=utf-8", preview: "text" },
-  ".sh": { contentType: "text/x-shellscript; charset=utf-8", preview: "text" },
-  ".py": { contentType: "text/x-python; charset=utf-8", preview: "text" },
-  ".rb": { contentType: "text/x-ruby; charset=utf-8", preview: "text" },
-  ".go": { contentType: "text/x-go; charset=utf-8", preview: "text" },
-  ".rs": { contentType: "text/x-rust; charset=utf-8", preview: "text" },
-  ".java": { contentType: "text/x-java-source; charset=utf-8", preview: "text" },
-  ".c": { contentType: "text/x-c; charset=utf-8", preview: "text" },
-  ".cpp": { contentType: "text/x-c++; charset=utf-8", preview: "text" },
-  ".h": { contentType: "text/x-c; charset=utf-8", preview: "text" },
-  ".hpp": { contentType: "text/x-c++; charset=utf-8", preview: "text" },
-};
-
-const ATTACHMENT_ARTIFACT_EXTENSIONS: Record<string, { contentType: string; preview: ArtifactPreview }> = {
-  ".png": { contentType: "image/png", preview: "image" },
-  ".jpg": { contentType: "image/jpeg", preview: "image" },
-  ".jpeg": { contentType: "image/jpeg", preview: "image" },
-  ".gif": { contentType: "image/gif", preview: "image" },
-  ".webp": { contentType: "image/webp", preview: "image" },
-  ".avif": { contentType: "image/avif", preview: "image" },
-  ".apng": { contentType: "image/apng", preview: "image" },
-  ".svg": { contentType: "application/octet-stream", preview: "download" },
-  ".mp3": { contentType: "audio/mpeg", preview: "audio" },
-  ".wav": { contentType: "audio/wav", preview: "audio" },
-  ".ogg": { contentType: "audio/ogg", preview: "audio" },
-  ".flac": { contentType: "audio/flac", preview: "audio" },
-  ".m4a": { contentType: "audio/mp4", preview: "audio" },
-  ".aac": { contentType: "audio/aac", preview: "audio" },
-  ".mp4": { contentType: "video/mp4", preview: "video" },
-  ".webm": { contentType: "video/webm", preview: "video" },
-  ".mov": { contentType: "video/quicktime", preview: "video" },
-  ".m4v": { contentType: "video/x-m4v", preview: "video" },
-  ".pdf": { contentType: "application/pdf", preview: "pdf" },
-  ".zip": { contentType: "application/zip", preview: "download" },
-  ".gz": { contentType: "application/gzip", preview: "download" },
-  ".tgz": { contentType: "application/gzip", preview: "download" },
-  ".tar": { contentType: "application/x-tar", preview: "download" },
-};
-
-export function classifyArtifactPath(relPath: string): ArtifactInfo {
-  const extension = path.posix.extname(relPath).toLowerCase();
-  const text = TEXT_ARTIFACT_EXTENSIONS[extension];
-  if (text) {
-    return {
-      kind: "text",
-      contentType: text.contentType,
-      editable: true,
-      preview: text.preview,
-    };
-  }
-
-  const attachment = ATTACHMENT_ARTIFACT_EXTENSIONS[extension];
-  if (attachment) {
-    return {
-      kind: "attachment",
-      contentType: attachment.contentType,
-      editable: false,
-      preview: attachment.preview,
-    };
-  }
-
-  return {
-    kind: "attachment",
-    contentType: "application/octet-stream",
-    editable: false,
-    preview: "download",
-  };
 }
 
 function ensureEditableArtifact(relPath: string): VaultResult<ArtifactInfo> {


### PR DESCRIPTION
## Summary

- extract artifact classification into a Node-free browser-safe module
- preserve the existing root and `vault-ops` exports and classification behavior
- expose `@kb-1/vault-core/artifact` for browser consumers

## Why

The Cloud editor needs to recognize image routes before its full vault tree arrives. The existing classifier lived in `vault-ops.ts`, which imports Node filesystem and path modules and cannot be safely bundled into the browser.

## Validation

- `pnpm check`
- `pnpm --filter @kb-1/vault-core exec vitest run src/artifact.test.ts src/index.test.ts --coverage.enabled=false`
- `pnpm --filter @kb-1/vault-core typecheck`
- autoreview clean: no accepted or actionable findings
