### PR TITLE
feat: warm pool of dialback sockets to cut cold document-open latency

### DIFF
--- a/apps/daemon/src/config.test.ts
+++ b/apps/daemon/src/config.test.ts
@@ -99,7 +99,8 @@ describe('daemon config', () => {
       webProxyTarget: 'http://127.0.0.1:5173',
       relay: {
         relayUrl: 'http://127.0.0.1:9920/t/dev1',
-        token: 'test-token'
+        token: 'test-token',
+        dialbackPoolSize: 3
       },
       actorDefault: 'user',
       historyCoalesceWindowMs: DEFAULT_HISTORY_COALESCE_WINDOW_MS,
@@ -163,7 +164,8 @@ describe('daemon config', () => {
       relayUrl: 'http://127.0.0.1:9920/t/dev1',
       token: 'test-token',
       daemonVersion: '0.1.0',
-      daemonBuild: 'registry.fly.io/kb1@sha256:abc123'
+      daemonBuild: 'registry.fly.io/kb1@sha256:abc123',
+      dialbackPoolSize: 3
     });
   });
 
@@ -180,6 +182,30 @@ describe('daemon config', () => {
     expect(resolveHistoryCoalesceWindowMs({ KB2_HISTORY_COALESCE_WINDOW_MS: '120000' })).toBe(DEFAULT_HISTORY_COALESCE_WINDOW_MS);
     expect(() => resolveHistoryCoalesceWindowMs({ KB1_HISTORY_COALESCE_WINDOW_MS: '-1' })).toThrow(/KB1_HISTORY_COALESCE_WINDOW_MS/);
     expect(resolveHistoryCoalesceWindowMs({ KB2_HISTORY_COALESCE_WINDOW_MS: 'five' })).toBe(DEFAULT_HISTORY_COALESCE_WINDOW_MS);
+  });
+
+  it('defaults dialbackPoolSize to 3 when KB1_DIALBACK_POOL_SIZE is unset', () => {
+    const cfg = resolveRelayConfig({ KB1_RELAY_URL: 'https://relay.test', KB1_RELAY_TOKEN: 't' });
+    expect(cfg?.dialbackPoolSize).toBe(3);
+  });
+
+  it('parses KB1_DIALBACK_POOL_SIZE as a non-negative integer', () => {
+    const cfg = resolveRelayConfig({
+      KB1_RELAY_URL: 'https://relay.test',
+      KB1_RELAY_TOKEN: 't',
+      KB1_DIALBACK_POOL_SIZE: '0'
+    });
+    expect(cfg?.dialbackPoolSize).toBe(0);
+  });
+
+  it('rejects a negative KB1_DIALBACK_POOL_SIZE', () => {
+    expect(() =>
+      resolveRelayConfig({
+        KB1_RELAY_URL: 'https://relay.test',
+        KB1_RELAY_TOKEN: 't',
+        KB1_DIALBACK_POOL_SIZE: '-1'
+      })
+    ).toThrow(/KB1_DIALBACK_POOL_SIZE/);
   });
 
   it('does not report KB2 deprecation warnings because KB2 env is not honored', () => {

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -46,6 +46,7 @@ interface DaemonRelayConfig {
   token: string;
   daemonVersion?: string;
   daemonBuild?: string;
+  dialbackPoolSize?: number;
 }
 
 export interface ResolveConfigOptions {
@@ -107,11 +108,24 @@ export function resolveRelayConfig(env: NodeJS.ProcessEnv = process.env): Daemon
   const daemonVersion = resolveEnvValue(env, 'DAEMON_VERSION');
   const daemonBuild = resolveEnvValue(env, 'DAEMON_BUILD');
 
+  const configuredPoolSize = resolveEnvValue(env, 'DIALBACK_POOL_SIZE');
+  let dialbackPoolSize = 3;
+  if (configuredPoolSize !== undefined) {
+    const parsed = Number(configuredPoolSize);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      throw new Error(
+        `KB1_DIALBACK_POOL_SIZE must be a non-negative integer. Received: ${configuredPoolSize}`
+      );
+    }
+    dialbackPoolSize = parsed;
+  }
+
   return {
     relayUrl: new URL(relayUrl).href,
     token,
     ...(daemonVersion ? { daemonVersion } : {}),
-    ...(daemonBuild ? { daemonBuild } : {})
+    ...(daemonBuild ? { daemonBuild } : {}),
+    dialbackPoolSize
   };
 }
 

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -399,6 +399,7 @@ function createRelayLifecycleController(
     token: config.relay.token,
     daemonVersion: config.relay.daemonVersion,
     daemonBuild: config.relay.daemonBuild,
+    dialbackPoolSize: config.relay.dialbackPoolSize,
     logger: daemonRelayLogger,
   });
   let unsubscribeVaultEvents: (() => void) | undefined;

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -1795,7 +1795,7 @@ describe("DialbackPool", () => {
     expect(pool.acquire()).toBeNull();
   });
 
