### PR TITLE
feat: add portable daemon snapshot archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,29 @@ Call it before snapshotting or syncing the vault. A clean vault returns
 canonical failure dialect as the rest of the API, and the existing save-warning
 event path still fires.
 
+`GET /api/ops/snapshot.zip` is the whole-daemon backup and export primitive. It
+flushes every active vault through the same conservative durability boundary,
+then streams a ZIP containing `vaults/`, recoverable
+`.trash/`, `kb1-snapshot.json`, and a final `kb1-snapshot.complete` marker. The
+manifest records the schema version, timestamps, paths, sizes, modes, and byte
+totals. The stream fails if any planned file or directory changes before the
+archive completes, so callers must discard an incomplete ZIP and retry instead
+of treating mixed filesystem state as a backup.
+
+The archive retains portable vault metadata. It excludes daemon-local
+`.kb1/cache/`, `.kb1/runtime/`, `.kb1/tmp/`, and `.kb1/secrets/` trees, along
+with the entire `.git` implementation directory. File history remains a
+best-effort local feature rather than part of the portable export contract.
+
+The snapshot endpoint is served on the daemon's normal local API. Packaged
+self-hosted daemons remain loopback-only unless an operator deliberately exposes
+them. Cloud-hosted backup/export callers use the private managed-container
+binding directly; the ordinary per-organization relay remains a bounded JSON/API
+transport and is not the snapshot transfer path.
+Never extract an archive over a running daemon home. Restore into a stopped or
+disposable `KB1_HOME`, validate the manifest and ZIP, start the daemon there,
+and exercise real vault reads before any separately approved cutover.
+
 `GET /api/vaults/:id/events` is the tooling primitive for one vault. It is a
 Server-Sent Events stream for watchers, backup triggers, and live tree refresh.
 Events report change kind, vault-relative paths, actor attribution, and

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -7,7 +7,7 @@ regenerated and reviewed for every release.
 Platform-specific optional native build bindings are excluded because they are not
 copied into the shipped runtime; their platform-neutral parent packages remain listed.
 
-Inventory count: **197 packages**.
+Inventory count: **199 packages**.
 
 | Package | Declared license | Source | Included notice files |
 | --- | --- | --- | --- |
