### PR TITLE
Tolerate more control heartbeat misses before reconnect (control-socket resilience)

### DIFF
--- a/packages/tunnel-client/src/heartbeat.test.ts
+++ b/packages/tunnel-client/src/heartbeat.test.ts
@@ -143,6 +143,37 @@ describe('TunnelClient control heartbeat', () => {
     expect(sentText(firstControl, 5)).toBe(encodeTunnelMessage({ type: 'control.ping' }));
     expect(Buffer.isBuffer(firstControl.sent[6])).toBe(true);
 
+    // Miss #2: with the raised tolerance the socket survives a slow DO wake.
+    await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_TIMEOUT_MS);
+    expect(firstControl.terminated).toBe(false);
+    expect(logger.log).toHaveBeenCalledWith(
+      'warn',
+      'relay control heartbeat missed; waiting for next probe',
+      {
+        consecutiveMisses: 2,
+        reconnectAfterMisses: CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT,
+      },
+    );
+
+    // Miss #3: still under the threshold.
+    await vi.advanceTimersByTimeAsync(
+      CONTROL_HEARTBEAT_INTERVAL_MS - CONTROL_HEARTBEAT_TIMEOUT_MS,
+    );
+    await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_TIMEOUT_MS);
+    expect(firstControl.terminated).toBe(false);
+    expect(logger.log).toHaveBeenCalledWith(
+      'warn',
+      'relay control heartbeat missed; waiting for next probe',
+      {
+        consecutiveMisses: 3,
+        reconnectAfterMisses: CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT,
+      },
+    );
+
+    // Miss #4 reaches the threshold and terminates the socket to reconnect.
+    await vi.advanceTimersByTimeAsync(
+      CONTROL_HEARTBEAT_INTERVAL_MS - CONTROL_HEARTBEAT_TIMEOUT_MS,
+    );
     await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_TIMEOUT_MS);
     expect(firstControl.terminated).toBe(true);
     expect(logger.log).toHaveBeenCalledWith(

--- a/packages/tunnel-client/src/heartbeat.test.ts
+++ b/packages/tunnel-client/src/heartbeat.test.ts
@@ -144,6 +144,9 @@ describe('TunnelClient control heartbeat', () => {
     expect(Buffer.isBuffer(firstControl.sent[6])).toBe(true);
 
     // Miss #2: with the raised tolerance the socket survives a slow DO wake.
+    // Clear first so the assertion below matches ONLY this phase's miss log,
+    // making the miss #2 -> #3 ordering exclusive rather than any-call.
+    logger.log.mockClear();
     await vi.advanceTimersByTimeAsync(CONTROL_HEARTBEAT_TIMEOUT_MS);
     expect(firstControl.terminated).toBe(false);
     expect(logger.log).toHaveBeenCalledWith(
@@ -155,7 +158,9 @@ describe('TunnelClient control heartbeat', () => {
       },
     );
 
-    // Miss #3: still under the threshold.
+    // Miss #3: still under the threshold. Clear again so this assertion is
+    // exclusive to the miss #3 log (guaranteeing it followed miss #2).
+    logger.log.mockClear();
     await vi.advanceTimersByTimeAsync(
       CONTROL_HEARTBEAT_INTERVAL_MS - CONTROL_HEARTBEAT_TIMEOUT_MS,
     );
@@ -171,6 +176,8 @@ describe('TunnelClient control heartbeat', () => {
     );
 
     // Miss #4 reaches the threshold and terminates the socket to reconnect.
+    // Clear so the terminate assertion is exclusive to this final phase.
+    logger.log.mockClear();
     await vi.advanceTimersByTimeAsync(
       CONTROL_HEARTBEAT_INTERVAL_MS - CONTROL_HEARTBEAT_TIMEOUT_MS,
     );

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -96,7 +96,10 @@ const MCP_READ_ONLY_TOOLS = new Set([
 ]);
 export const CONTROL_HEARTBEAT_INTERVAL_MS = 15_000;
 export const CONTROL_HEARTBEAT_TIMEOUT_MS = 12_000;
-export const CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT = 2;
+// Raised 2->4: a slow post-hibernation DO wake can delay the control pong past
+// the deadline for a probe or two; tolerate more misses before dropping the
+// control socket, since a reconnect strands any in-flight multiplexed doc open.
+export const CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT = 4;
 export const CONTROL_DURABLE_LIVENESS_INTERVAL_MS = 30_000;
 
 const hopByHopHeaders = new Set([


### PR DESCRIPTION
Part of the control-socket resilience fix (pairs with the cloud PR). **Merge this first**, then the cloud PR bumps the submodule pointer.

## Why
After the multiplex deploy, prod document opens regressed to 30–72s (`4003 PENDING_STREAM_TIMEOUT`). Root cause: multiplex routes all document data over the single daemon↔DO control socket, and in prod that socket churns — the DO is woken from hibernation on nearly every heartbeat, its control pong is intermittently delayed past the daemon's 12s deadline, and the daemon drops+reconnects the control socket, stranding any in-flight document open.

## Change
Raise `CONTROL_HEARTBEAT_MISSES_BEFORE_RECONNECT` 2 → 4 so a couple of slow control pongs (from a momentarily-busy, hibernation-waking DO) no longer terminate the control socket. The daemon still reconnects when the socket is genuinely dead — it just tolerates ~2 more probes (~54s worst case vs ~27s). Heartbeat test extended to walk misses #2/#3 (survive) and #4 (terminate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