-  it("closing a warming socket before it opens defers the refill via the injected scheduler (connect failure)", () => {
+  it("closing a warming socket before it opens defers the refill via the injected scheduler (connect failure), and suppresses new opens for the whole backoff window", () => {
     const { schedule, scheduled } = makeCapturingSchedule();
     const { pool, created } = makePool(1, { schedule });
     pool.prime();
@@ -1809,12 +1809,63 @@ describe("DialbackPool", () => {
     expect(scheduled[0].delayMs).toBeGreaterThan(0);
     // nothing acquirable until the scheduled refill actually runs
     expect(pool.acquire()).toBeNull();
+    // The real guarantee under test: interleaved calls on the hot path
+    // (acquire()'s internal refill, and a bare prime() like control.ready
+    // triggers) during the backoff window must NOT open a replacement
+    // socket. A prior version of this test only asserted acquire()'s
+    // return value, which stayed null (nothing readyState OPEN) whether or
+    // not a new CONNECTING socket was opened underneath — so it passed
+    // even while the guard was absent. Assert on `created.length` instead,
+    // which is the thing that actually distinguishes "no new socket was
+    // opened" from "a socket opened but isn't ready yet".
+    expect(created).toHaveLength(1);
+    pool.prime();
+    expect(created).toHaveLength(1);
+    expect(pool.acquire()).toBeNull();
+    expect(created).toHaveLength(1);
 
     scheduled[0].fn();
     expect(created).toHaveLength(2);
     expect(pool.acquire()).toBeNull();
     created[1].open();
     expect(pool.acquire()).toBe(created[1]);
+  });
+
+  it("control.ready-style prime() and hot-path acquire() calls during the backoff window open nothing until the scheduled callback runs", () => {
+    const { schedule, scheduled } = makeCapturingSchedule();
+    const { pool, created } = makePool(2, { schedule });
+    pool.prime();
+    expect(created).toHaveLength(2);
+    // one socket opens normally and sits ready; the other dies while
+    // warming — a connect failure that arms the backoff guard.
+    created[0].open();
+    created[1].close();
+    expect(scheduled).toHaveLength(1);
+    expect(created).toHaveLength(2);
+
+    // Simulate the two real call sites that raced the backoff window in
+    // the pre-fix code: control.ready firing prime() directly, and the hot
+    // openDialback path calling acquire() (which internally re-primes).
+    pool.prime();
+    expect(created).toHaveLength(2);
+    pool.prime();
+    expect(created).toHaveLength(2);
+    const acquired = pool.acquire();
+    // The still-ready, already-open socket from created[0] may be handed
+    // out — consuming an existing ready socket is fine and expected...
+    expect(acquired).toBe(created[0]);
+    // ...but acquiring it must not have opened a replacement while the
+    // backoff guard is set.
+    expect(created).toHaveLength(2);
+    expect(pool.acquire()).toBeNull();
+    expect(created).toHaveLength(2);
+
+    // Once the scheduled callback fires, the guard lifts and refilling
+    // resumes: two replacements are opened — one for the failed socket,
+    // one for the ready socket that acquire() just consumed — bringing
+    // the pool back up to `size`.
+    scheduled[0].fn();
+    expect(created).toHaveLength(4);
   });
 
   it("consecutive connect failures increase the backoff delay passed to schedule", () => {

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -15,6 +15,7 @@ import {
 import {
   ChunkedHttpRequestAssembler,
   DialbackBridge,
+  DialbackPool,
   TunnelClient,
   createBackoffDelay,
   materializedResponseBody,
@@ -1716,5 +1717,65 @@ describe('DialbackBridge', () => {
       streamId: 'stream-1',
       error: 'Error: daemon down',
     });
+  });
+});
+
+describe("DialbackPool", () => {
+  const OPEN = 1;
+
+  function makePool(size: number) {
+    const created: FakeSocket[] = [];
+    const helloed: FakeSocket[] = [];
+    const pool = new DialbackPool({
+      size,
+      createSocket: () => {
+        const s = new FakeSocket();
+        created.push(s);
+        return s;
+      },
+      sendPoolHello: (s) => helloed.push(s as FakeSocket),
+    });
+    return { pool, created, helloed };
+  }
+
+  it("primes up to size and sends pool hello once each socket opens", () => {
+    const { pool, created, helloed } = makePool(3);
+    pool.prime();
+    expect(created).toHaveLength(3);
+    created.forEach((s) => s.open());
+    expect(helloed).toHaveLength(3);
+  });
+
+  it("acquire returns an opened socket and refills back to size", () => {
+    const { pool, created } = makePool(2);
+    pool.prime();
+    created.forEach((s) => s.open());
+    const s = pool.acquire();
+    expect(s).not.toBeNull();
+    expect(s!.readyState).toBe(OPEN);
+    // one consumed; pool opened a replacement
+    expect(created).toHaveLength(3);
+  });
+
+  it("acquire returns null when the pool is empty", () => {
+    const { pool } = makePool(1);
+    // prime() called, socket still CONNECTING (never opened)
+    pool.prime();
+    expect(pool.acquire()).toBeNull();
+  });
+
+  it("acquire skips a dead ready socket and returns null", () => {
+    const { pool, created } = makePool(1);
+    pool.prime();
+    created[0].open();
+    created[0].readyState = 3; // CLOSED under the socket without emitting close
+    expect(pool.acquire()).toBeNull();
+  });
+
+  it("size 0 opens nothing and always returns null", () => {
+    const { pool, created } = makePool(0);
+    pool.prime();
+    expect(created).toHaveLength(0);
+    expect(pool.acquire()).toBeNull();
   });
 });

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -1944,4 +1944,65 @@ describe("DialbackPool", () => {
       vi.useRealTimers();
     }
   });
+
+  it("dispose closes parked ready sockets and clears the ready list", () => {
+    const { pool, created } = makePool(2);
+    pool.prime();
+    created.forEach((s) => s.open());
+    expect(created.every((s) => s.closes.length === 0)).toBe(true);
+
+    pool.dispose();
+
+    expect(created.every((s) => s.closes.length > 0)).toBe(true);
+    expect(pool.acquire()).toBeNull();
+  });
+
+  it("after dispose, prime() opens nothing and acquire() returns null and opens nothing", () => {
+    const { pool, created } = makePool(2);
+    pool.prime();
+    created.forEach((s) => s.open());
+    pool.dispose();
+
+    pool.prime();
+    expect(created).toHaveLength(2);
+
+    expect(pool.acquire()).toBeNull();
+    expect(created).toHaveLength(2);
+  });
+
+  it("dispose neutralizes a pending backoff timer: the scheduled callback opens no new socket", () => {
+    const { schedule, scheduled } = makeCapturingSchedule();
+    const { pool, created } = makePool(1, { schedule });
+    pool.prime();
+    expect(created).toHaveLength(1);
+    // dies while warming, never opened: a connect failure, arms backoff
+    created[0].close();
+    expect(scheduled).toHaveLength(1);
+    expect(created).toHaveLength(1);
+
+    pool.dispose();
+
+    // Invoke the captured backoff callback as if the timer fired after
+    // dispose. Without the `disposed` guard at the top of prime(), this
+    // would open a replacement socket and reopen a relay connection after
+    // the client already stopped.
+    scheduled[0].fn();
+    expect(created).toHaveLength(1);
+    expect(pool.acquire()).toBeNull();
+  });
+
+  it("a socket that fires 'open' after dispose is closed immediately and never handed out", () => {
+    const { pool, created } = makePool(1);
+    pool.prime();
+    expect(created).toHaveLength(1);
+    expect(created[0].closes).toHaveLength(0);
+
+    pool.dispose();
+
+    // The in-flight connect finishes after dispose already ran.
+    created[0].open();
+
+    expect(created[0].closes.length).toBeGreaterThan(0);
+    expect(pool.acquire()).toBeNull();
+  });
 });

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -1723,7 +1723,13 @@ describe('DialbackBridge', () => {
 describe("DialbackPool", () => {
   const OPEN = 1;
 
-  function makePool(size: number) {
+  function makePool(
+    size: number,
+    extra: {
+      schedule?: (fn: () => void, delayMs: number) => void;
+      random?: () => number;
+    } = {},
+  ) {
     const created: FakeSocket[] = [];
     const helloed: FakeSocket[] = [];
     const pool = new DialbackPool({
@@ -1734,8 +1740,18 @@ describe("DialbackPool", () => {
         return s;
       },
       sendPoolHello: (s) => helloed.push(s as FakeSocket),
+      ...extra,
     });
     return { pool, created, helloed };
+  }
+
+  /** Captures scheduled (fn, delayMs) pairs without running them until invoked. */
+  function makeCapturingSchedule() {
+    const scheduled: Array<{ fn: () => void; delayMs: number }> = [];
+    const schedule = (fn: () => void, delayMs: number) => {
+      scheduled.push({ fn, delayMs });
+    };
+    return { schedule, scheduled };
   }
 
   it("primes up to size and sends pool hello once each socket opens", () => {
@@ -1779,18 +1795,73 @@ describe("DialbackPool", () => {
     expect(pool.acquire()).toBeNull();
   });
 
-  it("closing a warming socket before it opens refills back to size", () => {
-    const { pool, created } = makePool(1);
+  it("closing a warming socket before it opens defers the refill via the injected scheduler (connect failure)", () => {
+    const { schedule, scheduled } = makeCapturingSchedule();
+    const { pool, created } = makePool(1, { schedule });
     pool.prime();
     expect(created).toHaveLength(1);
-    // still CONNECTING (never opened) — dies while warming
+    // still CONNECTING (never opened) — dies while warming: a connect failure
     created[0].close();
-    // onGone must decrement `warming` (not double-count) and trigger a background refill
+    // onGone must decrement `warming` (not double-count) but must NOT
+    // re-createSocket() synchronously — the refill is deferred.
+    expect(created).toHaveLength(1);
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].delayMs).toBeGreaterThan(0);
+    // nothing acquirable until the scheduled refill actually runs
+    expect(pool.acquire()).toBeNull();
+
+    scheduled[0].fn();
     expect(created).toHaveLength(2);
-    // the replacement isn't open yet, so nothing is acquirable
     expect(pool.acquire()).toBeNull();
     created[1].open();
     expect(pool.acquire()).toBe(created[1]);
+  });
+
+  it("consecutive connect failures increase the backoff delay passed to schedule", () => {
+    const { schedule, scheduled } = makeCapturingSchedule();
+    const { pool, created } = makePool(1, { schedule, random: () => 0 });
+    pool.prime();
+
+    // first connect failure
+    created[0].close();
+    expect(scheduled).toHaveLength(1);
+    const firstDelay = scheduled[0].delayMs;
+
+    // run the scheduled refill, which opens a new warming socket…
+    scheduled[0].fn();
+    expect(created).toHaveLength(2);
+    // …that itself fails to connect (still consecutive: no open in between)
+    created[1].close();
+    expect(scheduled).toHaveLength(2);
+    const secondDelay = scheduled[1].delayMs;
+
+    expect(secondDelay).toBeGreaterThan(firstDelay);
+  });
+
+  it("a successful open resets the failure count so a later failure starts from the base delay again", () => {
+    const { schedule, scheduled } = makeCapturingSchedule();
+    const { pool, created } = makePool(1, { schedule, random: () => 0 });
+    pool.prime();
+
+    // first connect failure
+    created[0].close();
+    const firstDelay = scheduled[0].delayMs;
+
+    // scheduled refill opens successfully, resetting consecutiveFailures
+    scheduled[0].fn();
+    created[1].open();
+
+    // that socket is later consumed/dies after opening — not a connect
+    // failure, refills promptly (no new schedule() call for it)…
+    created[1].close();
+    expect(scheduled).toHaveLength(1);
+    expect(created).toHaveLength(3);
+
+    // …and now the freshly-created replacement fails to connect: since the
+    // last open reset the counter, this should start from the base delay.
+    created[2].close();
+    expect(scheduled).toHaveLength(2);
+    expect(scheduled[1].delayMs).toBe(firstDelay);
   });
 
   it("closing an unconsumed ready socket removes it and refills back to size", () => {
@@ -1805,5 +1876,21 @@ describe("DialbackPool", () => {
     expect(pool.acquire()).toBeNull();
     created[1].open();
     expect(pool.acquire()).toBe(created[1]);
+  });
+
+  it("default scheduler (real setTimeout) still eventually refills after a connect failure", () => {
+    vi.useFakeTimers();
+    try {
+      const { pool, created } = makePool(1);
+      pool.prime();
+      expect(created).toHaveLength(1);
+      created[0].close();
+      // deferred: no synchronous refill with the default scheduler either
+      expect(created).toHaveLength(1);
+      vi.runOnlyPendingTimers();
+      expect(created).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -1778,4 +1778,32 @@ describe("DialbackPool", () => {
     expect(created).toHaveLength(0);
     expect(pool.acquire()).toBeNull();
   });
+
+  it("closing a warming socket before it opens refills back to size", () => {
+    const { pool, created } = makePool(1);
+    pool.prime();
+    expect(created).toHaveLength(1);
+    // still CONNECTING (never opened) — dies while warming
+    created[0].close();
+    // onGone must decrement `warming` (not double-count) and trigger a background refill
+    expect(created).toHaveLength(2);
+    // the replacement isn't open yet, so nothing is acquirable
+    expect(pool.acquire()).toBeNull();
+    created[1].open();
+    expect(pool.acquire()).toBe(created[1]);
+  });
+
+  it("closing an unconsumed ready socket removes it and refills back to size", () => {
+    const { pool, created } = makePool(1);
+    pool.prime();
+    created[0].open();
+    // sitting READY, unconsumed — dies on its own
+    created[0].close();
+    // onGone must remove it from `ready` and trigger a background refill
+    expect(created).toHaveLength(2);
+    // the replacement isn't open yet, so nothing is acquirable
+    expect(pool.acquire()).toBeNull();
+    created[1].open();
+    expect(pool.acquire()).toBe(created[1]);
+  });
 });

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -1271,6 +1271,15 @@ export class DialbackPool {
   private readonly schedule: (fn: () => void, delayMs: number) => void;
   private warming = 0;
   private consecutiveFailures = 0;
+  /**
+   * Set while a connect-failure backoff timer is outstanding. While true,
+   * `prime()` is a no-op: no new pool socket may be opened, whether `prime()`
+   * is invoked directly, via `acquire()`'s refill, or via a non-failure
+   * `onGone` refill that happens to race the window. The scheduled callback
+   * clears this before calling the real refill, so the backoff is enforced
+   * for the whole delay and then lifted atomically.
+   */
+  private backoffPending = false;
 
   constructor(private readonly options: DialbackPoolOptions) {
     this.schedule = options.schedule ?? ((fn, delayMs) => setTimeout(fn, delayMs));
@@ -1278,6 +1287,7 @@ export class DialbackPool {
 
   prime(): void {
     if (this.options.size <= 0) return;
+    if (this.backoffPending) return;
     while (this.ready.length + this.warming < this.options.size) {
       this.open();
     }
@@ -1327,7 +1337,11 @@ export class DialbackPool {
           {},
           this.options.random,
         );
-        this.schedule(() => this.prime(), delayMs);
+        this.backoffPending = true;
+        this.schedule(() => {
+          this.backoffPending = false;
+          this.prime();
+        }, delayMs);
         return;
       }
 

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -50,6 +50,7 @@ export type TunnelClientConfig = {
   daemonVersion?: string;
   daemonBuild?: string;
   daemonInstanceId?: string;
+  dialbackPoolSize?: number;
   logger?: TunnelClientLogger;
   fetch?: typeof fetch;
   random?: () => number;

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -167,6 +167,7 @@ export class TunnelClient {
             logger: this.logger,
             createSocket: () => this.openPoolRelaySocket(),
             sendPoolHello: (socket) => this.sendDialbackPoolHello(socket),
+            random: this.random,
           })
         : undefined;
   }
@@ -1253,15 +1254,27 @@ export type DialbackPoolOptions = {
   createSocket: () => PoolSocket;
   sendPoolHello: (socket: PoolSocket) => void;
   logger?: TunnelClientLogger;
+  /**
+   * Injectable scheduler for the backoff delay applied after a connect
+   * failure. Defaults to real `setTimeout`. Tests inject a synchronous or
+   * capturing implementation to drive the delay deterministically.
+   */
+  schedule?: (fn: () => void, delayMs: number) => void;
+  /** Injectable RNG passed through to `createBackoffDelay` for deterministic jitter in tests. */
+  random?: () => number;
 };
 
 const WS_OPEN = 1;
 
 export class DialbackPool {
   private readonly ready: PoolSocket[] = [];
+  private readonly schedule: (fn: () => void, delayMs: number) => void;
   private warming = 0;
+  private consecutiveFailures = 0;
 
-  constructor(private readonly options: DialbackPoolOptions) {}
+  constructor(private readonly options: DialbackPoolOptions) {
+    this.schedule = options.schedule ?? ((fn, delayMs) => setTimeout(fn, delayMs));
+  }
 
   prime(): void {
     if (this.options.size <= 0) return;
@@ -1291,16 +1304,35 @@ export class DialbackPool {
     socket.on('open', () => {
       opened = true;
       this.warming -= 1;
+      this.consecutiveFailures = 0;
       this.options.sendPoolHello(socket);
       this.ready.push(socket);
     });
     const onGone = () => {
+      const connectFailure = !opened;
       if (!opened) {
         opened = true;
         this.warming -= 1;
       }
       const i = this.ready.indexOf(socket);
       if (i >= 0) this.ready.splice(i, 1);
+
+      if (connectFailure) {
+        // Socket died without ever firing 'open' (e.g. persistently
+        // REJECTED pool-socket connects on version skew). Back off the
+        // re-prime instead of refilling every RTT with no ceiling.
+        this.consecutiveFailures += 1;
+        const delayMs = createBackoffDelay(
+          this.consecutiveFailures - 1,
+          {},
+          this.options.random,
+        );
+        this.schedule(() => this.prime(), delayMs);
+        return;
+      }
+
+      // Opened then later closed (consumed via acquire() or died while
+      // ready): not a connect failure, refill promptly as before.
       this.prime();
     };
     socket.on('close', onGone);

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -151,12 +151,24 @@ export class TunnelClient {
   private relaySupportsHttpResponseChunkAcks = false;
   private readonly daemonInstanceId: string;
   private vaultMutationEpoch = 0;
+  private readonly dialbackPool: DialbackPool | undefined;
 
   constructor(private readonly config: TunnelClientConfig) {
     this.logger = config.logger ?? consoleLogger;
     this.fetchImpl = config.fetch ?? fetch;
     this.random = config.random ?? Math.random;
     this.daemonInstanceId = config.daemonInstanceId ?? randomUUID();
+
+    const poolSize = config.dialbackPoolSize ?? 3;
+    this.dialbackPool =
+      poolSize > 0
+        ? new DialbackPool({
+            size: poolSize,
+            logger: this.logger,
+            createSocket: () => this.openPoolRelaySocket(),
+            sendPoolHello: (socket) => this.sendDialbackPoolHello(socket),
+          })
+        : undefined;
   }
 
   start(): void {
@@ -334,6 +346,7 @@ export class TunnelClient {
             TUNNEL_FEATURES.HTTP_RESPONSE_CHUNK_ACKS_V1,
           ) ?? false;
         this.logger.log('info', 'relay control ready', { protocolVersion: message.version });
+        this.dialbackPool?.prime();
         return;
       case 'control.pong':
         this.clearControlHeartbeatDeadline();
@@ -932,18 +945,15 @@ export class TunnelClient {
 
   private openDialback(envelope: TunnelWebSocketOpenEnvelope): void {
     // Coordinated relay wire path; see the control URL comment above.
-    const dialbackUrl = relayInternalUrl(this.config.relayUrl, '/__kb1_tunnel/dialback');
-    dialbackUrl.searchParams.set('streamId', envelope.streamId);
-
     const daemonWsUrl = new URL(envelope.path, this.config.daemonUrl);
     daemonWsUrl.protocol = daemonWsUrl.protocol === 'https:' ? 'wss:' : 'ws:';
-
-    const relaySocket = new WebSocket(dialbackUrl, {
-      headers: { authorization: `Bearer ${this.config.token}` },
-    });
     const daemonSocket = new WebSocket(daemonWsUrl, {
       headers: withoutHopByHop(envelope.headers),
     });
+
+    const pooled = this.dialbackPool?.acquire() ?? null;
+    const relaySocket = pooled ?? this.dialFreshRelaySocket(envelope.streamId);
+
     const bridge = new DialbackBridge({
       streamId: envelope.streamId,
       relaySocket,
@@ -952,16 +962,53 @@ export class TunnelClient {
       onRetrySafeClose: (message) => this.sendControlStreamClose(message),
     });
 
-    relaySocket.on('open', () => {
-      relaySocket.send(encodeJsonBytes({
+    if (pooled) {
+      // Already open + pool-hello'd: claim it for this stream now.
+      this.sendDialbackClaimHello(pooled, envelope.streamId);
+    } else {
+      relaySocket.on('open', () =>
+        this.sendDialbackClaimHello(relaySocket, envelope.streamId),
+      );
+    }
+
+    bridge.start();
+  }
+
+  private dialFreshRelaySocket(streamId: string): WebSocket {
+    const dialbackUrl = relayInternalUrl(this.config.relayUrl, '/__kb1_tunnel/dialback');
+    dialbackUrl.searchParams.set('streamId', streamId);
+    return new WebSocket(dialbackUrl, {
+      headers: { authorization: `Bearer ${this.config.token}` },
+    });
+  }
+
+  private openPoolRelaySocket(): WebSocket {
+    const url = relayInternalUrl(this.config.relayUrl, '/__kb1_tunnel/dialback');
+    url.searchParams.set('pool', '1');
+    return new WebSocket(url, {
+      headers: { authorization: `Bearer ${this.config.token}` },
+    });
+  }
+
+  private sendDialbackPoolHello(socket: BridgeSocket): void {
+    socket.send(
+      encodeJsonBytes({
+        type: 'ws.dialback.pool.hello',
+        version: TUNNEL_PROTOCOL_VERSION,
+        token: this.config.token,
+      }),
+    );
+  }
+
+  private sendDialbackClaimHello(socket: BridgeSocket, streamId: string): void {
+    socket.send(
+      encodeJsonBytes({
         type: 'ws.dialback.hello',
         version: TUNNEL_PROTOCOL_VERSION,
         token: this.config.token,
-        streamId: envelope.streamId,
-      }));
-    });
-
-    bridge.start();
+        streamId,
+      }),
+    );
   }
 
   private sendControlStreamClose(message: TunnelWebSocketCloseEnvelope): void {

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -151,7 +151,7 @@ export class TunnelClient {
   private relaySupportsHttpResponseChunkAcks = false;
   private readonly daemonInstanceId: string;
   private vaultMutationEpoch = 0;
-  private readonly dialbackPool: DialbackPool | undefined;
+  private dialbackPool: DialbackPool | undefined;
 
   constructor(private readonly config: TunnelClientConfig) {
     this.logger = config.logger ?? consoleLogger;
@@ -159,17 +159,20 @@ export class TunnelClient {
     this.random = config.random ?? Math.random;
     this.daemonInstanceId = config.daemonInstanceId ?? randomUUID();
 
-    const poolSize = config.dialbackPoolSize ?? 3;
-    this.dialbackPool =
-      poolSize > 0
-        ? new DialbackPool({
-            size: poolSize,
-            logger: this.logger,
-            createSocket: () => this.openPoolRelaySocket(),
-            sendPoolHello: (socket) => this.sendDialbackPoolHello(socket),
-            random: this.random,
-          })
-        : undefined;
+    this.dialbackPool = this.createDialbackPool();
+  }
+
+  private createDialbackPool(): DialbackPool | undefined {
+    const poolSize = this.config.dialbackPoolSize ?? 3;
+    return poolSize > 0
+      ? new DialbackPool({
+          size: poolSize,
+          logger: this.logger,
+          createSocket: () => this.openPoolRelaySocket(),
+          sendPoolHello: (socket) => this.sendDialbackPoolHello(socket),
+          random: this.random,
+        })
+      : undefined;
   }
 
   start(): void {
@@ -186,6 +189,12 @@ export class TunnelClient {
     }
     this.stopped = false;
     this.reconnectAttempt = 0;
+    // A prior stop() disposed the pool permanently; recreate a fresh,
+    // pristine instance for this (re)connect. Any still-in-flight sockets
+    // from the old, now-disposed pool resolve against handlers bound to
+    // that old instance and self-close via its `disposed` guard — they
+    // never get parked into the new pool's `ready` list.
+    this.dialbackPool = this.createDialbackPool();
     this.connectControl();
   }
 

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -202,6 +202,7 @@ export class TunnelClient {
     this.abortPendingRelayRpcRequests('Tunnel client stopping');
     this.control?.close(1001, 'Tunnel client stopping');
     this.control = undefined;
+    this.dialbackPool?.dispose();
   }
 
   status(): TunnelClientStatus {
@@ -1280,12 +1281,23 @@ export class DialbackPool {
    * for the whole delay and then lifted atomically.
    */
   private backoffPending = false;
+  /** Set once `dispose()` has run. Neutralizes prime()/acquire()/open() permanently. */
+  private disposed = false;
+  /**
+   * All pool-owned, not-yet-consumed sockets (warming or parked in `ready`).
+   * Tracked separately from `ready` so `dispose()` can close warming sockets
+   * too. A socket is removed from this set the moment ownership passes to
+   * the caller via `acquire()`, or the moment it's gone (closed/failed) —
+   * dispose() must never touch a socket the caller now owns.
+   */
+  private readonly sockets = new Set<PoolSocket>();
 
   constructor(private readonly options: DialbackPoolOptions) {
     this.schedule = options.schedule ?? ((fn, delayMs) => setTimeout(fn, delayMs));
   }
 
   prime(): void {
+    if (this.disposed) return;
     if (this.options.size <= 0) return;
     if (this.backoffPending) return;
     while (this.ready.length + this.warming < this.options.size) {
@@ -1294,6 +1306,7 @@ export class DialbackPool {
   }
 
   acquire(): PoolSocket | null {
+    if (this.disposed) return null;
     let socket: PoolSocket | null = null;
     while (this.ready.length > 0) {
       const candidate = this.ready.shift() as PoolSocket;
@@ -1302,16 +1315,49 @@ export class DialbackPool {
         break;
       }
       // stale/dead: drop it silently
+      this.sockets.delete(candidate);
+    }
+    if (socket) {
+      // Ownership passes to the caller: dispose() must not close it.
+      this.sockets.delete(socket);
     }
     this.prime();
     return socket;
   }
 
+  /**
+   * Permanently disables the pool: closes every pool-owned socket (warming
+   * or parked ready), clears the ready list, and neutralizes any in-flight
+   * backoff timer (its callback calls `prime()`, which is now a no-op).
+   * Sockets already handed out via `acquire()` are not touched — the caller
+   * owns their lifecycle.
+   */
+  dispose(): void {
+    this.disposed = true;
+    for (const s of this.sockets) {
+      try {
+        s.close(1001, 'pool disposed');
+      } catch {
+        /* already closed */
+      }
+    }
+    this.sockets.clear();
+    this.ready.length = 0;
+  }
+
   private open(): void {
     const socket = this.options.createSocket();
+    this.sockets.add(socket);
     this.warming += 1;
     let opened = false;
     socket.on('open', () => {
+      if (this.disposed) {
+        opened = true;
+        this.warming -= 1;
+        this.sockets.delete(socket);
+        socket.close(1001, 'pool disposed');
+        return;
+      }
       opened = true;
       this.warming -= 1;
       this.consecutiveFailures = 0;
@@ -1326,6 +1372,7 @@ export class DialbackPool {
       }
       const i = this.ready.indexOf(socket);
       if (i >= 0) this.ready.splice(i, 1);
+      this.sockets.delete(socket);
 
       if (connectFailure) {
         // Socket died without ever firing 'open' (e.g. persistently

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -1199,6 +1199,70 @@ export class DialbackBridge {
   }
 }
 
+export type PoolSocket = BridgeSocket;
+
+export type DialbackPoolOptions = {
+  size: number;
+  createSocket: () => PoolSocket;
+  sendPoolHello: (socket: PoolSocket) => void;
+  logger?: TunnelClientLogger;
+};
+
+const WS_OPEN = 1;
+
+export class DialbackPool {
+  private readonly ready: PoolSocket[] = [];
+  private warming = 0;
+
+  constructor(private readonly options: DialbackPoolOptions) {}
+
+  prime(): void {
+    if (this.options.size <= 0) return;
+    while (this.ready.length + this.warming < this.options.size) {
+      this.open();
+    }
+  }
+
+  acquire(): PoolSocket | null {
+    let socket: PoolSocket | null = null;
+    while (this.ready.length > 0) {
+      const candidate = this.ready.shift() as PoolSocket;
+      if (candidate.readyState === WS_OPEN) {
+        socket = candidate;
+        break;
+      }
+      // stale/dead: drop it silently
+    }
+    this.prime();
+    return socket;
+  }
+
+  private open(): void {
+    const socket = this.options.createSocket();
+    this.warming += 1;
+    let opened = false;
+    socket.on('open', () => {
+      opened = true;
+      this.warming -= 1;
+      this.options.sendPoolHello(socket);
+      this.ready.push(socket);
+    });
+    const onGone = () => {
+      if (!opened) {
+        opened = true;
+        this.warming -= 1;
+      }
+      const i = this.ready.indexOf(socket);
+      if (i >= 0) this.ready.splice(i, 1);
+      this.prime();
+    };
+    socket.on('close', onGone);
+    socket.on('error', () => {
+      /* a close event follows; cleanup happens there */
+    });
+  }
+}
+
 type ChunkedHttpRequestDraft = {
   start: TunnelHttpRequestStartEnvelope;
   chunks: Map<number, Buffer>;

--- a/packages/tunnel-protocol/src/index.test.ts
+++ b/packages/tunnel-protocol/src/index.test.ts
@@ -61,6 +61,16 @@ it("round-trips control hello feature advertisement", () => {
   expect(decodeTunnelMessage(encodeTunnelMessage(hello))).toEqual(hello);
 });
 
+it("round-trips dialback pool hello", () => {
+  const hello = {
+    type: "ws.dialback.pool.hello",
+    version: TUNNEL_PROTOCOL_VERSION,
+    token: "test-token"
+  } as const;
+
+  expect(decodeTunnelMessage(encodeTunnelMessage(hello))).toEqual(hello);
+});
+
 it("round-trips typed relay frames over the tunnel control socket", () => {
   const message = {
     type: "relay.frame",

--- a/packages/tunnel-protocol/src/index.ts
+++ b/packages/tunnel-protocol/src/index.ts
@@ -470,6 +470,12 @@ export type TunnelWebSocketDialbackHello = {
   streamId: string;
 };
 
+export type TunnelWebSocketDialbackPoolHello = {
+  type: "ws.dialback.pool.hello";
+  version: TunnelProtocolVersion;
+  token: string;
+};
+
 export type TunnelWebSocketCloseEnvelope = {
   type: "ws.close";
   streamId: string;
@@ -505,7 +511,9 @@ export type TunnelControlServerMessage =
   | TunnelHttpResponseChunkAckEnvelope
   | TunnelWebSocketOpenEnvelope;
 
-export type TunnelDialbackClientMessage = TunnelWebSocketDialbackHello;
+export type TunnelDialbackClientMessage =
+  | TunnelWebSocketDialbackHello
+  | TunnelWebSocketDialbackPoolHello;
 
 export type TunnelJsonMessage =
   | TunnelControlClientMessage


### PR DESCRIPTION
## Why

Opening a note in a hosted (and, by the shared-relay invariant, self-hosted) vault takes ~11–20s before the editor is editable. End-to-end tracing localized it: the daemon reads the file and emits its initial sync in ~4ms, but hosted opens use a **per-document dialback** — each open dials a brand-new outbound WebSocket to the relay, and that connect + TLS + auth handshake is the latency, paid on every first open of a document.

## What (daemon side)

A **warm pool** of pre-authenticated dialback sockets:

- `DialbackPool` keeps up to `K=3` pre-connected, pool-`hello`'d sockets. On a document open, `openDialback` **claims** a ready socket (sends the existing `ws.dialback.hello{streamId}` over it) instead of dialing fresh.
- **Fresh-dial fallback** is the correctness floor: pool empty / socket dead → today's behavior. Never worse than today (one narrow exception: a silently half-open pooled socket makes that single open stall until browser retry — see follow-ups).
- **`KB1_DIALBACK_POOL_SIZE`** env var (default `3`; **`0` = kill-switch**, pure fresh-dial). Enabled for all daemons.
- New protocol message `ws.dialback.pool.hello` (type-only addition).
- **Backoff** on repeated pool connect-failures (guarded so hot-path `acquire()`/`prime()` can't reopen during the backoff window), to bound reconnect churn under version skew.

## Companion PR (must go together)

The Cloudflare `OrgChannel` DO side (new `dialback-pool` role, `?pool=1` upgrade, `pool.hello` auth, claim/pair) is in **metatheoryinc/kb-1-cloud** — that PR bumps the submodule pointer to this branch. Merge the daemon branch first (or together). Design spec + implementation plan live in that repo under `docs/superpowers/`.

Rollout is order-safe either way: a new daemon hitting an old relay gets a 400 on `?pool=1` and falls back to fresh dial; an old daemon never exercises the new DO code.

## Testing

- `tunnel-protocol` / `tunnel-client` / daemon suites green; `tunnel-client` 66/66, 96.9% coverage. `DialbackPool` (incl. backoff + guard) fully unit-tested with an injected socket factory + scheduler; the backoff-guard tests were verified genuine (fail without the guard).

## Before enabling in prod (validation not in this PR)

- Live drills: **forced half-open pooled socket** and **version-skew** (new daemon vs. relay without `?pool=1`).
- e2e with pooling on **and** `KB1_DIALBACK_POOL_SIZE=0` (kill-switch = true no-op).
- Manual perf: `document.open.sent → editor.editable` should drop ~17s → sub-second on a cold open.

## Follow-ups (deliberately out of this minimal cut)

- Real pool keepalive/idle-reap — half-open recovery currently leans on browser retry.
- Backoff uses a single pending flag; near-simultaneous multi-socket failures use the shortest concurrent delay rather than the longest (still bounded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
