### PR TITLE
ci: accelerate daemon validation and publish verified release images

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,16 +9,20 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: check-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
 
@@ -32,3 +36,118 @@ jobs:
 
       - name: Run checks
         run: pnpm check
+
+  publish-container:
+    name: Smoke and publish daemon image
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    needs: check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+
+      - name: Enable package manager
+        run: |
+          corepack enable
+          corepack install
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Authenticate to the GitHub container registry
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+
+      - name: Prepare BuildKit
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build exact daemon image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: apps/daemon/Dockerfile
+          platforms: linux/amd64
+          provenance: false
+          tags: kb1-daemon-release:${{ github.sha }}
+          load: true
+          cache-from: type=gha,scope=kb1-daemon-release
+          cache-to: type=gha,mode=max,scope=kb1-daemon-release
+
+      - name: Smoke the exact packaged image
+        env:
+          IMAGE_REF: kb1-daemon-release:${{ github.sha }}
+          KB1_RELEASE_SMOKE_SKIP_BUILD: "1"
+        run: |
+          export KB1_RELEASE_SMOKE_IMAGE="$IMAGE_REF"
+          pnpm smoke:release
+
+      - name: Publish verified run image
+        id: published-image
+        env:
+          LOCAL_IMAGE_REF: kb1-daemon-release:${{ github.sha }}
+          RUN_IMAGE_REF: ghcr.io/${{ github.repository }}:run-${{ github.run_id }}-${{ github.run_attempt }}-sha-${{ github.sha }}
+        run: |
+          docker tag "$LOCAL_IMAGE_REF" "$RUN_IMAGE_REF"
+          docker push "$RUN_IMAGE_REF"
+          image_manifest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' "$RUN_IMAGE_REF")"
+          image_digest="$(jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$image_manifest")"
+          echo "digest=$image_digest" >> "$GITHUB_OUTPUT"
+
+      - name: Protect immutable SHA alias and record receipt
+        env:
+          PUBLISHED_DIGEST: ${{ steps.published-image.outputs.digest }}
+          IMAGE_REF: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
+          RUN_IMAGE_REF: ghcr.io/${{ github.repository }}:run-${{ github.run_id }}-${{ github.run_attempt }}-sha-${{ github.sha }}
+        run: |
+          image_digest="$(jq -Rer 'select(test("^sha256:[0-9a-f]{64}$"))' <<<"$PUBLISHED_DIGEST")"
+          inspect_error="$(mktemp)"
+          if image_manifest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' "$IMAGE_REF" 2>"$inspect_error")"; then
+            existing_digest="$(jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$image_manifest")"
+            if [[ "$existing_digest" != "$image_digest" ]]; then
+              echo "Existing SHA alias digest $existing_digest does not match verified source build $image_digest." >&2
+              exit 1
+            fi
+          elif grep -Eiq 'manifest unknown|no such manifest|not found|(^|[^0-9])404([^0-9]|$)' "$inspect_error"; then
+            docker buildx imagetools create \
+              --prefer-index=false \
+              --tag "$IMAGE_REF" \
+              "$RUN_IMAGE_REF@$image_digest"
+            alias_manifest="$(docker buildx imagetools inspect --format '{{json .Manifest}}' "$IMAGE_REF")"
+            alias_digest="$(jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$alias_manifest")"
+            if [[ "$alias_digest" != "$image_digest" ]]; then
+              echo "Created SHA alias digest $alias_digest does not match verified source build $image_digest." >&2
+              exit 1
+            fi
+          else
+            cat "$inspect_error" >&2
+            exit 1
+          fi
+          jq -n \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg sourceSha "$GITHUB_SHA" \
+            --arg imageRef "$RUN_IMAGE_REF" \
+            --arg sourceAlias "$IMAGE_REF" \
+            --arg imageDigest "$image_digest" \
+            '{schemaVersion: 1, repository: $repository, sourceSha: $sourceSha, imageRef: $imageRef, sourceAlias: $sourceAlias, imageDigest: $imageDigest, platform: "linux/amd64", releaseSmoke: true}' \
+            > kb1-daemon-image.json
+
+      - name: Upload immutable image receipt
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: kb1-daemon-image-${{ github.sha }}
+          path: kb1-daemon-image.json
+          if-no-files-found: error
+          retention-days: 90

