### PR TITLE
fix(editor): keep URL-shaped link labels visible

### DIFF
--- a/packages/editor/src/lib/plaintext-decorations.test.ts
+++ b/packages/editor/src/lib/plaintext-decorations.test.ts
@@ -697,6 +697,33 @@ describe('wikilinks (Slice 5) — parse + decoration', () => {
     expect(labelsOff.length).toBe(1);
     expect(doc.slice(labelsOff[0].from, labelsOff[0].to)).toBe('Anthropic');
   });
+
+  it('does not collapse the visible label of an off-line URL link', () => {
+    const doc =
+      '[https://x.com/GidoGidoGame](https://x.com/GidoGidoGame)\n\nelsewhere\n';
+    const state = makeState(doc);
+    const cursor = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(state, { from: cursor, to: cursor });
+    const labels = findMarksByClass(set, 'cm-md-link-label', doc.length);
+    const hiddenSyntax = findMarksByClass(
+      set,
+      'cm-md-syntax cm-hidden',
+      doc.length,
+    );
+
+    expect(labels).toHaveLength(1);
+    const label = labels[0];
+    expect(doc.slice(label.from, label.to)).toBe('https://x.com/GidoGidoGame');
+    expect(
+      hiddenSyntax.filter(({ from, to }) => from < label.to && to > label.from),
+    ).toEqual([]);
+    expect(
+      hiddenSyntax.some(
+        ({ from, to }) =>
+          from > label.to && doc.slice(from, to) === 'https://x.com/GidoGidoGame',
+      ),
+    ).toBe(true);
+  });
 });
 
 describe('escaped brackets in Markdown link labels', () => {

--- a/packages/editor/src/lib/plaintext-decorations.ts
+++ b/packages/editor/src/lib/plaintext-decorations.ts
@@ -380,6 +380,33 @@ const footnoteDefLabelMark = Decoration.mark({
 const hiddenSyntaxMark = Decoration.mark({ class: 'cm-md-syntax cm-hidden' });
 const visibleSyntaxMark = Decoration.mark({ class: 'cm-md-syntax' });
 
+/**
+ * Lezer may emit a `URL` child for URL-shaped text inside a link label as
+ * well as for the actual parenthesized destination. Only the destination is
+ * Markdown syntax that should collapse in live preview.
+ */
+function isLinkDestinationUrl(node: SyntaxNode, state: EditorState): boolean {
+  const parent = node.parent;
+  if (
+    parent === null ||
+    (parent.type.name !== 'Link' && parent.type.name !== 'Image')
+  ) {
+    return false;
+  }
+
+  let child: SyntaxNode | null = parent.firstChild;
+  while (child !== null) {
+    if (
+      child.type.name === 'LinkMark' &&
+      state.sliceDoc(child.from, child.to) === ']'
+    ) {
+      return node.from > child.from;
+    }
+    child = child.nextSibling;
+  }
+  return false;
+}
+
 /* ---------------------------------------------------------------- *
  * Inner-language registry for fenced code blocks.                   *
  *                                                                   *
@@ -3201,9 +3228,7 @@ export function buildMarkdownDecorations(
         (name === 'LinkMark' &&
           node.node.parent !== null &&
           (node.node.parent.type.name === 'Link' || node.node.parent.type.name === 'Image')) ||
-        (name === 'URL' &&
-          node.node.parent !== null &&
-          (node.node.parent.type.name === 'Link' || node.node.parent.type.name === 'Image'));
+        (name === 'URL' && isLinkDestinationUrl(node.node, state));
       if (isSyntaxMark) {
         const parent = node.node.parent;
         if (parent === null) return;


### PR DESCRIPTION
## Summary

- distinguish URL-shaped link labels from their parenthesized destinations
- collapse only destination URL syntax in live preview
- add a regression test matching the affected Gido accounts link shape

## Root cause

Lezer emits a `URL` node for URL-shaped label text as well as for the actual destination. The live-preview decoration pass treated both as syntax, nesting the visible label under `cm-hidden` and reducing it to zero size and opacity.

## Verification

- `pnpm --filter @kb-1/editor test` (178 tests passed)
- `pnpm check`
- local Storybook browser probe confirmed the label renders at 16px / full opacity while the destination remains collapsed
- autoreview clean (no actionable findings)