@@ -72,6 +72,7 @@ Inventory count: **197 packages**.
 | aria-query 5.3.1 | Apache-2.0 | [source](https://github.com/A11yance/aria-query) | LICENSE (c4da23066f58) |
 | axobject-query 4.1.0 | Apache-2.0 | [source](https://github.com/A11yance/axobject-query) | LICENSE (c4da23066f58) |
 | body-parser 2.2.2 | MIT | [source](https://github.com/expressjs/body-parser) | LICENSE (7cb4d976f1c8) |
+| buffer-crc32 1.0.0 | MIT | [source](https://github.com/brianloveswords/buffer-crc32) | LICENSE (696568bf81c2) |
 | bytes 3.1.2 | MIT | [source](https://github.com/visionmedia/bytes.js) | LICENSE (811223f2d339) |
 | call-bind-apply-helpers 1.0.2 | MIT | [source](https://github.com/ljharb/call-bind-apply-helpers) | LICENSE (3df72862fb6d) |
 | call-bound 1.0.4 | MIT | [source](https://github.com/ljharb/call-bound) | LICENSE (3df72862fb6d) |
@@ -204,6 +205,7 @@ Inventory count: **197 packages**.
 | ws 8.21.0 | MIT | [source](https://github.com/websockets/ws) | LICENSE (7adebaeee45b) |
 | y-protocols 1.0.7 | MIT | [source](https://github.com/yjs/y-protocols) | LICENSE (7ad5cbfd9f9f) |
 | yaml 2.9.0 | ISC | [source](https://github.com/eemeli/yaml) | LICENSE (cf12d35c36ba) |
+| yazl 3.3.1 | MIT | [source](https://github.com/thejoshwolfe/yazl) | LICENSE (da5f77b8bc87) |
 | yjs 13.6.31 | MIT | [source](https://github.com/yjs/yjs) | LICENSE (467c210a105c) |
 | zimmerframe 1.1.4 | MIT | [source](https://github.com/sveltejs/zimmerframe) | LICENSE (3ef5af147392) |
 | zod 4.4.3 | MIT | [source](https://github.com/colinhacks/zod) | LICENSE (f61cacc2acb8) |
@@ -1535,6 +1537,34 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+### 696568bf81c2a4c3ac62d551aec817da60d3855824e6a980c9031087188ae633
+
+Packages: buffer-crc32@1.0.0
+
+Files: buffer-crc32@1.0.0/LICENSE
+
+```text
+The MIT License
+
+Copyright (c) 2013-2024 Brian J. Brennan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 ### 811223f2d33910a962de4d6dc12bcb545252992e9d004f78936b94afde443749
@@ -7693,6 +7723,36 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
 OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
 TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
+```
+
+### da5f77b8bc8717f6e33aedce55a88702d79038d83cdc00af5ca08f3bc4f22ff9
+
+Packages: yazl@3.3.1
+
+Files: yazl@3.3.1/LICENSE
+
+```text
+The MIT License (MIT)
+
+Copyright (c) 2014 Josh Wolfe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ### 467c210a105ca58b1521a8b7eb574b68afed6706f79e0afec274e17185d7be5e

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -24,12 +24,16 @@
     "@kb-1/vault-service": "workspace:*",
     "github-slugger": "2.0.0",
     "hono": "4.12.25",
+    "yazl": "3.3.1",
     "ws": "8.21.0"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
+    "@types/yauzl": "3.4.0",
+    "@types/yazl": "3.3.1",
     "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "4.1.8",
+    "yauzl": "3.4.0",
     "yjs": "13.6.31"
   }
 }

--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -12,9 +12,11 @@ import {
   type VaultService
 } from '@kb-1/vault-service';
 import { timingSafeEqual } from 'node:crypto';
-import { createReadStream } from 'node:fs';
-import { resolve } from 'node:path';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { mkdir, mkdtemp, readdir, rm, stat } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
 import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 
 import { SERVICE_NAME, type ActorDefault } from './config.js';
 import {
@@ -46,6 +48,23 @@ interface CreateAppOptions {
   relay?: RelayLifecycleController;
   shutdown?: ShutdownController;
   shutdownSignal?: AbortSignal;
+  /** Maximum time a snapshot response may make no delivery progress. */
+  snapshotDeliveryIdleTimeoutMs?: number;
+  /** Daemon-owned directory for temporary, restart-cleanable snapshot files. */
+  snapshotSpoolHome?: string;
+}
+
+const SNAPSHOT_DELIVERY_IDLE_TIMEOUT_MS = 10 * 60_000;
+export const SNAPSHOT_SPOOL_DIRNAME = 'snapshot-spool';
+
+export async function prepareSnapshotSpoolHome(path: string): Promise<void> {
+  await mkdir(path, { recursive: true });
+  const staleEntries = await readdir(path);
+  await Promise.all(
+    staleEntries.map((entry) =>
+      rm(join(path, entry), { force: true, recursive: true }),
+    ),
+  );
 }
 
 export interface RelayLifecycleStatus {
@@ -162,6 +181,9 @@ export function createApp(options: CreateAppOptions): Hono {
   if (options.registry) {
     const registry = options.registry;
     const actorDefault = options.actorDefault ?? 'user';
+    const snapshotSpoolHome = options.snapshotSpoolHome
+      ?? join(dirname(options.statusFile), SNAPSHOT_SPOOL_DIRNAME);
+    let snapshotInProgress = false;
 
     // One MCP endpoint addresses every vault. vaultId resolution and vault
     // enumeration go through the registry — the same source of truth as the HTTP
@@ -197,6 +219,106 @@ export function createApp(options: CreateAppOptions): Hono {
         ok: true,
         usedBytes: await registry.storageUsageBytes()
       });
+    });
+
+    api.get('/ops/snapshot.zip', async (context) => {
+      // Hono routes HEAD through GET by default. Reject it before creating the
+      // potentially large spool because the framework discards the response
+      // body and would otherwise leave the source stream unread.
+      if (context.req.method !== 'GET') {
+        return context.body(null, 405, { allow: 'GET' });
+      }
+      if (snapshotInProgress) {
+        return context.json({
+          ok: false,
+          error: 'snapshot_in_progress',
+          message: 'A data snapshot is already in progress.'
+        }, 409);
+      }
+      snapshotInProgress = true;
+      let spoolDirectory: string | undefined;
+      try {
+        const snapshotSignal = options.shutdownSignal
+          ? AbortSignal.any([context.req.raw.signal, options.shutdownSignal])
+          : context.req.raw.signal;
+        const snapshot = await registry.createSnapshotArchive(
+          new Date(),
+          snapshotSignal,
+        );
+        // The relay protocol needs an exact total before it can stream bounded
+        // chunks with acknowledgements. Spool outside KB1_HOME so the archive
+        // never contains itself, then delete the temporary file when delivery
+        // finishes or is cancelled.
+        // Startup clears crash leftovers, and this preflight retries any
+        // cleanup that failed after an earlier request in the same process.
+        await prepareSnapshotSpoolHome(snapshotSpoolHome);
+        spoolDirectory = await mkdtemp(join(snapshotSpoolHome, 'run-'));
+        const spoolPath = join(spoolDirectory, 'snapshot.zip');
+        await pipeline(snapshot.stream, createWriteStream(spoolPath), {
+          signal: snapshotSignal,
+        });
+        const archiveSize = (await stat(spoolPath)).size;
+        const source = createReadStream(spoolPath);
+        let deliveryIdleTimeout: ReturnType<typeof setTimeout> | undefined;
+        const cleanup = () => {
+          if (deliveryIdleTimeout) clearTimeout(deliveryIdleTimeout);
+          deliveryIdleTimeout = undefined;
+          snapshotSignal.removeEventListener('abort', abortSource);
+          snapshotInProgress = false;
+          if (!spoolDirectory) return;
+          const directory = spoolDirectory;
+          spoolDirectory = undefined;
+          void rm(directory, { force: true, recursive: true }).catch((error) => {
+            console.error('KB-1 snapshot spool cleanup failed.', error);
+          });
+        };
+        const abortSource = () => {
+          source.destroy(new Error('Snapshot delivery was interrupted.'));
+        };
+        const refreshDeliveryIdleTimeout = () => {
+          if (deliveryIdleTimeout) clearTimeout(deliveryIdleTimeout);
+          deliveryIdleTimeout = setTimeout(() => {
+            source.destroy(new Error('Snapshot delivery timed out.'));
+          }, options.snapshotDeliveryIdleTimeoutMs ?? SNAPSHOT_DELIVERY_IDLE_TIMEOUT_MS);
+          deliveryIdleTimeout.unref();
+        };
+        source.once('close', cleanup);
+        source.once('error', cleanup);
+        source.on('data', refreshDeliveryIdleTimeout);
+        snapshotSignal.addEventListener('abort', abortSource, {
+          once: true
+        });
+        if (snapshotSignal.aborted) abortSource();
+        else refreshDeliveryIdleTimeout();
+        const filenameTimestamp = snapshot.manifest.createdAt.replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+        return new Response(
+          Readable.toWeb(source) as ReadableStream<Uint8Array>,
+          {
+            headers: {
+              'cache-control': 'no-store',
+              'content-length': String(archiveSize),
+              'content-disposition': `attachment; filename="kb1-data-${filenameTimestamp}.zip"`,
+              'content-type': 'application/zip',
+              'x-kb1-snapshot-bytes': String(snapshot.manifest.totals.bytes),
+              'x-kb1-snapshot-created-at': snapshot.manifest.createdAt,
+              'x-kb1-snapshot-durable-as-of': snapshot.manifest.durableAsOf,
+              'x-kb1-snapshot-files': String(snapshot.manifest.totals.files),
+              'x-kb1-snapshot-schema': String(snapshot.manifest.schemaVersion)
+            }
+          }
+        );
+      } catch (error) {
+        snapshotInProgress = false;
+        if (spoolDirectory) {
+          await rm(spoolDirectory, { force: true, recursive: true }).catch(() => undefined);
+        }
+        console.error('KB-1 snapshot creation failed.', error);
+        return context.json({
+          ok: false,
+          error: 'snapshot_failed',
+          message: 'The daemon could not create a consistent data snapshot.'
+        }, 503);
+      }
     });
 
     api.post('/vaults', async (context) => {

--- a/apps/daemon/src/config.ts
+++ b/apps/daemon/src/config.ts
@@ -13,6 +13,7 @@ export type ActorDefault = 'user' | 'unknown';
 
 export const DEFAULT_VAULT_SLUG = 'demo-vault';
 export const LEGACY_VAULT_DIRNAME = 'demo-vault';
+export const DAEMON_INITIALIZED_FILENAME = '.kb1-initialized';
 const VAULTS_DIRNAME = 'vaults';
 
 export interface DaemonConfig {

--- a/apps/daemon/src/main.test.ts
+++ b/apps/daemon/src/main.test.ts
@@ -54,6 +54,30 @@ describe('daemon startup', () => {
     await close(blocker);
   });
 
+  it('removes stale snapshot spools before accepting traffic', async () => {
+    const port = await reservePort();
+    const staleSpool = join(
+      kb1Home,
+      'daemon',
+      'snapshot-spool',
+      'run-interrupted',
+      'snapshot.zip',
+    );
+    await mkdir(join(staleSpool, '..'), { recursive: true });
+    await writeFile(staleSpool, 'sensitive snapshot bytes');
+    process.env = {
+      ...originalEnv,
+      KB1_HOME: kb1Home,
+      KB1_HOST: '127.0.0.1',
+      KB1_PORT: String(port),
+    };
+
+    const started = await startDaemon();
+
+    await expect(access(staleSpool)).rejects.toBeTruthy();
+    await started.close();
+  });
+
   it('releases a delayed document lease when its socket closes before attachment', async () => {
     let resolveLease: ((lease: ClientDocumentSession) => void) | undefined;
     const leasePromise = new Promise<ClientDocumentSession>((resolve) => {
@@ -160,6 +184,51 @@ describe('daemon startup', () => {
     // The retired flat surface is gone.
     const flat = await fetch(`http://127.0.0.1:${port}/api/demo-document`);
     expect(flat.status).toBe(404);
+
+    await started.close();
+  });
+
+  it('adopts a legacy empty home with trashed data without recreating the starter vault', async () => {
+    const port = await reservePort();
+    process.env = {
+      ...originalEnv,
+      KB1_HOME: kb1Home,
+      KB1_HOST: '127.0.0.1',
+      KB1_PORT: String(port)
+    };
+    const trashedVault = join(kb1Home, '.trash', 'last-vault');
+    await mkdir(trashedVault, { recursive: true });
+    await writeFile(join(trashedVault, 'kept.md'), 'recoverable\n', 'utf8');
+
+    const started = await startDaemon();
+    const list = await fetch(`http://127.0.0.1:${port}/api/vaults`);
+
+    expect(list.status).toBe(200);
+    await expect(list.json()).resolves.toEqual({ ok: true, vaults: [] });
+    await expect(access(join(kb1Home, 'vaults', 'demo-vault'))).rejects.toBeTruthy();
+    await expect(readFile(join(trashedVault, 'kept.md'), 'utf8')).resolves.toBe('recoverable\n');
+    await expect(access(join(kb1Home, 'vaults', '.kb1-initialized'))).resolves.toBeUndefined();
+
+    await started.close();
+  });
+
+  it('adopts a legacy empty home with an empty trash directory without recreating the starter vault', async () => {
+    const port = await reservePort();
+    process.env = {
+      ...originalEnv,
+      KB1_HOME: kb1Home,
+      KB1_HOST: '127.0.0.1',
+      KB1_PORT: String(port)
+    };
+    await mkdir(join(kb1Home, '.trash'), { recursive: true });
+
+    const started = await startDaemon();
+    const list = await fetch(`http://127.0.0.1:${port}/api/vaults`);
+
+    expect(list.status).toBe(200);
+    await expect(list.json()).resolves.toEqual({ ok: true, vaults: [] });
+    await expect(access(join(kb1Home, 'vaults', 'demo-vault'))).rejects.toBeTruthy();
+    await expect(access(join(kb1Home, 'vaults', '.kb1-initialized'))).resolves.toBeUndefined();
 
     await started.close();
   });
@@ -832,6 +901,12 @@ describe('daemon vault management API', () => {
     // The daemon is still healthy and the web bundle path still serves.
     const health = await fetch(`${base()}/api/health`);
     expect(health.status).toBe(200);
+
+    // The initialized-home marker distinguishes this valid empty state from a
+    // first boot, so restarting does not silently recreate the starter vault.
+    await started.close();
+    started = await startDaemon();
+    await expect(listVaults()).resolves.toEqual([]);
 
     // A fresh vault can still be created from the empty state.
     const recreated = await fetch(`${base()}/api/vaults`, {

--- a/apps/daemon/src/main.ts
+++ b/apps/daemon/src/main.ts
@@ -14,7 +14,7 @@ import { TunnelClient, type TunnelClientLogger } from '@kb-1/tunnel-client';
 import type { VaultChangeEventKind } from '@kb-1/vault-service';
 import { realpathSync } from 'node:fs';
 import type { IncomingMessage } from 'node:http';
-import { mkdir } from 'node:fs/promises';
+import { access, mkdir, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 import { classifyArtifactPath, validateVaultPath, type VaultActor } from '@kb-1/vault-core';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -25,10 +25,13 @@ import {
   actorFromHeaders,
   createApp,
   mcpVaultProvider,
+  prepareSnapshotSpoolHome,
+  SNAPSHOT_SPOOL_DIRNAME,
   type RelayLifecycleController
 } from './app.js';
 import {
   createDaemonConfig,
+  DAEMON_INITIALIZED_FILENAME,
   DEFAULT_KB1_HOME_DIRNAME,
   DEFAULT_VAULT_SLUG,
   LEGACY_KB2_HOME_DIRNAME,
@@ -72,12 +75,18 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Sta
   const config = createDaemonConfig(options);
   const env = options.env ?? process.env;
   const controlToken = env.KB1_CONTROL_TOKEN?.trim();
+  const snapshotSpoolHome = join(config.daemonHome, SNAPSHOT_SPOOL_DIRNAME);
 
   for (const warning of config.deprecationWarnings) {
     console.warn(`[${config.serviceName}] ${warning}`);
   }
 
   await migrateLegacyDaemonHome(config.kb1Home);
+
+  // Snapshot ZIPs contain the full recoverable organization state. Clear
+  // crash leftovers after legacy-home migration but before accepting traffic
+  // so deleted data and disk consumption cannot accumulate.
+  await prepareSnapshotSpoolHome(snapshotSpoolHome);
 
   // Boot migration: copy -> verify -> cleanup the legacy single-vault layout.
   await migrateLegacyVaultLayout({
@@ -90,6 +99,11 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Sta
   // and mutable at runtime (create/rename/soft-delete) with no restart.
   await mkdir(config.vaultsHome, { recursive: true });
   const trashHome = join(config.kb1Home, VAULT_TRASH_DIRNAME);
+  const initializedMarker = join(config.vaultsHome, DAEMON_INITIALIZED_FILENAME);
+  // Homes created before the marker existed can legitimately have no active
+  // vaults after the final vault was soft-deleted. Preserve that state when
+  // adopting the marker instead of recreating the starter vault.
+  const wasInitialized = await pathExists(initializedMarker) || await pathExists(trashHome);
   const registry = await VaultRegistry.load(config.vaultsHome, trashHome, {
     historyCoalesceWindowMs: config.historyCoalesceWindowMs
   });
@@ -98,12 +112,13 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Sta
   // a single starter vault seeded from the bundled kit. `create` performs the
   // seeding, so there is no separate seed path. After first boot, zero vaults is
   // a valid state — deleting every vault leaves the daemon serving an empty list.
-  if (registry.list().length === 0) {
+  if (registry.list().length === 0 && !wasInitialized) {
     const created = await registry.create({ displayName: DEFAULT_VAULT_SLUG, slug: DEFAULT_VAULT_SLUG });
     if (!created.ok) {
       throw new Error(`Failed to create the starter vault: ${created.message}`);
     }
   }
+  await writeFile(initializedMarker, '1\n', { flag: 'a' });
 
   // One MCP endpoint, every vault: vaultId resolution and vault enumeration both
   // go through the SAME live registry the HTTP layer uses — no second vault map.
@@ -136,6 +151,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Sta
     webBuildDir: fileURLToPath(new URL('../../web/build', import.meta.url)),
     webProxyTarget: config.webProxyTarget,
     actorDefault: config.actorDefault,
+    snapshotSpoolHome,
     relay,
     shutdownSignal: shutdownSignal.signal,
     ...(controlToken ? {
@@ -533,6 +549,16 @@ function documentUpdateAttributionForActor(actor: VaultActor): DocumentUpdateAtt
 
 function firstHeaderValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return false;
+    throw error;
+  }
 }
 
 function traceIdFromDocumentRequest(request: IncomingMessage): string | undefined {

--- a/apps/daemon/src/routing.test.ts
+++ b/apps/daemon/src/routing.test.ts
@@ -16,6 +16,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { serve } from "@hono/node-server";
 import type { Hono } from "hono";
 import { createServer } from "node:http";
+import { randomBytes } from "node:crypto";
 import type { AddressInfo } from "node:net";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
@@ -129,6 +130,101 @@ describe("daemon routing", () => {
       },
     });
     expect(statusFileContents).toMatchObject(body.status);
+  });
+
+  it("flushes live documents before streaming the organization snapshot", async () => {
+    const { app, registry, manager, vaultRoot } = await setupScopedVault();
+    const session = manager.getSession("live.md", { defaultContent: "" });
+    await session.open();
+    session.ydoc.getText("markdown").insert(0, "durable snapshot\n");
+
+    const response = await app.request("/api/ops/snapshot.zip");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/zip");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-disposition")).toMatch(
+      /^attachment; filename="kb1-data-\d{8}T\d{6}Z\.zip"$/,
+    );
+    expect(Number(response.headers.get("x-kb1-snapshot-files"))).toBeGreaterThan(0);
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    expect([...bytes.subarray(0, 4)]).toEqual([0x50, 0x4b, 0x03, 0x04]);
+    await expect(readFile(join(vaultRoot, "live.md"), "utf8")).resolves.toBe(
+      "durable snapshot\n",
+    );
+    await registry.close();
+  });
+
+  it("rejects HEAD without creating a snapshot spool", async () => {
+    const { app, registry } = await setupScopedVault();
+    const createSnapshotArchive = vi.spyOn(
+      registry,
+      "createSnapshotArchive",
+    );
+
+    const response = await app.request("/api/ops/snapshot.zip", {
+      method: "HEAD",
+    });
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("GET");
+    expect(createSnapshotArchive).not.toHaveBeenCalled();
+    await registry.close();
+  });
+
+  it("allows only one snapshot spool or delivery at a time", async () => {
+    const { app, registry } = await setupScopedVault();
+    const first = await app.request("/api/ops/snapshot.zip");
+
+    const overlapping = await app.request("/api/ops/snapshot.zip");
+    expect(overlapping.status).toBe(409);
+    await expect(overlapping.json()).resolves.toMatchObject({
+      error: "snapshot_in_progress",
+    });
+
+    await first.arrayBuffer();
+    const afterDelivery = await app.request("/api/ops/snapshot.zip");
+    expect(afterDelivery.status).toBe(200);
+    await afterDelivery.arrayBuffer();
+    await registry.close();
+  });
+
+  it("releases a stalled snapshot delivery after its idle timeout", async () => {
+    const { registry, vaultRoot, config } = await setupScopedVault();
+    await writeFile(join(vaultRoot, "large.bin"), randomBytes(2 * 1024 * 1024));
+    const timedApp = createApp({
+      statusFile: config.statusFile,
+      registry,
+      actorDefault: config.actorDefault,
+      snapshotDeliveryIdleTimeoutMs: 25,
+    });
+
+    const first = await timedApp.request("/api/ops/snapshot.zip");
+    const reader = first.body?.getReader();
+    if (!reader) throw new Error("Expected snapshot response body");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    await expect(reader.read()).rejects.toThrow("Snapshot delivery timed out.");
+    const afterTimeout = await timedApp.request("/api/ops/snapshot.zip");
+    expect(afterTimeout.status).toBe(200);
+    await afterTimeout.arrayBuffer();
+    await registry.close();
+  });
+
+  it("stops snapshot delivery when the requesting client disconnects", async () => {
+    const { app, registry } = await setupScopedVault();
+    const request = new AbortController();
+    const response = await app.request("/api/ops/snapshot.zip", {
+      signal: request.signal,
+    });
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("Expected snapshot response body");
+
+    request.abort();
+
+    await expect(reader.read()).rejects.toThrow(
+      "Snapshot delivery was interrupted.",
+    );
+    await registry.close();
   });
 
   it("requires the private control token before requesting daemon shutdown", async () => {

--- a/apps/daemon/src/snapshot-archive.test.ts
+++ b/apps/daemon/src/snapshot-archive.test.ts
@@ -121,6 +121,9 @@ describe('daemon snapshot archive', () => {
     });
     const entries = await readZipEntries(await buffer(archive.stream));
 
+    expect(entries.get('vaults/demo/.kb1/vault.json')?.toString('utf8')).toBe(
+      '{"id":"demo","displayName":"Demo"}\n'
+    );
     expect(entries.has('vaults/demo/.kb1/secrets/token')).toBe(false);
     expect(entries.has('vaults/demo/.kb1/cache/index')).toBe(false);
     expect(entries.has('vaults/demo/.git/config')).toBe(false);

--- a/apps/daemon/src/snapshot-archive.test.ts
+++ b/apps/daemon/src/snapshot-archive.test.ts
@@ -1,0 +1,375 @@
+import { createServer } from 'node:http';
+import { chmod, mkdir, mkdtemp, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { buffer } from 'node:stream/consumers';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { fromBufferPromise } from 'yauzl';
+
+import { startDaemon } from './main.js';
+import { DAEMON_INITIALIZED_FILENAME } from './config.js';
+import {
+  SNAPSHOT_COMPLETION_PATH,
+  SNAPSHOT_MANIFEST_PATH,
+  createSnapshotArchive,
+  type SnapshotArchiveManifest,
+} from './snapshot-archive.js';
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(cleanupPaths.splice(0).map((path) => rm(path, { force: true, recursive: true })));
+});
+
+describe('daemon snapshot archive', () => {
+  it('round-trips active and trashed vault bytes into a disposable daemon runtime', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-source-');
+    const restoredHome = await temporaryDirectory('kb1-snapshot-restored-');
+    await mkdir(join(sourceHome, 'vaults', 'field-notes', '.kb1'), { recursive: true });
+    await mkdir(join(sourceHome, '.trash', 'old-vault'), { recursive: true });
+    await writeFile(
+      join(sourceHome, 'vaults', 'field-notes', '.kb1', 'vault.json'),
+      '{"id":"field-notes","displayName":"Field Notes"}\n',
+    );
+    await writeFile(join(sourceHome, 'vaults', 'field-notes', 'note.md'), 'recover me\n');
+    await writeFile(join(sourceHome, '.trash', 'old-vault', 'deleted.md'), 'still recoverable\n');
+
+    const archive = await createSnapshotArchive({
+      roots: [
+        { archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') },
+        { archivePath: '.trash', filesystemPath: join(sourceHome, '.trash') },
+      ],
+      createdAt: new Date('2026-09-03T08:00:00.000Z'),
+      durableAsOf: new Date('2026-09-03T08:00:01.000Z'),
+    });
+    const archiveBytes = await buffer(archive.stream);
+    const entries = await readZipEntries(archiveBytes);
+
+    expect(entries.get('vaults/field-notes/note.md')?.toString('utf8')).toBe('recover me\n');
+    expect(entries.get('.trash/old-vault/deleted.md')?.toString('utf8')).toBe('still recoverable\n');
+    const manifest = JSON.parse(
+      entries.get(SNAPSHOT_MANIFEST_PATH)?.toString('utf8') ?? '',
+    ) as SnapshotArchiveManifest;
+    expect(manifest).toMatchObject({
+      schemaVersion: 1,
+      createdAt: '2026-09-03T08:00:00.000Z',
+      durableAsOf: '2026-09-03T08:00:01.000Z',
+      totals: { files: 3 },
+    });
+    expect(manifest.files.every((file) => /^[0-9a-f]{64}$/.test(file.sha256))).toBe(true);
+    expect(entries.get(SNAPSHOT_COMPLETION_PATH)?.toString('utf8')).toBe(
+      '2026-09-03T08:00:00.000Z\n'
+    );
+
+    await extractZip(entries, restoredHome);
+    const port = await reservePort();
+    const restored = await startDaemon({
+      env: {
+        KB1_HOME: restoredHome,
+        KB1_HOST: '127.0.0.1',
+        KB1_PORT: String(port),
+      },
+    });
+    try {
+      const response = await fetch(`http://127.0.0.1:${String(port)}/api/vaults/field-notes/files/note.md`);
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        ok: true,
+        content: 'recover me\n',
+      });
+    } finally {
+      await restored.close();
+    }
+  });
+
+  it('fails closed when a snapshot root contains a symbolic link', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-symlink-');
+    await mkdir(join(sourceHome, 'vaults', 'demo'), { recursive: true });
+    await symlink('/tmp', join(sourceHome, 'vaults', 'demo', 'outside'));
+
+    await expect(createSnapshotArchive({
+      roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
+      createdAt: new Date(),
+      durableAsOf: new Date(),
+    })).rejects.toThrow('unsupported symbolic link');
+  });
+
+  it('excludes daemon-local state and the Git implementation directory', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-portable-');
+    const vaultRoot = join(sourceHome, 'vaults', 'demo');
+    await mkdir(join(vaultRoot, '.kb1', 'secrets'), { recursive: true });
+    await mkdir(join(vaultRoot, '.kb1', 'cache'), { recursive: true });
+    await mkdir(join(vaultRoot, '.git', 'objects', 'aa'), { recursive: true });
+    await mkdir(join(vaultRoot, '.git', 'refs', 'heads'), { recursive: true });
+    await mkdir(join(vaultRoot, '.KB1', 'Secrets'), { recursive: true });
+    await mkdir(join(vaultRoot, '.GIT'), { recursive: true });
+    await writeFile(join(vaultRoot, '.kb1', 'vault.json'), '{"id":"demo","displayName":"Demo"}\n');
+    await writeFile(join(vaultRoot, '.kb1', 'secrets', 'token'), 'do-not-export');
+    await writeFile(join(vaultRoot, '.kb1', 'cache', 'index'), 'rebuildable');
+    await writeFile(join(vaultRoot, '.git', 'config'), '[remote "origin"]\nurl = secret\n');
+    await writeFile(join(vaultRoot, '.git', 'HEAD'), 'ref: refs/heads/main\n');
+    await writeFile(join(vaultRoot, '.git', 'refs', 'heads', 'main'), 'abc123\n');
+    await writeFile(join(vaultRoot, '.git', 'objects', 'aa', 'object'), 'history');
+    await writeFile(join(vaultRoot, '.KB1', 'Secrets', 'case-token'), 'do-not-export');
+    await writeFile(join(vaultRoot, '.GIT', 'config'), 'case-variant secret');
+
+    const archive = await createSnapshotArchive({
+      roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
+      createdAt: new Date(),
+      durableAsOf: new Date(),
+    });
+    const entries = await readZipEntries(await buffer(archive.stream));
+
+    expect(entries.has('vaults/demo/.kb1/secrets/token')).toBe(false);
+    expect(entries.has('vaults/demo/.kb1/cache/index')).toBe(false);
+    expect(entries.has('vaults/demo/.git/config')).toBe(false);
+    expect(entries.has('vaults/demo/.KB1/Secrets/case-token')).toBe(false);
+    expect(entries.has('vaults/demo/.GIT/config')).toBe(false);
+    expect([...entries.keys()].some((path) => path.startsWith('vaults/demo/.git/'))).toBe(false);
+  });
+
+  it('cancels planning and lazy archive work through an AbortSignal', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-cancel-');
+    const vaultRoot = join(sourceHome, 'vaults', 'demo');
+    await mkdir(vaultRoot, { recursive: true });
+    await writeFile(join(vaultRoot, 'note.md'), 'cancel me\n');
+
+    const planningController = new AbortController();
+    planningController.abort();
+    await expect(createSnapshotArchive({
+      roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
+      createdAt: new Date(),
+      durableAsOf: new Date(),
+      signal: planningController.signal,
+    })).rejects.toMatchObject({ name: 'AbortError' });
+
+    const streamingController = new AbortController();
+    const archive = await createSnapshotArchive({
+      roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
+      createdAt: new Date(),
+      durableAsOf: new Date(),
+      signal: streamingController.signal,
+    });
+    streamingController.abort();
+    await expect(buffer(archive.stream)).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('contains an abort before the caller attaches a stream consumer', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-early-abort-');
+    const vaultRoot = join(sourceHome, 'vaults', 'demo');
+    await mkdir(vaultRoot, { recursive: true });
+    await writeFile(join(vaultRoot, 'note.md'), 'cancel before consume\n');
+    const controller = new AbortController();
+
+    const archive = await createSnapshotArchive({
+      roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
+      createdAt: new Date(),
+      durableAsOf: new Date(),
+      signal: controller.signal,
+    });
+    controller.abort();
+    await new Promise<void>((resolvePromise) => setImmediate(resolvePromise));
+
+    expect(archive.stream.destroyed).toBe(true);
+  });
+
+  it('round-trips an intentionally empty initialized daemon without reseeding', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-empty-source-');
+    const restoredHome = await temporaryDirectory('kb1-snapshot-empty-restored-');
+    await mkdir(join(sourceHome, 'vaults'), { recursive: true });
+    await mkdir(join(sourceHome, '.trash'), { recursive: true });
+    await writeFile(join(sourceHome, 'vaults', DAEMON_INITIALIZED_FILENAME), '1\n');
+
+    const archive = await createSnapshotArchive({
+      roots: [
+        { archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') },
+        { archivePath: '.trash', filesystemPath: join(sourceHome, '.trash') },
+      ],
+      createdAt: new Date(),
+      durableAsOf: new Date(),
+    });
+    await extractZip(await readZipEntries(await buffer(archive.stream)), restoredHome);
+
+    const port = await reservePort();
+    const restored = await startDaemon({
+      env: {
+        KB1_HOME: restoredHome,
+        KB1_HOST: '127.0.0.1',
+        KB1_PORT: String(port),
+      },
+    });
+    try {
+      const response = await fetch(`http://127.0.0.1:${String(port)}/api/vaults`);
+      await expect(response.json()).resolves.toEqual({ ok: true, vaults: [] });
+    } finally {
+      await restored.close();
+    }
+  });
+
+  it('fails closed for file names that ZIP tools would reinterpret as paths', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-backslash-');
+    const vaultRoot = join(sourceHome, 'vaults', 'demo');
+    await mkdir(vaultRoot, { recursive: true });
+    await writeFile(join(vaultRoot, 'one\\two.md'), 'ambiguous\n');
+
+    await expect(createSnapshotArchive({
+      roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
+      createdAt: new Date(),
+      durableAsOf: new Date(),
+    })).rejects.toThrow('non-portable path segment');
+  });
+
+  it('fails closed for Windows-reserved path segments', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-reserved-');
+    const vaultRoot = join(sourceHome, 'vaults', 'demo');
+    await mkdir(vaultRoot, { recursive: true });
+    await writeFile(join(vaultRoot, 'con.md'), 'not portable\n');
+
+    await expect(createSnapshotArchive({
+      roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
+      createdAt: new Date(),
+      durableAsOf: new Date(),
+    })).rejects.toThrow('non-portable path segment');
+  });
+
+  it('fails closed when target filesystems would collapse distinct archive paths', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-collision-');
+    const firstRoot = join(sourceHome, 'first');
+    const secondRoot = join(sourceHome, 'second');
+    await mkdir(firstRoot, { recursive: true });
+    await mkdir(secondRoot, { recursive: true });
+    await writeFile(join(firstRoot, 'note.md'), 'first\n');
+    await writeFile(join(secondRoot, 'note.md'), 'second\n');
+
+    await expect(createSnapshotArchive({
+      roots: [
+        { archivePath: 'vaults/Demo', filesystemPath: firstRoot },
+        { archivePath: 'vaults/demo', filesystemPath: secondRoot },
+      ],
+      createdAt: new Date(),
+      durableAsOf: new Date(),
+    })).rejects.toThrow('colliding portable paths');
+  });
+
+  it('fails the ZIP stream when the source tree changes after planning', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-changing-');
+    const vaultRoot = join(sourceHome, 'vaults', 'demo');
+    await mkdir(vaultRoot, { recursive: true });
+    await writeFile(join(vaultRoot, 'before.md'), 'planned\n');
+
+    const archive = await createSnapshotArchive({
+      roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
+      createdAt: new Date(),
+      durableAsOf: new Date(),
+    });
+    await writeFile(join(vaultRoot, 'after.md'), 'not planned\n');
+
+    await expect(buffer(archive.stream)).rejects.toThrow(
+      'Snapshot source changed while archiving'
+    );
+  });
+
+  it('fails the ZIP stream when an initially absent root appears after planning', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-new-root-');
+    const trashRoot = join(sourceHome, '.trash');
+    const archive = await createSnapshotArchive({
+      roots: [{ archivePath: '.trash', filesystemPath: trashRoot }],
+      createdAt: new Date(),
+      durableAsOf: new Date(),
+    });
+    await mkdir(join(trashRoot, 'deleted-vault'), { recursive: true });
+    await writeFile(join(trashRoot, 'deleted-vault', 'note.md'), 'appeared\n');
+
+    await expect(buffer(archive.stream)).rejects.toThrow(
+      'Snapshot source changed while archiving'
+    );
+  });
+
+  it('fails the ZIP stream when source permissions change after planning', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-mode-changing-');
+    const vaultRoot = join(sourceHome, 'vaults', 'demo');
+    const file = join(vaultRoot, 'script.sh');
+    await mkdir(vaultRoot, { recursive: true });
+    await writeFile(file, '#!/bin/sh\n');
+    await chmod(file, 0o600);
+
+    const archive = await createSnapshotArchive({
+      roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
+      createdAt: new Date(),
+      durableAsOf: new Date(),
+    });
+    await chmod(file, 0o700);
+
+    await expect(buffer(archive.stream)).rejects.toThrow(
+      'Snapshot source changed while archiving'
+    );
+  });
+
+  it('fails the ZIP stream after a same-size rewrite with restored mtime', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-content-changing-');
+    const vaultRoot = join(sourceHome, 'vaults', 'demo');
+    const file = join(vaultRoot, 'note.md');
+    await mkdir(vaultRoot, { recursive: true });
+    await writeFile(file, 'before\n');
+    const original = await stat(file);
+
+    const archive = await createSnapshotArchive({
+      roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
+      createdAt: new Date(),
+      durableAsOf: new Date(),
+    });
+    await writeFile(file, 'after!\n');
+    await utimes(file, original.atime, original.mtime);
+
+    await expect(buffer(archive.stream)).rejects.toThrow(
+      'Snapshot source changed while archiving'
+    );
+  });
+});
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), prefix));
+  cleanupPaths.push(path);
+  return path;
+}
+
+async function readZipEntries(archive: Buffer): Promise<Map<string, Buffer>> {
+  const zip = await fromBufferPromise(archive, { lazyEntries: true });
+  const entries = new Map<string, Buffer>();
+  for await (const entry of zip.eachEntry()) {
+    if (entry.fileName.endsWith('/')) continue;
+    const stream = await zip.openReadStreamPromise(entry);
+    entries.set(entry.fileName, await buffer(stream));
+  }
+  zip.close();
+  return entries;
+}
+
+async function extractZip(entries: Map<string, Buffer>, targetRoot: string): Promise<void> {
+  const canonicalRoot = `${resolve(targetRoot)}/`;
+  for (const [entryPath, bytes] of entries) {
+    if (entryPath === SNAPSHOT_MANIFEST_PATH) continue;
+    const target = resolve(targetRoot, entryPath);
+    if (!target.startsWith(canonicalRoot)) {
+      throw new Error(`Archive entry escaped restore root: ${entryPath}`);
+    }
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, bytes);
+  }
+}
+
+async function reservePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once('error', rejectListen);
+    server.listen(0, '127.0.0.1', () => resolveListen());
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Could not reserve test port.');
+  const port = address.port;
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => error ? rejectClose(error) : resolveClose());
+  });
+  return port;
+}

