### PR TITLE
fix(editor): preserve URL link destinations in tables

### DIFF
--- a/packages/editor/src/lib/plaintext-decorations.test.ts
+++ b/packages/editor/src/lib/plaintext-decorations.test.ts
@@ -326,6 +326,32 @@ describe('table cells — inline rendering contract', () => {
     });
   });
 
+  it('uses destinations when table link labels are URL-shaped', () => {
+    const parts = parseTableCellInlineMarkdown(
+      '[https://label.example](https://destination.example) ' +
+        '[https://profile.example](mention:alice@kb-1.dev)',
+      {
+        orgPeople: [
+          {
+            id: 'user-alice',
+            email: 'alice@kb-1.dev',
+            name: 'Alice (dev)',
+            image: null,
+          },
+        ],
+        livePaths: [],
+      },
+    );
+
+    const link = parts.find((part) => part.kind === 'link');
+    expect(link?.kind === 'link' ? link.href : null).toBe('https://destination.example');
+    expect(link?.kind === 'link' ? link.children : null).toEqual([
+      { kind: 'text', text: 'https://label.example' },
+    ]);
+    const mention = parts.find((part) => part.kind === 'mention');
+    expect(mention?.kind === 'mention' ? mention.props.displayName : null).toBe('Alice (dev)');
+  });
+
   it('keeps table source raw while the cursor is inside the table', () => {
     const doc =
       '| Feature | Value |\n' +

--- a/packages/editor/src/lib/plaintext-decorations.ts
+++ b/packages/editor/src/lib/plaintext-decorations.ts
@@ -660,8 +660,10 @@ function linkUrlFromElement(
   link: InlineElement,
   source: string,
 ): string | null {
+  const labelEnd = linkLabelEnd(parser, link, source);
+  if (labelEnd === null) return null;
   for (const child of childElements(link)) {
-    if (inlineElementName(parser, child) === 'URL') {
+    if (inlineElementName(parser, child) === 'URL' && child.from > labelEnd) {
       return stripAngleUrl(source.slice(child.from, child.to));
     }
   }
@@ -704,13 +706,16 @@ function tableInlinePartsFromRange(
   to: number,
   elements: readonly InlineElement[],
   context: Pick<TableInlineRenderContext, 'livePaths' | 'orgPeople'>,
+  suppressAutolinks = false,
 ): TableInlinePart[] {
   const parts: TableInlinePart[] = [];
   let pos = from;
   for (const element of elements) {
     if (element.to <= from || element.from >= to) continue;
     if (element.from > pos) pushTextPart(parts, source.slice(pos, element.from));
-    parts.push(...tableInlinePartsFromElement(parser, source, element, context));
+    parts.push(
+      ...tableInlinePartsFromElement(parser, source, element, context, suppressAutolinks),
+    );
     pos = Math.max(pos, element.to);
   }
   if (pos < to) pushTextPart(parts, source.slice(pos, to));
@@ -722,6 +727,7 @@ function tableInlinePartsFromElement(
   source: string,
   element: InlineElement,
   context: Pick<TableInlineRenderContext, 'livePaths' | 'orgPeople'>,
+  suppressAutolinks: boolean,
 ): TableInlinePart[] {
   const name = inlineElementName(parser, element);
   const children = childElements(element);
@@ -749,6 +755,7 @@ function tableInlinePartsFromElement(
           element.to,
           children,
           context,
+          suppressAutolinks,
         ),
       },
     ];
@@ -764,6 +771,7 @@ function tableInlinePartsFromElement(
           element.to,
           children,
           context,
+          suppressAutolinks,
         ),
       },
     ];
@@ -779,6 +787,7 @@ function tableInlinePartsFromElement(
           element.to,
           children,
           context,
+          suppressAutolinks,
         ),
       },
     ];
@@ -791,6 +800,7 @@ function tableInlinePartsFromElement(
       element.to,
       children,
       context,
+      suppressAutolinks,
     );
     return [
       {
@@ -820,12 +830,14 @@ function tableInlinePartsFromElement(
           labelEnd,
           children,
           context,
+          true,
         ),
       },
     ];
   }
   if (name === 'URL') {
     const raw = source.slice(element.from, element.to);
+    if (suppressAutolinks) return [{ kind: 'text', text: raw }];
     return [
       { kind: 'link', href: normalizeInlineHref(raw), children: [{ kind: 'text', text: raw }] },
     ];
@@ -844,7 +856,15 @@ function tableInlinePartsFromElement(
     ];
   }
   if (children.length > 0) {
-    return tableInlinePartsFromRange(parser, source, element.from, element.to, children, context);
+    return tableInlinePartsFromRange(
+      parser,
+      source,
+      element.from,
+      element.to,
+      children,
+      context,
+      suppressAutolinks,
+    );
   }
   return [{ kind: 'text', text: source.slice(element.from, element.to) }];
 }


### PR DESCRIPTION
## Summary
- select the Markdown destination URL after the closing label bracket in rendered table cells
- keep URL-shaped labels as text inside the outer link instead of creating a nested autolink
- preserve mention destinations when their labels are URL-shaped
- add regression coverage for the outer destination, rendered label children, and mention resolution

## Verification
- `CI=1 pnpm check`
- editor suite: 183 tests passed
- web suite: 49 tests passed
- autoreview clean after fixing its nested-autolink finding

Follow-up to #119. Cloud consumer PR metatheoryinc/kb-1-cloud#262 remains draft until this lands.
