### PR TITLE
feat: dispatch linked Cloud repins

### DIFF
--- a/.github/workflows/dispatch-linked-cloud-repin.yml
+++ b/.github/workflows/dispatch-linked-cloud-repin.yml
@@ -1,0 +1,84 @@
+name: Dispatch linked Cloud repin
+
+on:
+  pull_request:
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      daemon_pr_number:
+        description: Already-merged internal daemon PR to replay
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: dispatch-linked-cloud-repin-${{ github.event.pull_request.number || inputs.daemon_pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Notify linked Cloud PRs
+    if: >-
+      ${{
+        (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+        (
+          github.event.pull_request.merged == true &&
+          github.event.pull_request.base.ref == 'main' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        )
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout trusted dispatcher
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+
+      - name: Resolve and verify the merged daemon PR
+        id: resolve
+        run: node scripts/linked-cloud-repin-dispatch.mjs resolve
+        env:
+          DAEMON_GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check repin App configuration
+        id: config
+        env:
+          APP_CLIENT_ID: ${{ vars.KB1_REPIN_APP_CLIENT_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.KB1_REPIN_APP_PRIVATE_KEY }}
+        run: |
+          if [[ -n "$APP_CLIENT_ID" && -n "$APP_PRIVATE_KEY" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Linked Cloud repin is dormant until KB1_REPIN_APP_CLIENT_ID and KB1_REPIN_APP_PRIVATE_KEY are configured."
+          fi
+
+      - name: Create scoped KB-1 repin token
+        if: ${{ steps.config.outputs.enabled == 'true' }}
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.KB1_REPIN_APP_CLIENT_ID }}
+          private-key: ${{ secrets.KB1_REPIN_APP_PRIVATE_KEY }}
+          owner: metatheoryinc
+          repositories: kb-1-cloud
+          permission-contents: write
+
+      - name: Dispatch exact merge coordinates to Cloud
+        if: ${{ steps.config.outputs.enabled == 'true' }}
+        run: node scripts/linked-cloud-repin-dispatch.mjs dispatch
+        env:
+          CLOUD_GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          DISPATCH_PAYLOAD: ${{ steps.resolve.outputs.payload }}

--- a/scripts/linked-cloud-repin-dispatch.mjs
+++ b/scripts/linked-cloud-repin-dispatch.mjs
@@ -1,0 +1,159 @@
+import { appendFileSync, readFileSync } from 'node:fs';
+
+export const CLOUD_REPOSITORY = 'metatheoryinc/kb-1-cloud';
+export const DAEMON_REPOSITORY = 'metatheoryinc/kb-1-daemon';
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+function requireValue(value, name) {
+  if (value === undefined || value === null || value === '') {
+    throw new Error(`${name} is required`);
+  }
+  return String(value);
+}
+
+function requireSha(value, name) {
+  const sha = requireValue(value, name).toLowerCase();
+  if (!SHA_PATTERN.test(sha)) {
+    throw new Error(`${name} must be a full lowercase 40-character SHA`);
+  }
+  return sha;
+}
+
+function requirePositiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+export function buildDispatchPayload(pull) {
+  if (!pull || typeof pull !== 'object') {
+    throw new Error('pull request payload must be an object');
+  }
+  if (pull.state !== 'closed' || !pull.merged_at) {
+    throw new Error('daemon pull request must be merged');
+  }
+  if (pull.base?.ref !== 'main') {
+    throw new Error(`daemon pull request must target main, received: ${pull.base?.ref}`);
+  }
+  if (pull.base?.repo?.full_name !== DAEMON_REPOSITORY) {
+    throw new Error(`unexpected daemon base repository: ${pull.base?.repo?.full_name}`);
+  }
+  if (pull.head?.repo?.full_name !== DAEMON_REPOSITORY) {
+    throw new Error('linked daemon pull request must use an internal branch');
+  }
+
+  return {
+    event_type: 'daemon-pr-merged',
+    client_payload: {
+      source_repository: DAEMON_REPOSITORY,
+      daemon_pr_number: requirePositiveInteger(pull.number, 'pull.number'),
+      daemon_head_sha: requireSha(pull.head?.sha, 'pull.head.sha'),
+      daemon_merge_sha: requireSha(pull.merge_commit_sha, 'pull.merge_commit_sha'),
+      daemon_base_ref: 'main',
+    },
+  };
+}
+
+async function githubRequest(path, { token, method = 'GET', body } = {}) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${requireValue(token, 'GitHub token')}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'kb1-linked-cloud-repin-dispatch',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`GitHub API ${method} ${path} failed (${response.status}): ${detail}`);
+  }
+
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+function writeOutput(name, value) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  const line = `${name}=${value}\n`;
+  if (outputPath) {
+    appendFileSync(outputPath, line);
+  } else {
+    process.stdout.write(line);
+  }
+}
+
+async function resolve() {
+  if (process.env.GITHUB_REPOSITORY !== DAEMON_REPOSITORY) {
+    throw new Error(`workflow must run in ${DAEMON_REPOSITORY}`);
+  }
+
+  const eventPath = requireValue(process.env.GITHUB_EVENT_PATH, 'GITHUB_EVENT_PATH');
+  const event = JSON.parse(readFileSync(eventPath, 'utf8'));
+  let pull;
+
+  if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
+    if (event.action !== 'closed') {
+      throw new Error(`unexpected pull_request action: ${event.action}`);
+    }
+    pull = event.pull_request;
+  } else if (process.env.GITHUB_EVENT_NAME === 'workflow_dispatch') {
+    const pullNumber = requirePositiveInteger(
+      event.inputs?.daemon_pr_number,
+      'inputs.daemon_pr_number',
+    );
+    pull = await githubRequest(`/repos/${DAEMON_REPOSITORY}/pulls/${pullNumber}`, {
+      token: process.env.DAEMON_GITHUB_TOKEN,
+    });
+  } else {
+    throw new Error(`unsupported event: ${process.env.GITHUB_EVENT_NAME}`);
+  }
+
+  const payload = buildDispatchPayload(pull);
+  writeOutput('payload', JSON.stringify(payload));
+  writeOutput('daemon_pr_number', String(payload.client_payload.daemon_pr_number));
+}
+
+async function dispatch() {
+  const payload = JSON.parse(requireValue(process.env.DISPATCH_PAYLOAD, 'DISPATCH_PAYLOAD'));
+  buildDispatchPayload({
+    number: payload.client_payload?.daemon_pr_number,
+    state: 'closed',
+    merged_at: 'validated-by-resolve',
+    merge_commit_sha: payload.client_payload?.daemon_merge_sha,
+    base: {
+      ref: payload.client_payload?.daemon_base_ref,
+      repo: { full_name: payload.client_payload?.source_repository },
+    },
+    head: {
+      sha: payload.client_payload?.daemon_head_sha,
+      repo: { full_name: payload.client_payload?.source_repository },
+    },
+  });
+  if (payload.event_type !== 'daemon-pr-merged') {
+    throw new Error(`unexpected event type: ${payload.event_type}`);
+  }
+
+  await githubRequest(`/repos/${CLOUD_REPOSITORY}/dispatches`, {
+    token: process.env.CLOUD_GITHUB_TOKEN,
+    method: 'POST',
+    body: payload,
+  });
+}
+
+const commands = { resolve, dispatch };
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const command = process.argv[2];
+  if (!commands[command]) {
+    throw new Error(
+      `usage: node scripts/linked-cloud-repin-dispatch.mjs ${Object.keys(commands).join('|')}`,
+    );
+  }
+  await commands[command]();
+}

