### PR TITLE
Stabilize snapshot stream test under CI load

### DIFF
--- a/packages/tunnel-client/src/index.test.ts
+++ b/packages/tunnel-client/src/index.test.ts
@@ -1416,7 +1416,7 @@ describe('TunnelClient HTTP proxy cancellation', () => {
         .filter((frame) => frame.type === 'http.response.chunk')
         .map((frame) => Buffer.from(frame.bodyB64 ?? '', 'base64')),
     )).toEqual(archive);
-  });
+  }, 15_000);
 
   it('cancels the daemon snapshot body when relaying a response chunk fails', async () => {
     let bodyCanceled = false;


### PR DESCRIPTION
## Summary

- raise only the private snapshot streaming test timeout from Vitest's 5-second default to 15 seconds
- keep production request and acknowledgement timeouts unchanged
- avoid false failures when the daemon lane runs multiple coverage and build targets in parallel

## Verification

- `pnpm --filter @kb-1/tunnel-client test` (65 passed)
- Cloud exact `pnpm check:ci:daemon`
- daemon `pnpm check`