--- a/apps/daemon/src/snapshot-archive.ts
+++ b/apps/daemon/src/snapshot-archive.ts
@@ -350,8 +350,13 @@ function assertPortableArchiveSegment(segment: string): void {
 }
 
 function isPortableSnapshotPath(path: string): boolean {
-  const segments = path.split('/').map((segment) => segment.toLocaleLowerCase('en-US'));
+  const originalSegments = path.split('/');
+  const segments = originalSegments.map((segment) => segment.toLocaleLowerCase('en-US'));
   const kb1Index = segments.lastIndexOf('.kb1');
+  // `.kb1` is a reserved metadata directory whose canonical spelling is
+  // lowercase. A distinct case-variant can exist on Linux but would collide
+  // when the portable archive is restored on Windows or common macOS volumes.
+  if (kb1Index >= 0 && originalSegments[kb1Index] !== '.kb1') return false;
   if (
     kb1Index >= 0
     && segments.length > kb1Index + 1

--- a/apps/daemon/src/snapshot-archive.ts
+++ b/apps/daemon/src/snapshot-archive.ts
@@ -1,0 +1,514 @@
+import { lstat, open, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import type { Stats } from 'node:fs';
+import { Readable, Transform } from 'node:stream';
+
+import { ZipFile } from 'yazl';
+
+export const SNAPSHOT_ARCHIVE_SCHEMA_VERSION = 1;
+export const SNAPSHOT_MANIFEST_PATH = 'kb1-snapshot.json';
+export const SNAPSHOT_COMPLETION_PATH = 'kb1-snapshot.complete';
+
+export interface SnapshotArchiveFile {
+  path: string;
+  sizeBytes: number;
+  modifiedAt: string;
+  mode: number;
+  sha256: string;
+}
+
+export interface SnapshotArchiveManifest {
+  schemaVersion: typeof SNAPSHOT_ARCHIVE_SCHEMA_VERSION;
+  createdAt: string;
+  durableAsOf: string;
+  files: SnapshotArchiveFile[];
+  totals: {
+    files: number;
+    bytes: number;
+  };
+}
+
+export interface SnapshotArchive {
+  stream: Readable;
+  manifest: SnapshotArchiveManifest;
+}
+
+interface SnapshotRoot {
+  archivePath: string;
+  filesystemPath: string;
+}
+
+interface PlannedFile extends SnapshotArchiveFile {
+  filesystemPath: string;
+  device: number;
+  inode: number;
+  modifiedAtMs: number;
+  changedAtMs: number;
+}
+
+interface PlannedDirectory {
+  path: string;
+  filesystemPath: string;
+  modifiedAt: Date;
+  device: number;
+  inode: number;
+  modifiedAtMs: number;
+  changedAtMs: number;
+  mode: number;
+}
+
+const LOCAL_KB1_DIRECTORY_NAMES = new Set(['cache', 'runtime', 'secrets', 'tmp']);
+const WINDOWS_RESERVED_BASENAME = /^(?:con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])(?:\.|$)/i;
+const WINDOWS_INVALID_CHARACTER = /[<>:"\\|?*\u0000-\u001f]/;
+
+/**
+ * Build one portable ZIP containing every active vault plus the daemon trash.
+ * Callers must flush live document sessions before invoking this function.
+ *
+ * Files are planned with lstat and reopened lazily as yazl consumes them. If a
+ * file was replaced between planning and streaming, the stream fails instead
+ * of silently producing a mixed snapshot. Hosted daemon writes are atomic
+ * renames, so this detects the concurrent-write shape that matters there.
+ */
+export async function createSnapshotArchive(input: {
+  roots: SnapshotRoot[];
+  createdAt: Date;
+  durableAsOf: Date;
+  signal?: AbortSignal;
+}): Promise<SnapshotArchive> {
+  throwIfSnapshotAborted(input.signal);
+  const plan = await planSnapshot(input.roots, input.signal);
+  throwIfSnapshotAborted(input.signal);
+  const manifest: SnapshotArchiveManifest = {
+    schemaVersion: SNAPSHOT_ARCHIVE_SCHEMA_VERSION,
+    createdAt: input.createdAt.toISOString(),
+    durableAsOf: input.durableAsOf.toISOString(),
+    files: plan.files.map((file) => manifestFile(file)),
+    totals: {
+      files: plan.files.length,
+      bytes: plan.files.reduce((total, file) => total + file.sizeBytes, 0),
+    },
+  };
+
+  const archive = new ZipFile();
+  const outputStream = archive.outputStream as Readable;
+  // Creation returns before the HTTP caller can attach pipeline listeners.
+  // Keep cancellation or lazy ZIP failures in that gap from becoming an
+  // uncaught process-level error; downstream consumers still receive the same
+  // error event and reject normally.
+  outputStream.on('error', () => undefined);
+  const activeSources = new Set<Readable>();
+  let stopped = false;
+  archive.on('error', (error: Error) => {
+    outputStream.destroy(error);
+  });
+  const abortHandler = () => {
+    stopped = true;
+    outputStream.destroy(snapshotAbortError(input.signal));
+  };
+  input.signal?.addEventListener('abort', abortHandler, { once: true });
+  outputStream.once('close', () => {
+    stopped = true;
+    input.signal?.removeEventListener('abort', abortHandler);
+    for (const source of activeSources) source.destroy();
+    activeSources.clear();
+  });
+  archive.addBuffer(
+    Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, 'utf8'),
+    SNAPSHOT_MANIFEST_PATH,
+    { mtime: input.createdAt, mode: 0o100600 },
+  );
+  for (const directory of plan.directories) {
+    archive.addEmptyDirectory(directory.path, {
+      mtime: directory.modifiedAt,
+      mode: directory.mode,
+    });
+  }
+  for (const file of plan.files) {
+    archive.addReadStreamLazy(
+      file.path,
+      {
+        mtime: new Date(file.modifiedAt),
+        mode: file.mode,
+        size: file.sizeBytes,
+        compress: true,
+      },
+      (callback) => {
+        if (stopped || input.signal?.aborted) {
+          callback(snapshotAbortError(input.signal), Readable.from([]));
+          return;
+        }
+        void open(file.filesystemPath, 'r').then(async (handle) => {
+          try {
+            if (stopped || input.signal?.aborted) {
+              await handle.close();
+              callback(snapshotAbortError(input.signal), Readable.from([]));
+              return;
+            }
+            const current = await handle.stat();
+            if (stopped || input.signal?.aborted) {
+              await handle.close();
+              callback(snapshotAbortError(input.signal), Readable.from([]));
+              return;
+            }
+            if (
+              current.dev !== file.device
+              || current.ino !== file.inode
+              || current.size !== file.sizeBytes
+              || current.mtimeMs !== file.modifiedAtMs
+              || current.ctimeMs !== file.changedAtMs
+              || current.mode !== file.mode
+            ) {
+              await handle.close();
+              callback(new Error('Snapshot source changed while archiving.'), Readable.from([]));
+              return;
+            }
+            const source = handle.createReadStream({ autoClose: true });
+            const verifier = createHashVerifyingStream(file.sha256);
+            // yazl's lazy stream API does not subscribe to source errors. Keep
+            // one listener here so an EIO fails the HTTP body instead of
+            // becoming an unhandled process error or a permanently open ZIP.
+            source.once('error', (error) => archive.emit('error', error));
+            verifier.once('error', (error) => archive.emit('error', error));
+            activeSources.add(source);
+            activeSources.add(verifier);
+            source.once('close', () => activeSources.delete(source));
+            verifier.once('close', () => activeSources.delete(verifier));
+            source.pipe(verifier);
+            callback(null, verifier);
+          } catch (error) {
+            await handle.close().catch(() => undefined);
+            callback(error, Readable.from([]));
+          }
+        }, (error: unknown) => callback(error, Readable.from([])));
+      },
+    );
+  }
+  const completion = Buffer.from(`${input.createdAt.toISOString()}\n`, 'utf8');
+  archive.addReadStreamLazy(
+    SNAPSHOT_COMPLETION_PATH,
+    {
+      mtime: input.createdAt,
+      mode: 0o100600,
+      size: completion.byteLength,
+      compress: false
+    },
+    (callback) => {
+      if (stopped || input.signal?.aborted) {
+        callback(snapshotAbortError(input.signal), Readable.from([]));
+        return;
+      }
+      void validateSnapshotPlan(plan, input.signal).then(
+        () => callback(null, Readable.from(completion)),
+        (error: unknown) => callback(error, Readable.from([]))
+      );
+    }
+  );
+  archive.end();
+
+  return {
+    stream: outputStream,
+    manifest,
+  };
+}
+
+async function planSnapshot(roots: SnapshotRoot[], signal?: AbortSignal): Promise<{
+  files: PlannedFile[];
+  directories: PlannedDirectory[];
+  missingRoots: SnapshotRoot[];
+}> {
+  const files: PlannedFile[] = [];
+  const directories: PlannedDirectory[] = [];
+  const missingRoots: SnapshotRoot[] = [];
+  for (const root of roots) {
+    throwIfSnapshotAborted(signal);
+    const rootInfo = await lstatOrNull(root.filesystemPath);
+    throwIfSnapshotAborted(signal);
+    if (!rootInfo) {
+      missingRoots.push(root);
+      continue;
+    }
+    if (!rootInfo.isDirectory()) {
+      throw new Error(`Snapshot root is not a directory: ${root.archivePath}`);
+    }
+    directories.push({
+      path: archiveDirectoryPath(root.archivePath),
+      filesystemPath: root.filesystemPath,
+      modifiedAt: rootInfo.mtime,
+      modifiedAtMs: rootInfo.mtimeMs,
+      changedAtMs: rootInfo.ctimeMs,
+      device: rootInfo.dev,
+      inode: rootInfo.ino,
+      mode: rootInfo.mode,
+    });
+    await walkSnapshotRoot(root.filesystemPath, root.archivePath, files, directories, signal);
+  }
+  files.sort((left, right) => left.path.localeCompare(right.path));
+  directories.sort((left, right) => left.path.localeCompare(right.path));
+  validatePortableArchivePaths(files, directories);
+  return { files, directories, missingRoots };
+}
+
+async function walkSnapshotRoot(
+  filesystemPath: string,
+  archivePath: string,
+  files: PlannedFile[],
+  directories: PlannedDirectory[],
+  signal?: AbortSignal,
+): Promise<void> {
+  throwIfSnapshotAborted(signal);
+  const entries = await readdir(filesystemPath, { withFileTypes: true });
+  throwIfSnapshotAborted(signal);
+  entries.sort((left, right) => left.name.localeCompare(right.name));
+  for (const entry of entries) {
+    throwIfSnapshotAborted(signal);
+    const childFilesystemPath = join(filesystemPath, entry.name);
+    const childArchivePath = `${archivePath}/${entry.name}`;
+    if (!isPortableSnapshotPath(childArchivePath)) continue;
+    const info = await lstat(childFilesystemPath);
+    throwIfSnapshotAborted(signal);
+    if (info.isSymbolicLink()) {
+      throw new Error('Snapshot source contains an unsupported symbolic link.');
+    }
+    if (info.isDirectory()) {
+      directories.push({
+        path: archiveDirectoryPath(childArchivePath),
+        filesystemPath: childFilesystemPath,
+        modifiedAt: info.mtime,
+        modifiedAtMs: info.mtimeMs,
+        changedAtMs: info.ctimeMs,
+        device: info.dev,
+        inode: info.ino,
+        mode: info.mode,
+      });
+      await walkSnapshotRoot(childFilesystemPath, childArchivePath, files, directories, signal);
+      continue;
+    }
+    if (!info.isFile()) {
+      throw new Error('Snapshot source contains an unsupported filesystem entry.');
+    }
+    const plannedFile = {
+      path: childArchivePath,
+      filesystemPath: childFilesystemPath,
+      sizeBytes: info.size,
+      modifiedAt: info.mtime.toISOString(),
+      modifiedAtMs: info.mtimeMs,
+      changedAtMs: info.ctimeMs,
+      mode: info.mode,
+      device: info.dev,
+      inode: info.ino,
+    };
+    files.push({
+      ...plannedFile,
+      sha256: await hashSnapshotFile(plannedFile, signal),
+    });
+  }
+}
+
+function validatePortableArchivePaths(
+  files: PlannedFile[],
+  directories: PlannedDirectory[],
+): void {
+  const paths = [
+    SNAPSHOT_MANIFEST_PATH,
+    SNAPSHOT_COMPLETION_PATH,
+    ...directories.map((directory) => directory.path.replace(/\/$/, '')),
+    ...files.map((file) => file.path),
+  ];
+  const canonicalPaths = new Map<string, string>();
+
+  for (const path of paths) {
+    const segments = path.split('/');
+    for (const segment of segments) assertPortableArchiveSegment(segment);
+
+    // Windows and common macOS installations compare names without case, and
+    // macOS also normalizes canonically equivalent Unicode. Reject collisions
+    // up front so extraction cannot silently merge two source entries.
+    const canonicalPath = segments
+      .map((segment) => segment.normalize('NFC').toLocaleLowerCase('en-US'))
+      .join('/');
+    const existing = canonicalPaths.get(canonicalPath);
+    if (existing !== undefined) {
+      throw new Error(`Snapshot source contains colliding portable paths: ${existing} and ${path}`);
+    }
+    canonicalPaths.set(canonicalPath, path);
+  }
+}
+
+function assertPortableArchiveSegment(segment: string): void {
+  if (
+    segment.length === 0
+    || segment === '.'
+    || segment === '..'
+    || WINDOWS_INVALID_CHARACTER.test(segment)
+    || /[. ]$/.test(segment)
+    || WINDOWS_RESERVED_BASENAME.test(segment)
+  ) {
+    throw new Error(`Snapshot source contains a non-portable path segment: ${JSON.stringify(segment)}`);
+  }
+}
+
+function isPortableSnapshotPath(path: string): boolean {
+  const segments = path.split('/').map((segment) => segment.toLocaleLowerCase('en-US'));
+  const kb1Index = segments.lastIndexOf('.kb1');
+  if (
+    kb1Index >= 0
+    && segments.length > kb1Index + 1
+    && LOCAL_KB1_DIRECTORY_NAMES.has(segments[kb1Index + 1] ?? '')
+  ) {
+    return false;
+  }
+
+  const gitIndex = segments.lastIndexOf('.git');
+  if (gitIndex < 0) return true;
+  return false;
+}
+
+function manifestFile(file: PlannedFile): SnapshotArchiveFile {
+  return {
+    path: file.path,
+    sizeBytes: file.sizeBytes,
+    modifiedAt: file.modifiedAt,
+    mode: file.mode,
+    sha256: file.sha256,
+  };
+}
+
+async function validateSnapshotPlan(plan: {
+  files: PlannedFile[];
+  directories: PlannedDirectory[];
+  missingRoots: SnapshotRoot[];
+}, signal?: AbortSignal): Promise<void> {
+  for (const root of plan.missingRoots) {
+    throwIfSnapshotAborted(signal);
+    const current = await lstatOrNull(root.filesystemPath);
+    throwIfSnapshotAborted(signal);
+    if (current !== null) {
+      throw new Error('Snapshot source changed while archiving.');
+    }
+  }
+  for (const directory of plan.directories) {
+    throwIfSnapshotAborted(signal);
+    const current = await lstat(directory.filesystemPath);
+    throwIfSnapshotAborted(signal);
+    if (
+      !current.isDirectory()
+      || current.dev !== directory.device
+      || current.ino !== directory.inode
+      || current.mtimeMs !== directory.modifiedAtMs
+      || current.ctimeMs !== directory.changedAtMs
+      || current.mode !== directory.mode
+    ) {
+      throw new Error('Snapshot source changed while archiving.');
+    }
+  }
+  for (const file of plan.files) {
+    throwIfSnapshotAborted(signal);
+    const current = await lstat(file.filesystemPath);
+    throwIfSnapshotAborted(signal);
+    if (
+      !current.isFile()
+      || current.dev !== file.device
+      || current.ino !== file.inode
+      || current.size !== file.sizeBytes
+      || current.mtimeMs !== file.modifiedAtMs
+      || current.ctimeMs !== file.changedAtMs
+      || current.mode !== file.mode
+    ) {
+      throw new Error('Snapshot source changed while archiving.');
+    }
+  }
+}
+
+async function hashSnapshotFile(file: Omit<PlannedFile, 'sha256'>, signal?: AbortSignal): Promise<string> {
+  throwIfSnapshotAborted(signal);
+  const handle = await open(file.filesystemPath, 'r');
+  try {
+    const before = await handle.stat();
+    if (!matchesPlannedFile(before, file)) {
+      throw new Error('Snapshot source changed while archiving.');
+    }
+    const hash = createHash('sha256');
+    const readBuffer = Buffer.allocUnsafe(256 * 1024);
+    let position = 0;
+    for (;;) {
+      throwIfSnapshotAborted(signal);
+      const { bytesRead } = await handle.read(
+        readBuffer,
+        0,
+        readBuffer.byteLength,
+        position,
+      );
+      if (bytesRead === 0) break;
+      hash.update(readBuffer.subarray(0, bytesRead));
+      position += bytesRead;
+    }
+    throwIfSnapshotAborted(signal);
+    const after = await handle.stat();
+    if (!matchesPlannedFile(after, file)) {
+      throw new Error('Snapshot source changed while archiving.');
+    }
+    return hash.digest('hex');
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
+
+function matchesPlannedFile(
+  current: Stats,
+  file: Omit<PlannedFile, 'sha256'>,
+): boolean {
+  return current.isFile()
+    && current.dev === file.device
+    && current.ino === file.inode
+    && current.size === file.sizeBytes
+    && current.mtimeMs === file.modifiedAtMs
+    && current.ctimeMs === file.changedAtMs
+    && current.mode === file.mode;
+}
+
+function createHashVerifyingStream(expectedSha256: string): Transform {
+  const hash = createHash('sha256');
+  return new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      hash.update(chunk);
+      callback(null, chunk);
+    },
+    flush(callback) {
+      if (hash.digest('hex') !== expectedSha256) {
+        callback(new Error('Snapshot source changed while archiving.'));
+        return;
+      }
+      callback();
+    },
+  });
+}
+
+function throwIfSnapshotAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw snapshotAbortError(signal);
+}
+
+function snapshotAbortError(signal?: AbortSignal): Error {
+  if (signal?.reason instanceof Error) return signal.reason;
+  const error = new Error('Snapshot creation was canceled.');
+  error.name = 'AbortError';
+  return error;
+}
+
+function archiveDirectoryPath(path: string): string {
+  return path.endsWith('/') ? path : `${path}/`;
+}
+
+async function lstatOrNull(path: string) {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    if (isNodeErrorCode(error, 'ENOENT')) return null;
+    throw error;
+  }
+}
+
+function isNodeErrorCode(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error && error.code === code;
+}