--- a/scripts/linked-cloud-repin-dispatch.test.mjs
+++ b/scripts/linked-cloud-repin-dispatch.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildDispatchPayload } from './linked-cloud-repin-dispatch.mjs';
+
+const HEAD_SHA = '1'.repeat(40);
+const MERGE_SHA = '2'.repeat(40);
+
+function mergedPull(overrides = {}) {
+  return {
+    number: 111,
+    state: 'closed',
+    merged_at: '2026-08-18T20:56:38Z',
+    merge_commit_sha: MERGE_SHA,
+    base: {
+      ref: 'main',
+      repo: { full_name: 'metatheoryinc/kb-1-daemon' },
+    },
+    head: {
+      sha: HEAD_SHA,
+      repo: { full_name: 'metatheoryinc/kb-1-daemon' },
+    },
+    ...overrides,
+  };
+}
+
+test('builds an exact Cloud repository dispatch payload', () => {
+  assert.deepEqual(buildDispatchPayload(mergedPull()), {
+    event_type: 'daemon-pr-merged',
+    client_payload: {
+      source_repository: 'metatheoryinc/kb-1-daemon',
+      daemon_pr_number: 111,
+      daemon_head_sha: HEAD_SHA,
+      daemon_merge_sha: MERGE_SHA,
+      daemon_base_ref: 'main',
+    },
+  });
+});
+
+test('rejects a closed but unmerged daemon pull request', () => {
+  assert.throws(() => buildDispatchPayload(mergedPull({ merged_at: null })), /must be merged/);
+});
+
+test('rejects a daemon pull request that targets another branch', () => {
+  assert.throws(
+    () =>
+      buildDispatchPayload(
+        mergedPull({
+          base: {
+            ref: 'release',
+            repo: { full_name: 'metatheoryinc/kb-1-daemon' },
+          },
+        }),
+      ),
+    /must target main/,
+  );
+});
+
+test('rejects a fork daemon pull request', () => {
+  assert.throws(
+    () =>
+      buildDispatchPayload(
+        mergedPull({
+          head: { sha: HEAD_SHA, repo: { full_name: 'someone/fork' } },
+        }),
+      ),
+    /must use an internal branch/,
+  );
+});


### PR DESCRIPTION
## What changed

- dispatch exact merged daemon PR coordinates to `kb-1-cloud`
- support automatic dispatch for merged internal PRs targeting `main`
- support manual replay for an already-merged daemon PR
- validate repository, branch, merged state, and full head/merge SHAs before dispatch
- remain safely dormant when the scoped repin App is not configured

## Dependency and merge order

Merge the Cloud receiver first: https://github.com/metatheoryinc/kb-1-cloud/pull/251

After #251 is merged and the GitHub App variable/secret are configured, this dispatcher can be merged. It does not deploy or merge any Cloud PR.

## Verification

- `node --test scripts/linked-cloud-repin-dispatch.test.mjs` — 4 passing
- `CI=1 pnpm check`
- final autoreview: clean
