### PR TITLE
test(doc-session): raise timeout for oversized-document baseline test

### DIFF
--- a/packages/doc-session/src/session.test.ts
+++ b/packages/doc-session/src/session.test.ts
@@ -343,7 +343,10 @@ describe('OneFileDocumentSession', () => {
     if (typeof staleContent !== 'string') throw new Error('expected current_content');
     expect(new TextEncoder().encode(staleContent).length).toBeLessThanOrEqual(1024 * 1024);
     await session.close();
-  });
+    // Builds a 1MB+ resident document and runs fast-diff + Yjs delta over it —
+    // CPU-bound enough to exceed vitest's 5s default under v8 coverage on slower
+    // CI runners (observed ~7.3s), while ~1s locally. Give it explicit headroom.
+  }, 20_000);
 
   it('applies a baseline edit through the session Y.Text so concurrent Yjs updates survive', async () => {
     const session = new OneFileDocumentSession(filePath, { defaultContent: 'alpha\nomega\n' });


### PR DESCRIPTION
## Problem

`session.test.ts > OneFileDocumentSession > truncates stale baseline echoes for oversized resident documents` intermittently times out in CI:

```
Error: Test timed out in 5000ms.
 × truncates stale baseline echoes for oversized resident documents 7336ms
```

The test builds a **1 MB+** resident document (`'x'.repeat(1024*1024+32)`) and runs fast-diff + Yjs delta + truncation over it — CPU-bound. It passes comfortably locally (~1 s even under coverage) but crosses vitest's **5 s default** timeout on slower GitHub Actions runners with v8 coverage instrumentation enabled (`vitest run --coverage`), where it was observed at ~7.3 s. Classic edge-of-timeout flake — passes on fast hardware, fails on slow CI.

## Fix

Give just this one legitimately-heavy test explicit **20 s** headroom (the 1 MB size is the point of the test, so it can't shrink; other tests are unaffected). One-line change plus an explanatory comment.

No production code changed; behavior identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)