--- a/apps/daemon/Dockerfile
+++ b/apps/daemon/Dockerfile
@@ -32,6 +32,8 @@ FROM node:22-slim AS runtime
 
 WORKDIR /app
 
+LABEL org.opencontainers.image.source="https://github.com/metatheoryinc/kb-1-daemon"
+
 ENV NODE_ENV=production
 ENV KB1_HOME=/data/kb1
 ENV KB1_HOST=0.0.0.0

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -37,7 +37,20 @@ there is no signed native Windows installer or SCM service release.
    container, volume, and default per-run image tag are removed even when a
    check fails. Set
    `KB1_RELEASE_SMOKE_IMAGE` to override the image tag or
-   `KB1_RELEASE_SMOKE_PORT` when a fixed host port is needed.
+   `KB1_RELEASE_SMOKE_PORT` when a fixed host port is needed. CI sets
+   `KB1_RELEASE_SMOKE_SKIP_BUILD=1` only after BuildKit has loaded the exact
+   checkout image locally. CI tags and pushes that same local image only after
+   the smoke succeeds.
+
+   A successful push to `main` publishes a unique run tag after the release
+   smoke, then creates `sha-<full-git-sha>` only when the alias is absent or
+   already resolves to that verified digest. A mismatched existing alias fails
+   closed. The retained receipt contains the unique run ref, source alias,
+   source SHA, platform, and registry digest. There is intentionally no mutable
+   `latest` release tag. KB-1 Cloud may copy the exact SHA-alias digest into its
+   Fly staging registry instead of rebuilding the same daemon source. The GHCR
+   package must grant the Cloud repository Actions read access; until then
+   Cloud falls back to its cached source build for the same submodule SHA.
 
    The regular GitHub Actions check must also pass its Windows jobs. Those jobs
    verify source startup, note create/read/soft-delete, restart persistence,