--- a/apps/daemon/src/vault-registry.ts
+++ b/apps/daemon/src/vault-registry.ts
@@ -8,6 +8,7 @@ import { slug as githubSlug } from 'github-slugger';
 
 import { seedVaultFromStarterKit } from './starter-kit.js';
 import { migrateDirectoryCopyVerifyCleanup, verifyCopy } from './migrations.js';
+import { createSnapshotArchive, type SnapshotArchive } from './snapshot-archive.js';
 
 const VAULT_IDENTITY_DIR = '.kb1';
 const LEGACY_VAULT_IDENTITY_DIR = '.kb2';
@@ -398,6 +399,38 @@ export class VaultRegistry {
       await directorySizeBytes(this.vaultsHome) +
       await directorySizeBytes(this.trashHome)
     );
+  }
+
+  /** Flush all live documents, then stream a portable snapshot of vaults + trash. */
+  async createSnapshotArchive(
+    now: Date = new Date(),
+    signal?: AbortSignal,
+  ): Promise<SnapshotArchive> {
+    // This is deliberately captured before any flush begins. Concurrent edits
+    // may land while a multi-vault snapshot is being prepared, so a later
+    // timestamp would claim a durability boundary we cannot globally fence.
+    const durableAsOf = new Date(now.getTime());
+    const results = await Promise.allSettled(
+      [...this.instances.values()].map((instance) => instance.service.flushDirtySessions()),
+    );
+    const rejected = results.find((result) => result.status === 'rejected');
+    if (rejected) throw rejected.reason;
+    const failed = results.find(
+      (result) => result.status === 'fulfilled' && !result.value.ok
+    );
+    if (failed?.status === 'fulfilled' && !failed.value.ok) {
+      throw new Error(failed.value.message);
+    }
+
+    return createSnapshotArchive({
+      roots: [
+        { archivePath: 'vaults', filesystemPath: this.vaultsHome },
+        { archivePath: VAULT_TRASH_DIRNAME, filesystemPath: this.trashHome },
+      ],
+      createdAt: now,
+      durableAsOf,
+      signal,
+    });
   }
 
   /** Resolve a vault's live instance by slug, or `undefined` when unknown. */

