### PR TITLE
fix(editor): render escaped link brackets

### DIFF
--- a/packages/editor/src/lib/plaintext-decorations.test.ts
+++ b/packages/editor/src/lib/plaintext-decorations.test.ts
@@ -699,6 +699,90 @@ describe('wikilinks (Slice 5) — parse + decoration', () => {
   });
 });
 
+describe('escaped brackets in Markdown link labels', () => {
+  function hiddenEscapeRanges(
+    set: ReturnType<typeof buildMarkdownDecorations>,
+    doc: string,
+  ): { from: number; to: number }[] {
+    const hits: { from: number; to: number }[] = [];
+    set.between(0, doc.length, (from, to, value) => {
+      const spec = value.spec as { class?: string };
+      if (spec.class?.includes('cm-hidden') && doc.slice(from, to) === '\\') {
+        hits.push({ from, to });
+      }
+    });
+    return hits;
+  }
+
+  it('hides escape slashes when a bracketed link label is rendered', () => {
+    const doc = '[Q2 notes \\[Ongoing\\]](https://example.com)\nelsewhere';
+    const state = makeState(doc);
+    const cursor = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(state, { from: cursor, to: cursor });
+
+    const escapes = hiddenEscapeRanges(set, doc);
+    expect(escapes).toHaveLength(2);
+    expect(escapes.map(({ from }) => from)).toEqual([
+      doc.indexOf('\\['),
+      doc.indexOf('\\]'),
+    ]);
+  });
+
+  it('finds escaped brackets nested inside formatted label content', () => {
+    const doc = '[**Q2 \\[Ongoing\\]**](https://example.com)\nelsewhere';
+    const state = makeState(doc);
+    const cursor = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(state, { from: cursor, to: cursor });
+
+    expect(hiddenEscapeRanges(set, doc)).toHaveLength(2);
+  });
+
+  it('reveals the escape slashes on the active link line', () => {
+    const doc = '[Q2 notes \\[Ongoing\\]](https://example.com)\nelsewhere';
+    const state = makeState(doc);
+    const cursor = doc.indexOf('Q2');
+    const set = buildMarkdownDecorations(state, { from: cursor, to: cursor });
+
+    expect(hiddenEscapeRanges(set, doc)).toHaveLength(0);
+  });
+
+  it('reveals escapes on an active continuation line of a multiline label', () => {
+    const doc = '[first line\nsecond \\[Ongoing\\]](https://example.com)\nelsewhere';
+    const state = makeState(doc);
+    const cursor = doc.indexOf('Ongoing');
+    const set = buildMarkdownDecorations(state, { from: cursor, to: cursor });
+
+    expect(hiddenEscapeRanges(set, doc)).toHaveLength(0);
+  });
+
+  it('reveals escapes included in a multiline range selection', () => {
+    const doc = '[Q2 notes \\[Ongoing\\]](https://example.com)\nselected tail';
+    const state = makeState(doc);
+    const set = buildMarkdownDecorations(state, {
+      from: doc.indexOf('Ongoing'),
+      to: doc.indexOf('tail') + 'tail'.length,
+    });
+
+    expect(hiddenEscapeRanges(set, doc)).toHaveLength(0);
+  });
+
+  it('does not hide escapes in link-shaped inline or fenced code', () => {
+    const doc = [
+      '`[inline \\[example\\]](https://example.com)`',
+      '',
+      '```md',
+      '[fenced \\[example\\]](https://example.com)',
+      '```',
+      'elsewhere',
+    ].join('\n');
+    const state = makeState(doc);
+    const cursor = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(state, { from: cursor, to: cursor });
+
+    expect(hiddenEscapeRanges(set, doc)).toHaveLength(0);
+  });
+});
+
 describe('autolinks (GFM) — parse + decoration', () => {
   /**
    * Same shape as the wikilink `findMarksByClass` helper. Kept local

--- a/packages/editor/src/lib/plaintext-decorations.ts
+++ b/packages/editor/src/lib/plaintext-decorations.ts
@@ -2305,6 +2305,50 @@ export function buildMarkdownDecorations(
         return false;
       }
 
+      // -- Escapes inside link labels -------------------------------
+      // CommonMark requires nested `[` / `]` characters in link labels
+      // to be escaped. Keep those escapes in the source so the parser
+      // retains the outer Link node, but hide only the slash while the
+      // link is rendered. The normal line-based Link reveal still shows
+      // the original Markdown when the user edits that line.
+      if (name === 'Escape') {
+        const escaped = state.sliceDoc(node.from, node.to);
+        if (escaped === '\\[' || escaped === '\\]') {
+          let link: SyntaxNode | null = node.node.parent;
+          while (link !== null && link.type.name !== 'Link') link = link.parent;
+
+          if (link !== null) {
+            let closeBracket: number | null = null;
+            let child: SyntaxNode | null = link.firstChild;
+            while (child !== null) {
+              if (
+                child.type.name === 'LinkMark' &&
+                state.sliceDoc(child.from, child.to) === ']'
+              ) {
+                closeBracket = child.from;
+                break;
+              }
+              child = child.nextSibling;
+            }
+
+            const escapeLine = state.doc.lineAt(node.from);
+            if (
+              closeBracket !== null &&
+              node.to <= closeBracket &&
+              !intersects(escapeLine.from, escapeLine.to)
+            ) {
+              items.push({
+                kind: 'mark',
+                from: node.from,
+                to: node.from + 1,
+                deco: hiddenSyntaxMark,
+              });
+            }
+          }
+        }
+        return false;
+      }
+
       // -- Link (inline) --------------------------------------------
       // `[label](url)` — emit a `.cm-md-link-label` mark over the
       // label range so CSS can paint a subtle tint. The bracket /


### PR DESCRIPTION
## What changed

- hide CommonMark escape slashes for square brackets inside rendered link labels
- reveal the original escapes on the active editing line or selection
- cover formatted and multiline labels while leaving code and non-label escapes unchanged

## Why

Google Docs smart-chip labels can contain bracketed status text such as Q2 notes [Ongoing]. Valid Markdown must escape those inner brackets so the outer link continues to parse. The shared editor previously displayed the escape slashes.

This renderer change keeps the stored Markdown valid and lossless while displaying the original label in both local and Cloud clients.

## Validation

- focused editor decoration suite: 108 tests passed
- pnpm check
- autoreview clean