--- a/nx.json
+++ b/nx.json
@@ -2,7 +2,14 @@
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "defaultBase": "main",
   "namedInputs": {
-    "default": ["{projectRoot}/**/*"],
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "sharedGlobals": [
+      "{workspaceRoot}/package.json",
+      "{workspaceRoot}/pnpm-lock.yaml",
+      "{workspaceRoot}/pnpm-workspace.yaml",
+      "{workspaceRoot}/nx.json",
+      "{workspaceRoot}/tsconfig.base.json"
+    ],
     "production": ["default", "!{projectRoot}/**/*.test.ts"]
   },
   "targetDefaults": {

--- a/packages/tunnel-client/tsconfig.build.json
+++ b/packages/tunnel-client/tsconfig.build.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": false,
+    "tsBuildInfoFile": "dist/tsconfig.build.tsbuildinfo",
     "types": ["node"],
     "paths": {
       "@kb-1/tunnel-protocol": ["../tunnel-protocol/dist/index.d.ts"]

--- a/packages/tunnel-protocol/tsconfig.build.json
+++ b/packages/tunnel-protocol/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "dist/tsconfig.build.tsbuildinfo",
     "types": []
   },
   "exclude": ["src/**/*.test.ts"]

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -7,12 +7,29 @@ const env = {
   ...(skipNxCache ? { NX_SKIP_NX_CACHE: 'true' } : {})
 };
 
-for (const script of ['typecheck', 'test', 'build', 'licenses:check']) {
-  const code = await run([script], env);
-  if (code !== 0) {
-    process.exitCode = code;
-    break;
+// Nx owns dependency ordering for the non-web workspace. Web targets stay
+// serial because SvelteKit's sync, test, and build paths share `.svelte-kit`.
+// Repository-level checks remain independent of that workspace lane.
+const results = await Promise.all([
+  runWorkspaceChecks(),
+  run(['test:scripts'], env),
+  run(['licenses:check'], env)
+]);
+const failure = results.find((code) => code !== 0);
+if (failure !== undefined) process.exitCode = failure;
+
+async function runWorkspaceChecks() {
+  const nonWebCode = await run(
+    ['exec', 'nx', 'run-many', '-t', 'typecheck', 'test', 'build', '--parallel=3', '--exclude=web'],
+    env
+  );
+  if (nonWebCode !== 0) return nonWebCode;
+
+  for (const target of ['typecheck', 'test', 'build']) {
+    const webCode = await run(['exec', 'nx', 'run', `web:${target}`], env);
+    if (webCode !== 0) return webCode;
   }
+  return 0;
 }
 
 function run(args, env) {

--- a/scripts/process-runner.test.mjs
+++ b/scripts/process-runner.test.mjs
@@ -26,6 +26,26 @@ test('spawnPnpm uses one validated shell command on Windows', () => {
   ]]);
 });
 
+test('spawnPnpm accepts the full Nx check arguments on Windows', () => {
+  const calls = [];
+  spawnPnpm(
+    ['exec', 'nx', 'run-many', '-t', 'typecheck', 'test', 'build', '--parallel=3', '--exclude=web'],
+    { stdio: 'inherit' },
+    {
+      platform: 'win32',
+      spawnImpl(...args) {
+        calls.push(args);
+        return {};
+      }
+    }
+  );
+
+  assert.deepEqual(calls, [[
+    'pnpm exec nx run-many -t typecheck test build --parallel=3 --exclude=web',
+    { shell: true, stdio: 'inherit' }
+  ]]);
+});
+
 test('spawnPnpm rejects shell metacharacters on Windows', () => {
   let spawned = false;
   assert.throws(

--- a/scripts/release-smoke.mjs
+++ b/scripts/release-smoke.mjs
@@ -10,6 +10,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 const repoRoot = resolve(import.meta.dirname, '..');
 const nonce = `${Date.now()}-${process.pid}`;
 const imageOverride = process.env.KB1_RELEASE_SMOKE_IMAGE;
+const skipImageBuild = process.env.KB1_RELEASE_SMOKE_SKIP_BUILD === '1';
 const image = imageOverride || `kb-1-daemon:release-smoke-${nonce}`;
 const container = `kb1-release-smoke-${nonce}`;
 const volume = `kb1-release-smoke-${nonce}`;
@@ -20,7 +21,14 @@ let containerCreated = false;
 let volumeCreated = false;
 
 try {
-  await run('docker', ['build', '-f', 'apps/daemon/Dockerfile', '-t', image, '.']);
+  if (skipImageBuild) {
+    if (!imageOverride) {
+      throw new Error('KB1_RELEASE_SMOKE_SKIP_BUILD=1 requires KB1_RELEASE_SMOKE_IMAGE.');
+    }
+    await run('docker', ['image', 'inspect', image], process.env, false);
+  } else {
+    await run('docker', ['build', '-f', 'apps/daemon/Dockerfile', '-t', image, '.']);
+  }
   await run('docker', ['volume', 'create', volume]);
   volumeCreated = true;
   await run('docker', [


### PR DESCRIPTION
## Summary
- parallelize daemon validation while serializing SvelteKit-owned web targets
- smoke the exact checkout-built container before publishing a digest-bound run image
- add fail-closed SHA alias and receipt handling plus BuildKit caching

## Verification
- NX_SKIP_NX_CACHE=true pnpm check
- pnpm smoke:release (cold Colima run, 5m18s)
- final autoreview: clean

## Related
- Cloud release orchestration: https://github.com/metatheoryinc/kb-1-cloud/pull/261