### PR TITLE
fix(editor): use destinations for URL-shaped link labels

### DIFF
--- a/packages/editor/src/lib/plaintext-decorations.test.ts
+++ b/packages/editor/src/lib/plaintext-decorations.test.ts
@@ -1813,6 +1813,30 @@ describe('mentions (Apple lane Slice 1, widget-mount edition) — chip decoratio
     expect(linkLabelCount).toBe(0);
   });
 
+  it('renders a mention whose label is URL-shaped', () => {
+    const doc =
+      '[https://profile.example](mention:alice@kb-1.dev)\nelsewhere\n';
+    const state = makeState(doc);
+    const offLine = doc.indexOf('elsewhere');
+    const set = buildMarkdownDecorations(
+      state,
+      { from: offLine, to: offLine },
+      {
+        orgPeople: [
+          {
+            id: 'user-alice',
+            email: 'alice@kb-1.dev',
+            name: 'Alice',
+            image: null,
+          },
+        ],
+      },
+    );
+    const mentions = findMentionWidgets(set, doc.length);
+    expect(mentions).toHaveLength(1);
+    expect(mentions[0].email).toBe('alice@kb-1.dev');
+  });
+
   it('skips the widget ONLY for the mention the cursor sits inside (per-Link reveal)', () => {
     // Per-Link reveal: caret inside Alice's `[...](mention:...)` range
     // reveals ONLY Alice's source; Bob's widget on the same line still

--- a/packages/editor/src/lib/plaintext-decorations.ts
+++ b/packages/editor/src/lib/plaintext-decorations.ts
@@ -352,7 +352,7 @@ function buildMentionWidgetProps(email: string, resolved: OrgPerson | null): Men
 function extractMentionEmailFromLink(link: SyntaxNode, state: EditorState): string | null {
   let child: SyntaxNode | null = link.firstChild;
   while (child !== null) {
-    if (child.type.name === 'URL') {
+    if (child.type.name === 'URL' && isLinkDestinationUrl(child, state)) {
       let raw = state.sliceDoc(child.from, child.to).trim();
       if (raw.startsWith('<') && raw.endsWith('>')) {
         raw = raw.slice(1, -1);

--- a/packages/editor/src/lib/plaintext-link-affordance.test.ts
+++ b/packages/editor/src/lib/plaintext-link-affordance.test.ts
@@ -1,0 +1,41 @@
+import { syntaxTree } from '@codemirror/language';
+import { EditorState } from '@codemirror/state';
+import type { SyntaxNode } from '@lezer/common';
+import { describe, expect, it } from 'vitest';
+import { plaintextDecorations } from './plaintext-decorations';
+import { extractLinkUrl } from './plaintext-link-affordance';
+
+function linkNodeFor(doc: string): { state: EditorState; node: SyntaxNode } {
+  const state = EditorState.create({
+    doc,
+    extensions: [plaintextDecorations()],
+  });
+  let node: SyntaxNode | null = null;
+  syntaxTree(state).iterate({
+    enter: (candidate) => {
+      if (candidate.type.name === 'Link') {
+        node = candidate.node;
+        return false;
+      }
+      return undefined;
+    },
+  });
+  if (node === null) throw new Error('expected a Link node');
+  return { state, node };
+}
+
+describe('extractLinkUrl', () => {
+  it('returns the destination rather than a URL-shaped label', () => {
+    const { state, node } = linkNodeFor(
+      '[https://label.example](https://destination.example)',
+    );
+    expect(extractLinkUrl(state, node)).toBe('https://destination.example');
+  });
+
+  it('returns a mention destination behind a URL-shaped label', () => {
+    const { state, node } = linkNodeFor(
+      '[https://profile.example](mention:alice@kb-1.dev)',
+    );
+    expect(extractLinkUrl(state, node)).toBe('mention:alice@kb-1.dev');
+  });
+});

--- a/packages/editor/src/lib/plaintext-link-affordance.ts
+++ b/packages/editor/src/lib/plaintext-link-affordance.ts
@@ -255,9 +255,15 @@ export function extractLinkUrl(
   state: EditorState,
   linkNode: SyntaxNode,
 ): string | null {
+  let sawCloseBracket = false;
   let child: SyntaxNode | null = linkNode.firstChild;
   while (child !== null) {
-    if (child.type.name === 'URL') {
+    if (
+      child.type.name === 'LinkMark' &&
+      state.sliceDoc(child.from, child.to) === ']'
+    ) {
+      sawCloseBracket = true;
+    } else if (child.type.name === 'URL' && sawCloseBracket) {
       let raw = state.sliceDoc(child.from, child.to).trim();
       if (raw.startsWith('<') && raw.endsWith('>')) raw = raw.slice(1, -1);
       return raw.length > 0 ? raw : null;

--- a/packages/editor/src/lib/plaintext-mention-keymap.test.ts
+++ b/packages/editor/src/lib/plaintext-mention-keymap.test.ts
@@ -63,6 +63,13 @@ describe('mentionAtomicDeleteRange — Backspace at right edge', () => {
     const range = mentionAtomicDeleteRange(state, doc.length, 'Backspace');
     expect(range).toBeNull();
   });
+
+  it('uses the destination when a mention has a URL-shaped label', () => {
+    const doc = '[https://profile.example](mention:alice@kb-1.dev)';
+    const state = makeState(doc);
+    const range = mentionAtomicDeleteRange(state, doc.length, 'Backspace');
+    expect(range).toEqual({ from: 0, to: doc.length });
+  });
 });
 
 describe('mentionAtomicDeleteRange — Delete at left edge', () => {


### PR DESCRIPTION
## Summary
- select the parenthesized Markdown destination when a link label is itself URL-shaped
- preserve mention rendering and atomic deletion for URL-shaped mention labels
- add regression coverage for differing label/destination URLs and `mention:` destinations

## Context
Follow-up to #118. The visibility fix correctly kept URL-shaped labels visible, but review of the Cloud consumer bump found that click and mention extraction could still select the label's `URL` syntax node instead of the destination.

## Verification
- `pnpm check`
- editor suite: 182 tests passed
- autoreview clean