--- a/packages/tunnel-client/src/heartbeat.test.ts
+++ b/packages/tunnel-client/src/heartbeat.test.ts
@@ -97,6 +97,7 @@ describe('TunnelClient control heartbeat', () => {
         TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V2,
         TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
         TUNNEL_FEATURES.HTTP_RESPONSE_CHUNK_ACKS_V1,
+        TUNNEL_FEATURES.SNAPSHOT_STREAM_V1,
       ],
     }));
 
@@ -253,6 +254,7 @@ describe('TunnelClient control heartbeat', () => {
         TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V2,
         TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
         TUNNEL_FEATURES.HTTP_RESPONSE_CHUNK_ACKS_V1,
+        TUNNEL_FEATURES.SNAPSHOT_STREAM_V1,
       ],
     }));
   });

--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -1248,6 +1248,315 @@ describe('TunnelClient typed relay RPC', () => {
 });
 
 describe('TunnelClient HTTP proxy cancellation', () => {
+  it('does not expose the whole-home snapshot endpoint through the relay', async () => {
+    const fetchImpl = vi.fn();
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+    const control = new FakeSocket();
+    control.open();
+
+    const handleControlMessage = (
+      client as unknown as {
+        handleControlMessage(control: FakeSocket, data: Buffer): Promise<void>;
+      }
+    ).handleControlMessage.bind(client);
+    const paths = [
+      '/api/ops/snapshot.zip?source=relay',
+      '/api/ops/%73napshot.zip',
+      '/api/ops/snap%73hot.zip',
+    ];
+    for (const [index, path] of paths.entries()) {
+      await handleControlMessage(
+        control,
+        Buffer.from(encodeTunnelMessage({
+          type: 'http.request',
+          id: `private-snapshot-${index}`,
+          method: 'GET',
+          path,
+          headers: {},
+          bodyB64: null,
+        })),
+      );
+    }
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(control.sent).toHaveLength(paths.length);
+    for (const [index, sent] of control.sent.entries()) {
+      const response = JSON.parse(
+        Buffer.from(sent.data as Uint8Array).toString('utf8'),
+      ) as TunnelHttpResponseEnvelope;
+      expect(response).toMatchObject({
+        type: 'http.response',
+        id: `private-snapshot-${index}`,
+        status: 404,
+      });
+      expect(Buffer.from(response.bodyB64 ?? '', 'base64').toString('utf8')).toBe('Not found\n');
+    }
+  });
+
+  it('keeps ordinary relay HTTP on the daemon origin and does not follow redirects', async () => {
+    const fetchImpl = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, {
+          status: 302,
+          headers: { location: '/api/ops/snapshot.zip' },
+        }),
+    );
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+    const control = new FakeSocket();
+    control.open();
+    const handleControlMessage = (
+      client as unknown as {
+        handleControlMessage(control: FakeSocket, data: Buffer): Promise<void>;
+      }
+    ).handleControlMessage.bind(client);
+
+    await handleControlMessage(
+      control,
+      Buffer.from(encodeTunnelMessage({
+        type: 'http.request',
+        id: 'external-origin',
+        method: 'GET',
+        path: '//attacker.example/start',
+        headers: {},
+        bodyB64: null,
+      })),
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    await handleControlMessage(
+      control,
+      Buffer.from(encodeTunnelMessage({
+        type: 'http.request',
+        id: 'redirecting-daemon-route',
+        method: 'GET',
+        path: '/redirect-me',
+        headers: {},
+        bodyB64: null,
+      })),
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0]?.[1]).toMatchObject({ redirect: 'manual' });
+    const response = JSON.parse(
+      Buffer.from(control.sent.at(-1)?.data as Uint8Array).toString('utf8'),
+    ) as TunnelHttpResponseEnvelope;
+    expect(response).toMatchObject({
+      type: 'http.response',
+      id: 'redirecting-daemon-route',
+      status: 302,
+    });
+  });
+
+  it('streams a dedicated private snapshot request without materializing its body', async () => {
+    const archive = Buffer.alloc(384 * 1024, 0xa5);
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(new URL(input.toString()).pathname).toBe('/api/ops/snapshot.zip');
+      expect(new Headers(init?.headers).has('x-kb1-internal-snapshot-relay')).toBe(false);
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(archive.subarray(0, 123_457));
+          controller.enqueue(archive.subarray(123_457));
+          controller.close();
+        },
+      }), {
+        headers: {
+          'content-length': String(archive.byteLength),
+          'content-type': 'application/zip',
+        },
+      });
+    });
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+    const control = new FakeSocket();
+    control.open();
+    acknowledgeHttpResponseChunks(client, control);
+    await advertiseHttpResponseChunkAcks(client, control);
+
+    await (
+      client as unknown as {
+        handleControlMessage(control: FakeSocket, data: Buffer): Promise<void>;
+      }
+    ).handleControlMessage(
+      control,
+      Buffer.from(encodeTunnelMessage({
+        type: 'snapshot.request',
+        id: 'authorized-private-snapshot',
+      })),
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const frames = control.sent.map(({ data }) =>
+      JSON.parse(Buffer.from(data as Uint8Array).toString('utf8')) as {
+        type: string;
+        bodyB64?: string;
+        totalBytes?: number;
+      },
+    );
+    expect(frames[0]).toMatchObject({
+      type: 'http.response.start',
+      totalBytes: archive.byteLength,
+    });
+    expect(frames.at(-1)).toMatchObject({ type: 'http.response.end' });
+    expect(Buffer.concat(
+      frames
+        .filter((frame) => frame.type === 'http.response.chunk')
+        .map((frame) => Buffer.from(frame.bodyB64 ?? '', 'base64')),
+    )).toEqual(archive);
+  });
+
+  it('cancels the daemon snapshot body when relaying a response chunk fails', async () => {
+    let bodyCanceled = false;
+    const fetchImpl = vi.fn(async () => new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(Buffer.alloc(64 * 1024, 0xa5));
+      },
+      cancel() {
+        bodyCanceled = true;
+      },
+    }), {
+      headers: {
+        'content-length': String(128 * 1024),
+        'content-type': 'application/zip',
+      },
+    }));
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+    const control = new FakeSocket();
+    control.open();
+    await advertiseHttpResponseChunkAcks(client, control);
+    control.onSend = (data) => {
+      const message = JSON.parse(Buffer.from(data as Uint8Array).toString('utf8')) as {
+        type: string;
+      };
+      if (message.type === 'http.response.chunk') {
+        throw new Error('relay socket write failed');
+      }
+    };
+
+    await (
+      client as unknown as {
+        handleControlMessage(control: FakeSocket, data: Buffer): Promise<void>;
+      }
+    ).handleControlMessage(
+      control,
+      Buffer.from(encodeTunnelMessage({
+        type: 'snapshot.request',
+        id: 'snapshot-relay-write-failure',
+      })),
+    );
+
+    expect(bodyCanceled).toBe(true);
+  });
+
+  it('rejects snapshot streaming when chunk acknowledgements were not negotiated', async () => {
+    const fetchImpl = vi.fn();
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+    const control = new FakeSocket();
+    control.open();
+
+    await (
+      client as unknown as {
+        handleControlMessage(control: FakeSocket, data: Buffer): Promise<void>;
+      }
+    ).handleControlMessage(
+      control,
+      Buffer.from(encodeTunnelMessage({
+        type: 'snapshot.request',
+        id: 'snapshot-without-acks',
+      })),
+    );
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    const response = JSON.parse(
+      Buffer.from(control.sent.at(-1)?.data as Uint8Array).toString('utf8'),
+    ) as TunnelHttpResponseEnvelope;
+    expect(response).toMatchObject({
+      type: 'http.response',
+      id: 'snapshot-without-acks',
+      status: 503,
+    });
+  });
+
+  it('keeps snapshot preparation alive until the relay cancels it', async () => {
+    let observedSignal: AbortSignal | undefined;
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      observedSignal = init?.signal as AbortSignal | undefined;
+      await new Promise((_resolve, reject) => {
+        observedSignal?.addEventListener(
+          'abort',
+          () => reject(new Error('aborted')),
+          { once: true },
+        );
+      });
+      return new Response('late');
+    });
+    const client = new TunnelClient({
+      relayUrl: new URL('ws://relay.test/t/demo'),
+      daemonUrl: new URL('http://daemon.test'),
+      token: 'token',
+      fetch: fetchImpl as typeof fetch,
+    });
+    const control = new FakeSocket();
+    control.open();
+    await advertiseHttpResponseChunkAcks(client, control);
+    const handleControlMessage = (
+      client as unknown as {
+        handleControlMessage(control: FakeSocket, data: Buffer): Promise<void>;
+      }
+    ).handleControlMessage.bind(client);
+
+    vi.useFakeTimers();
+    try {
+      const request = handleControlMessage(
+        control,
+        Buffer.from(encodeTunnelMessage({
+          type: 'snapshot.request',
+          id: 'long-snapshot-preparation',
+        })),
+      );
+      expect(observedSignal).toBeDefined();
+
+      await vi.advanceTimersByTimeAsync(10 * 60_000 + 1);
+      expect(observedSignal?.aborted).toBe(false);
+
+      await handleControlMessage(
+        control,
+        Buffer.from(encodeTunnelMessage({
+          type: 'http.cancel',
+          id: 'long-snapshot-preparation',
+          reason: 'relay idle timeout',
+        })),
+      );
+      await request;
+      expect(observedSignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('aborts an in-flight daemon HTTP fetch when the relay sends http.cancel', async () => {
     let observedSignal: AbortSignal | undefined;
     const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {

--- a/packages/tunnel-client/src/index.ts
+++ b/packages/tunnel-client/src/index.ts
@@ -27,6 +27,7 @@ import {
   type TunnelHttpResponseChunkEnvelope,
   type TunnelHttpResponseEnvelope,
   type TunnelJsonMessage,
+  type TunnelSnapshotRequestEnvelope,
   type TunnelWebSocketDataAckEnvelope,
   type TunnelWebSocketDataEnvelope,
   type TunnelWebSocketOpenEnvelope,
@@ -78,6 +79,28 @@ export type BackoffOptions = {
 const DEFAULT_BACKOFF_BASE_MS = 250;
 const DEFAULT_BACKOFF_MAX_MS = 10_000;
 const DEFAULT_BACKOFF_JITTER_RATIO = 0.25;
+const PRIVATE_DAEMON_HTTP_PATHS = new Set(['/api/ops/snapshot.zip']);
+
+function daemonRoutingPath(pathname: string): string {
+  // Match Hono's default getPath decoding. In particular, preserve encoded
+  // percent signs so a doubly encoded path is not decoded more times here than
+  // it is by the daemon router.
+  const escapedPercentSigns = pathname.includes('%25')
+    ? pathname.replace(/%25/gi, '%2525')
+    : pathname;
+  try {
+    return decodeURI(escapedPercentSigns);
+  } catch {
+    return escapedPercentSigns.replace(/(?:%[0-9A-Fa-f]{2})+/g, (match) => {
+      try {
+        return decodeURI(match);
+      } catch {
+        return match;
+      }
+    });
+  }
+}
+
 const MCP_RELAY_CLIENT_NAME = 'kb-1-cloud-relay';
 const MCP_RELAY_MAX_PAYLOAD_BYTES = 192 * 1024;
 const MAX_MCP_TOOL_NAME_BYTES = 256;
@@ -282,6 +305,7 @@ export class TunnelClient {
           TUNNEL_FEATURES.VAULT_CONTENT_EVENTS_V2,
           TUNNEL_FEATURES.MCP_TOOL_CALL_BOUNDED_RESULTS_V1,
           TUNNEL_FEATURES.HTTP_RESPONSE_CHUNK_ACKS_V1,
+          TUNNEL_FEATURES.SNAPSHOT_STREAM_V1,
         ],
       }));
       this.startControlHeartbeat(control);
@@ -363,6 +387,9 @@ export class TunnelClient {
         return;
       case 'http.request':
         await this.proxyAndSendHttpResponse(control, message);
+        return;
+      case 'snapshot.request':
+        await this.proxyAndSendSnapshotResponse(control, message);
         return;
       case 'http.request.start':
         this.httpAssembler.start(message);
@@ -740,6 +767,23 @@ export class TunnelClient {
 
   private async proxyHttp(envelope: TunnelHttpRequestEnvelope): Promise<TunnelHttpResponseEnvelope | null> {
     const upstreamUrl = new URL(envelope.path, this.config.daemonUrl);
+    // Whole-home operational endpoints require a capability added only by the
+    // private OrgChannel backup path. Ordinary organization-facing relay
+    // requests must never proxy them, even if their URL is percent-encoded.
+    // A protocol-relative path must not turn the daemon into an outbound proxy.
+    if (
+      upstreamUrl.origin !== this.config.daemonUrl.origin
+      ||
+      PRIVATE_DAEMON_HTTP_PATHS.has(daemonRoutingPath(upstreamUrl.pathname))
+    ) {
+      return {
+        type: 'http.response',
+        id: envelope.id,
+        status: 404,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+        bodyB64: Buffer.from('Not found\n').toString('base64'),
+      };
+    }
     const abort = new AbortController();
     const timeout = setTimeout(() => abort.abort(), TUNNEL_HTTP_REQUEST_TIMEOUT_MS);
     const pending: PendingDaemonHttpRequest = { abort, canceled: false };
@@ -750,6 +794,9 @@ export class TunnelClient {
         method: envelope.method,
         headers: withoutHopByHop(envelope.headers),
         body: envelope.bodyB64 ? Buffer.from(envelope.bodyB64, 'base64') : undefined,
+        // Relay callers may choose the path, so never allow fetch to follow a
+        // redirect into a daemon-private endpoint (or away from the daemon).
+        redirect: 'manual',
         signal: abort.signal,
       });
 
@@ -793,6 +840,171 @@ export class TunnelClient {
       }
     } finally {
       if (!pending || this.pendingHttpRequests.get(envelope.id) === pending) {
+        this.pendingHttpRequests.delete(envelope.id);
+      }
+    }
+  }
+
+  private async proxyAndSendSnapshotResponse(
+    control: WebSocket,
+    request: TunnelSnapshotRequestEnvelope,
+  ): Promise<void> {
+    if (!this.relaySupportsHttpResponseChunkAcks) {
+      await this.sendHttpResponse(control, {
+        type: 'http.response',
+        id: request.id,
+        status: 503,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+        bodyB64: Buffer.from(
+          'Snapshot streaming requires relay chunk acknowledgements.\n',
+        ).toString('base64'),
+      });
+      return;
+    }
+
+    const envelope: TunnelHttpRequestEnvelope = {
+      type: 'http.request',
+      id: request.id,
+      method: 'GET',
+      path: '/api/ops/snapshot.zip',
+      headers: {},
+      bodyB64: null,
+    };
+    await this.proxyAndSendStreamingHttpResponse(
+      control,
+      envelope,
+      new URL(envelope.path, this.config.daemonUrl),
+    );
+  }
+
+  private async proxyAndSendStreamingHttpResponse(
+    control: WebSocket,
+    envelope: TunnelHttpRequestEnvelope,
+    upstreamUrl: URL,
+  ): Promise<void> {
+    const abort = new AbortController();
+    const pending: PendingDaemonHttpRequest = { abort, canceled: false };
+    this.pendingHttpRequests.set(envelope.id, pending);
+    let responseStarted = false;
+    let chunks = 0;
+
+    try {
+      const response = await this.fetchImpl(upstreamUrl, {
+        method: envelope.method,
+        headers: withoutHopByHop(envelope.headers),
+        body: envelope.bodyB64 ? Buffer.from(envelope.bodyB64, 'base64') : undefined,
+        redirect: 'manual',
+        signal: abort.signal,
+      });
+      const totalBytes = Number(response.headers.get('content-length'));
+      if (
+        !response.ok
+        || !response.body
+        || !Number.isSafeInteger(totalBytes)
+        || totalBytes <= 0
+      ) {
+        await this.sendHttpResponse(control, {
+          type: 'http.response',
+          id: envelope.id,
+          status: response.status,
+          headers: serializableResponseHeaders(response.headers),
+          bodyB64: (await materializedResponseBody(response)).toString('base64'),
+        });
+        return;
+      }
+
+      control.send(encodeJsonBytes({
+        type: 'http.response.start',
+        id: envelope.id,
+        status: response.status,
+        headers: serializableResponseHeaders(response.headers),
+        totalBytes,
+      }));
+      responseStarted = true;
+      let sentBytes = 0;
+      const reader = response.body.getReader();
+      let responseCompleted = false;
+      let streamFailure: unknown;
+      try {
+        for (;;) {
+          const result = await reader.read();
+          if (result.done) break;
+          let offset = 0;
+          while (offset < result.value.byteLength) {
+            if (pending.canceled) return;
+            const emptyChunk = encodeJsonBytes({
+              type: 'http.response.chunk',
+              id: envelope.id,
+              sequence: chunks,
+              bodyB64: '',
+            });
+            const chunkBytes = Math.floor(
+              (TUNNEL_WS_FRAME_BYTE_LIMIT - emptyChunk.byteLength) / 4,
+            ) * 3;
+            if (chunkBytes <= 0) {
+              throw new Error('HTTP response chunk metadata exceeded tunnel frame cap');
+            }
+            const chunk = result.value.subarray(offset, offset + chunkBytes);
+            if (sentBytes + chunk.byteLength > totalBytes) {
+              throw new Error('Streaming HTTP response exceeded its content length');
+            }
+            const message: TunnelHttpResponseChunkEnvelope = {
+              type: 'http.response.chunk',
+              id: envelope.id,
+              sequence: chunks,
+              bodyB64: Buffer.from(chunk).toString('base64'),
+            };
+            if (this.relaySupportsHttpResponseChunkAcks) {
+              await this.sendHttpResponseChunk(control, message);
+            } else {
+              control.send(encodeJsonBytes(message));
+            }
+            sentBytes += chunk.byteLength;
+            chunks += 1;
+            offset += chunk.byteLength;
+          }
+        }
+        if (sentBytes !== totalBytes) {
+          throw new Error('Streaming HTTP response ended before its content length');
+        }
+        responseCompleted = true;
+      } catch (error) {
+        streamFailure = error;
+        throw error;
+      } finally {
+        if (!responseCompleted) {
+          abort.abort(streamFailure ?? 'streaming HTTP response was cancelled');
+          await reader.cancel(streamFailure).catch(() => undefined);
+        }
+        reader.releaseLock();
+      }
+      if (!pending.canceled) {
+        control.send(encodeJsonBytes({
+          type: 'http.response.end',
+          id: envelope.id,
+          chunks,
+        }));
+      }
+    } catch (error) {
+      if (pending.canceled) return;
+      if (responseStarted) {
+        // Let the relay reject the incomplete byte count immediately.
+        control.send(encodeJsonBytes({
+          type: 'http.response.end',
+          id: envelope.id,
+          chunks,
+        }));
+        return;
+      }
+      await this.sendHttpResponse(control, {
+        type: 'http.response',
+        id: envelope.id,
+        status: 502,
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+        bodyB64: Buffer.from(`Tunnel client failed to reach daemon: ${String(error)}\n`).toString('base64'),
+      });
+    } finally {
+      if (this.pendingHttpRequests.get(envelope.id) === pending) {
         this.pendingHttpRequests.delete(envelope.id);
       }
     }

--- a/packages/tunnel-protocol/src/index.ts
+++ b/packages/tunnel-protocol/src/index.ts
@@ -36,7 +36,8 @@ export const TUNNEL_FEATURES = {
   VAULT_CONTENT_EVENTS_V2: "relay.vault-content-events.v2",
   MCP_TOOL_CALL_BOUNDED_RESULTS_V1:
     "relay.mcp-tool-call.bounded-results.v1",
-  HTTP_RESPONSE_CHUNK_ACKS_V1: "relay.http-response-chunk-acks.v1"
+  HTTP_RESPONSE_CHUNK_ACKS_V1: "relay.http-response-chunk-acks.v1",
+  SNAPSHOT_STREAM_V1: "relay.snapshot-stream.v1"
 } as const;
 
 export type TunnelFeature = (typeof TUNNEL_FEATURES)[keyof typeof TUNNEL_FEATURES];
@@ -572,6 +573,11 @@ export type TunnelHttpCancelEnvelope = {
   reason?: string;
 };
 
+export type TunnelSnapshotRequestEnvelope = {
+  type: "snapshot.request";
+  id: string;
+};
+
 export type TunnelHttpResponseEnvelope = {
   type: "http.response";
   id: string;
@@ -661,6 +667,7 @@ export type TunnelControlServerMessage =
   | TunnelHttpRequestStartEnvelope
   | TunnelHttpRequestChunkEnvelope
   | TunnelHttpRequestEndEnvelope
+  | TunnelSnapshotRequestEnvelope
   | TunnelHttpCancelEnvelope
   | TunnelHttpResponseChunkAckEnvelope
   | TunnelWebSocketOpenEnvelope

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       ws:
         specifier: 8.21.0
         version: 8.21.0
+      yazl:
+        specifier: 3.3.1
+        version: 3.3.1
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
@@ -134,9 +137,18 @@ importers:
       '@types/ws':
         specifier: 8.18.1
         version: 8.18.1
+      '@types/yauzl':
+        specifier: 3.4.0
+        version: 3.4.0
+      '@types/yazl':
+        specifier: 3.3.1
+        version: 3.3.1
       '@vitest/coverage-v8':
         specifier: 4.1.8
         version: 4.1.8(vitest@4.1.8)
+      yauzl:
+        specifier: 3.4.0
+        version: 3.4.0
       yjs:
         specifier: 13.6.31
         version: 13.6.31
@@ -1688,6 +1700,12 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@types/yauzl@3.4.0':
+    resolution: {integrity: sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==}
+
+  '@types/yazl@3.3.1':
+    resolution: {integrity: sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==}
+
   '@vitest/coverage-v8@4.1.8':
     resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
     peerDependencies:
@@ -1832,6 +1850,10 @@ packages:
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
+
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
 
   buffer-image-size@0.6.4:
     resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
@@ -2644,6 +2666,9 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   phosphor-svelte@3.1.0:
     resolution: {integrity: sha512-nldtxx+XCgNREvrb7O5xgDsefytXpSkPTx8Rnu3f2qQCUZLDV1rLxYSd2Jcwckuo9lZB1qKMqGR17P4UDC0PrA==}
     peerDependencies:
@@ -3194,6 +3219,13 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
+    engines: {node: '>=12'}
+
+  yazl@3.3.1:
+    resolution: {integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==}
 
   yjs@13.6.31:
     resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
@@ -4218,6 +4250,14 @@ snapshots:
     dependencies:
       '@types/node': 25.9.2
 
+  '@types/yauzl@3.4.0':
+    dependencies:
+      '@types/node': 25.9.2
+
+  '@types/yazl@3.3.1':
+    dependencies:
+      '@types/node': 25.9.2
+
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -4390,6 +4430,8 @@ snapshots:
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.3
+
+  buffer-crc32@1.0.0: {}
 
   buffer-image-size@0.6.4:
     dependencies:
@@ -5246,6 +5288,8 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pend@1.2.0: {}
+
   phosphor-svelte@3.1.0(svelte@5.55.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       estree-walker: 3.0.3
@@ -5791,6 +5835,14 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@3.4.0:
+    dependencies:
+      pend: 1.2.0
+
+  yazl@3.3.1:
+    dependencies:
+      buffer-crc32: 1.0.0
 
   yjs@13.6.31:
     dependencies:


### PR DESCRIPTION
## Summary

- add portable, checksummed ZIP snapshots for active and trashed vault data
- fail closed on source mutations, unsupported paths, interrupted or stalled delivery
- stream snapshots through the authenticated relay protocol with bounded backpressure
- clean daemon-owned snapshot spools after restarts

## Verification

- `pnpm check`
- focused daemon snapshot, routing, startup, tunnel client, and protocol tests
- disposable restore into a real daemon runtime
- `git diff --check`

## Follow-up

After this merges, kb-1-cloud must repin its `local` submodule to this daemon commit before the Cloud backup/export PR is opened.