### PR TITLE
Preserve accepted filenames and stabilize backup capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,9 +303,28 @@ flushes every active vault through the same conservative durability boundary,
 then streams a ZIP containing `vaults/`, recoverable
 `.trash/`, `kb1-snapshot.json`, and a final `kb1-snapshot.complete` marker. The
 manifest records the schema version, timestamps, paths, sizes, modes, and byte
-totals. The stream fails if any planned file or directory changes before the
-archive completes, so callers must discard an incomplete ZIP and retry instead
-of treating mixed filesystem state as a backup.
+totals. Files are captured into private temporary storage before hashing and
+compression. Source changes during capture fail the attempt; edits after a
+validated capture do not invalidate it. Callers must discard incomplete ZIPs
+and retry instead of treating mixed filesystem state as a backup.
+
+Schema 2 preserves accepted names such as `Meeting: launch.md`, `con.md`, and
+case-colliding paths. Names that common extraction filesystems cannot safely
+represent use a `~kb1-` archive segment; `originalPath` in the manifest records
+the exact original file or directory path. Contents and source names are not
+modified. The ZIP can be inspected with ordinary tools, but use the restore
+command to recover a working vault with its original names and links:
+
+```bash
+pnpm snapshot:restore --archive /path/to/snapshot.zip --target /tmp/kb1-restored-home
+```
+
+The target must not exist. The command accepts schema 1 and 2, checks the
+completion marker and every file's SHA-256, preserves empty directories, and
+refuses to merge into an existing home. If the destination filesystem cannot
+represent the original names, restoration fails and removes only its newly
+created partial home; use a compatible filesystem such as a case-sensitive
+Linux volume. See [the snapshot format](docs/snapshot-format.md).
 
 The archive retains portable vault metadata. It excludes daemon-local
 `.kb1/cache/`, `.kb1/runtime/`, `.kb1/tmp/`, and `.kb1/secrets/` trees, along
@@ -317,7 +336,7 @@ self-hosted daemons remain loopback-only unless an operator deliberately exposes
 them. Cloud-hosted backup/export callers use the private managed-container
 binding directly; the ordinary per-organization relay remains a bounded JSON/API
 transport and is not the snapshot transfer path.
-Never extract an archive over a running daemon home. Restore into a stopped or
+Never extract an archive over a running daemon home. Restore into a new
 disposable `KB1_HOME`, validate the manifest and ZIP, start the daemon there,
 and exercise real vault reads before any separately approved cutover.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -7,7 +7,7 @@ regenerated and reviewed for every release.
 Platform-specific optional native build bindings are excluded because they are not
 copied into the shipped runtime; their platform-neutral parent packages remain listed.
 
-Inventory count: **199 packages**.
+Inventory count: **201 packages**.
 
 | Package | Declared license | Source | Included notice files |
 | --- | --- | --- | --- |
@@ -160,6 +160,7 @@ Inventory count: **199 packages**.
 | parseurl 1.3.3 | MIT | [source](https://github.com/pillarjs/parseurl) | LICENSE (7f36c1a3cd7f) |
 | path-key 3.1.1 | MIT | [source](https://github.com/sindresorhus/path-key) | license (c9808a775260) |
 | path-to-regexp 8.4.2 | MIT | [source](https://github.com/pillarjs/path-to-regexp) | LICENSE (e257f36bcf5e) |
+| pend 1.2.0 | MIT | [source](https://github.com/andrewrk/node-pend) | LICENSE (92832e59724a) |
 | phosphor-svelte 3.1.0 | MIT | [source](https://github.com/haruaki07/phosphor-svelte) | LICENSE (1609a422af37) |
 | picocolors 1.1.1 | ISC | [source](https://github.com/alexeyraspopov/picocolors) | LICENSE (fa11af88c78d) |
 | picomatch 4.0.4 | MIT | [source](https://github.com/micromatch/picomatch) | LICENSE (9219a3ebed1d) |
@@ -205,6 +206,7 @@ Inventory count: **199 packages**.
 | ws 8.21.0 | MIT | [source](https://github.com/websockets/ws) | LICENSE (7adebaeee45b) |
 | y-protocols 1.0.7 | MIT | [source](https://github.com/yjs/y-protocols) | LICENSE (7ad5cbfd9f9f) |
 | yaml 2.9.0 | ISC | [source](https://github.com/eemeli/yaml) | LICENSE (cf12d35c36ba) |
+| yauzl 3.4.0 | MIT | [source](https://github.com/thejoshwolfe/yauzl) | LICENSE (da5f77b8bc87) |
 | yazl 3.3.1 | MIT | [source](https://github.com/thejoshwolfe/yazl) | LICENSE (da5f77b8bc87) |
 | yjs 13.6.31 | MIT | [source](https://github.com/yjs/yjs) | LICENSE (467c210a105c) |
 | zimmerframe 1.1.4 | MIT | [source](https://github.com/sveltejs/zimmerframe) | LICENSE (3ef5af147392) |
@@ -4577,6 +4579,38 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
+### 92832e59724a11084eeb483058f27197d06a4d4f34a18cedb462892001c74d60
+
+Packages: pend@1.2.0
+
+Files: pend@1.2.0/LICENSE
+
+```text
+The MIT License (Expat)
+
+Copyright (c) 2014 Andrew Kelley
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ### 1609a422af374a9fe833b3e897ec3b1d9b5006b1ac69822e6001d599f426e330
 
 Packages: phosphor-svelte@3.1.0
@@ -7727,9 +7761,9 @@ THIS SOFTWARE.
 
 ### da5f77b8bc8717f6e33aedce55a88702d79038d83cdc00af5ca08f3bc4f22ff9
 
-Packages: yazl@3.3.1
+Packages: yauzl@3.4.0, yazl@3.3.1
 
-Files: yazl@3.3.1/LICENSE
+Files: yauzl@3.4.0/LICENSE, yazl@3.3.1/LICENSE
 
 ```text
 The MIT License (MIT)

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -4,13 +4,14 @@
   "private": true,
   "type": "module",
   "bin": {
-    "kb1d": "./dist/main.js"
+    "kb1d": "./dist/main.js",
+    "kb1-restore": "./dist/snapshot-restore-cli.js"
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.build.json && node -e \"require('node:fs').chmodSync('dist/main.js', 0o755)\" && node scripts/bundle-starter-kit.mjs",
+    "build": "tsc -p tsconfig.build.json && node -e \"for (const path of ['dist/main.js', 'dist/snapshot-restore-cli.js']) require('node:fs').chmodSync(path, 0o755)\" && node scripts/bundle-starter-kit.mjs",
     "dev": "tsx src/main.ts",
     "test": "vitest run --coverage",
     "typecheck": "tsc -p tsconfig.json --noEmit"
@@ -25,6 +26,8 @@
     "github-slugger": "2.0.0",
     "hono": "4.12.25",
     "yazl": "3.3.1",
+    "yauzl": "3.4.0",
+    "zod": "4.4.3",
     "ws": "8.21.0"
   },
   "devDependencies": {
@@ -33,7 +36,6 @@
     "@types/yazl": "3.3.1",
     "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "4.1.8",
-    "yauzl": "3.4.0",
     "yjs": "13.6.31"
   }
 }

--- a/apps/daemon/src/app.ts
+++ b/apps/daemon/src/app.ts
@@ -241,10 +241,6 @@ export function createApp(options: CreateAppOptions): Hono {
         const snapshotSignal = options.shutdownSignal
           ? AbortSignal.any([context.req.raw.signal, options.shutdownSignal])
           : context.req.raw.signal;
-        const snapshot = await registry.createSnapshotArchive(
-          new Date(),
-          snapshotSignal,
-        );
         // The relay protocol needs an exact total before it can stream bounded
         // chunks with acknowledgements. Spool outside KB1_HOME so the archive
         // never contains itself, then delete the temporary file when delivery
@@ -253,6 +249,11 @@ export function createApp(options: CreateAppOptions): Hono {
         // cleanup that failed after an earlier request in the same process.
         await prepareSnapshotSpoolHome(snapshotSpoolHome);
         spoolDirectory = await mkdtemp(join(snapshotSpoolHome, 'run-'));
+        const snapshot = await registry.createSnapshotArchive(
+          new Date(),
+          snapshotSignal,
+          spoolDirectory,
+        );
         const spoolPath = join(spoolDirectory, 'snapshot.zip');
         await pipeline(snapshot.stream, createWriteStream(spoolPath), {
           signal: snapshotSignal,

--- a/apps/daemon/src/snapshot-archive.test.ts
+++ b/apps/daemon/src/snapshot-archive.test.ts
@@ -1,11 +1,12 @@
 import { createServer } from 'node:http';
-import { chmod, mkdir, mkdtemp, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { join } from 'node:path';
 import { buffer } from 'node:stream/consumers';
 
 import { afterEach, describe, expect, it } from 'vitest';
 import { fromBufferPromise } from 'yauzl';
+import { ZipFile } from 'yazl';
 
 import { startDaemon } from './main.js';
 import { DAEMON_INITIALIZED_FILENAME } from './config.js';
@@ -15,6 +16,8 @@ import {
   createSnapshotArchive,
   type SnapshotArchiveManifest,
 } from './snapshot-archive.js';
+import { restoreSnapshotArchive } from './snapshot-restore.js';
+import { isPortableSnapshotSegment } from './snapshot-paths.js';
 
 const cleanupPaths: string[] = [];
 
@@ -25,7 +28,7 @@ afterEach(async () => {
 describe('daemon snapshot archive', () => {
   it('round-trips active and trashed vault bytes into a disposable daemon runtime', async () => {
     const sourceHome = await temporaryDirectory('kb1-snapshot-source-');
-    const restoredHome = await temporaryDirectory('kb1-snapshot-restored-');
+    const restoredHome = join(await temporaryDirectory('kb1-snapshot-restored-'), 'home');
     await mkdir(join(sourceHome, 'vaults', 'field-notes', '.kb1'), { recursive: true });
     await mkdir(join(sourceHome, '.trash', 'old-vault'), { recursive: true });
     await writeFile(
@@ -52,7 +55,7 @@ describe('daemon snapshot archive', () => {
       entries.get(SNAPSHOT_MANIFEST_PATH)?.toString('utf8') ?? '',
     ) as SnapshotArchiveManifest;
     expect(manifest).toMatchObject({
-      schemaVersion: 1,
+      schemaVersion: 2,
       createdAt: '2026-09-03T08:00:00.000Z',
       durableAsOf: '2026-09-03T08:00:01.000Z',
       totals: { files: 3 },
@@ -62,7 +65,7 @@ describe('daemon snapshot archive', () => {
       '2026-09-03T08:00:00.000Z\n'
     );
 
-    await extractZip(entries, restoredHome);
+    await restoreBytes(archiveBytes, restoredHome);
     const port = await reservePort();
     const restored = await startDaemon({
       env: {
@@ -179,7 +182,7 @@ describe('daemon snapshot archive', () => {
 
   it('round-trips an intentionally empty initialized daemon without reseeding', async () => {
     const sourceHome = await temporaryDirectory('kb1-snapshot-empty-source-');
-    const restoredHome = await temporaryDirectory('kb1-snapshot-empty-restored-');
+    const restoredHome = join(await temporaryDirectory('kb1-snapshot-empty-restored-'), 'home');
     await mkdir(join(sourceHome, 'vaults'), { recursive: true });
     await mkdir(join(sourceHome, '.trash'), { recursive: true });
     await writeFile(join(sourceHome, 'vaults', DAEMON_INITIALIZED_FILENAME), '1\n');
@@ -192,7 +195,7 @@ describe('daemon snapshot archive', () => {
       createdAt: new Date(),
       durableAsOf: new Date(),
     });
-    await extractZip(await readZipEntries(await buffer(archive.stream)), restoredHome);
+    await restoreBytes(await buffer(archive.stream), restoredHome);
 
     const port = await reservePort();
     const restored = await startDaemon({
@@ -220,23 +223,43 @@ describe('daemon snapshot archive', () => {
       roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
       createdAt: new Date(),
       durableAsOf: new Date(),
-    })).rejects.toThrow('non-portable path segment');
+    })).rejects.toThrow('Unsafe snapshot path');
   });
 
-  it('fails closed for Windows-reserved path segments', async () => {
+  it.skipIf(process.platform === 'win32')('round-trips valid names through portable archive paths without changing source names or bytes', async () => {
     const sourceHome = await temporaryDirectory('kb1-snapshot-reserved-');
     const vaultRoot = join(sourceHome, 'vaults', 'demo');
     await mkdir(vaultRoot, { recursive: true });
-    await writeFile(join(vaultRoot, 'con.md'), 'not portable\n');
+    const names = ['Meeting: launch.md', 'con.md', 'feedback /bug reports.md', '~kb1-literal.md'];
+    for (const name of names) {
+      const segments = name.split('/');
+      await mkdir(join(vaultRoot, ...segments.slice(0, -1)), { recursive: true });
+      await writeFile(join(vaultRoot, name), `original ${name}\n`);
+    }
+    await mkdir(join(vaultRoot, 'empty: folder'), { recursive: true });
 
-    await expect(createSnapshotArchive({
+    const archive = await createSnapshotArchive({
       roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
       createdAt: new Date(),
       durableAsOf: new Date(),
-    })).rejects.toThrow('non-portable path segment');
+    });
+    const bytes = await buffer(archive.stream);
+    const entries = await readZipEntries(bytes);
+    expect(archive.manifest.files).toHaveLength(names.length);
+    for (const file of archive.manifest.files) {
+      expect(file.path.split('/').every(isPortableSnapshotSegment)).toBe(true);
+      expect(file.originalPath).toBeDefined();
+      expect(entries.get(file.path)?.toString('utf8')).toBe(`original ${file.originalPath!.slice('vaults/demo/'.length)}\n`);
+    }
+    const restoredHome = join(await temporaryDirectory('kb1-snapshot-names-'), 'home');
+    await restoreBytes(bytes, restoredHome);
+    for (const name of names) {
+      expect(await readFile(join(restoredHome, 'vaults/demo', name), 'utf8')).toBe(await readFile(join(vaultRoot, name), 'utf8'));
+    }
+    expect((await stat(join(restoredHome, 'vaults/demo/empty: folder'))).isDirectory()).toBe(true);
   });
 
-  it('fails closed when target filesystems would collapse distinct archive paths', async () => {
+  it('preserves colliding names in the ZIP and restores only on a compatible filesystem', async () => {
     const sourceHome = await temporaryDirectory('kb1-snapshot-collision-');
     const firstRoot = join(sourceHome, 'first');
     const secondRoot = join(sourceHome, 'second');
@@ -245,90 +268,104 @@ describe('daemon snapshot archive', () => {
     await writeFile(join(firstRoot, 'note.md'), 'first\n');
     await writeFile(join(secondRoot, 'note.md'), 'second\n');
 
-    await expect(createSnapshotArchive({
+    const archive = await createSnapshotArchive({
       roots: [
         { archivePath: 'vaults/Demo', filesystemPath: firstRoot },
         { archivePath: 'vaults/demo', filesystemPath: secondRoot },
       ],
       createdAt: new Date(),
       durableAsOf: new Date(),
-    })).rejects.toThrow('colliding portable paths');
+    });
+    const bytes = await buffer(archive.stream);
+    const entries = await readZipEntries(bytes);
+    expect(new Set(archive.manifest.files.map((file) => file.path.toLowerCase())).size).toBe(2);
+    expect(archive.manifest.files.map((file) => file.originalPath).sort()).toEqual(['vaults/Demo/note.md', 'vaults/demo/note.md']);
+    expect(archive.manifest.files.map((file) => entries.get(file.path)?.toString('utf8')).sort()).toEqual(['first\n', 'second\n']);
+    const restoredHome = join(await temporaryDirectory('kb1-snapshot-case-'), 'home');
+    if (await supportsDistinctCase(sourceHome)) {
+      await restoreBytes(bytes, restoredHome);
+      expect(await readFile(join(restoredHome, 'vaults/Demo/note.md'), 'utf8')).toBe('first\n');
+      expect(await readFile(join(restoredHome, 'vaults/demo/note.md'), 'utf8')).toBe('second\n');
+    } else {
+      await expect(restoreBytes(bytes, restoredHome)).rejects.toMatchObject({ code: 'EEXIST' });
+      await expect(stat(restoredHome)).rejects.toMatchObject({ code: 'ENOENT' });
+    }
   });
 
-  it('fails the ZIP stream when the source tree changes after planning', async () => {
+  it('restores v1 archives and refuses to merge into an existing home', async () => {
+    const sourceHome = await temporaryDirectory('kb1-snapshot-v1-');
+    await writeFile(join(sourceHome, 'note.md'), 'legacy archive\n');
+    const archive = await createSnapshotArchive({
+      roots: [{ archivePath: 'vaults/demo', filesystemPath: sourceHome }],
+      createdAt: new Date(), durableAsOf: new Date(),
+    });
+    const entries = await readZipEntries(await buffer(archive.stream));
+    const { directories: _directories, ...manifest } = archive.manifest;
+    entries.set(SNAPSHOT_MANIFEST_PATH, Buffer.from(JSON.stringify({ ...manifest, schemaVersion: 1 })));
+    const bytes = await zipEntries(entries);
+    const restoredHome = join(await temporaryDirectory('kb1-restore-v1-'), 'home');
+    await restoreBytes(bytes, restoredHome);
+    expect(await readFile(join(restoredHome, 'vaults/demo/note.md'), 'utf8')).toBe('legacy archive\n');
+    await expect(restoreBytes(bytes, restoredHome)).rejects.toMatchObject({ code: 'EEXIST' });
+    expect(await readFile(join(restoredHome, 'vaults/demo/note.md'), 'utf8')).toBe('legacy archive\n');
+  });
+
+  it.each(['traversal', 'changed bytes', 'missing completion', 'symbolic link'] as const)(
+    'refuses a damaged or unsafe restore (%s) and removes only its partial target', async (damage) => {
+      const sourceHome = await temporaryDirectory('kb1-snapshot-unsafe-');
+      await writeFile(join(sourceHome, 'note.md'), 'original bytes\n');
+      const archive = await createSnapshotArchive({
+        roots: [{ archivePath: 'vaults/demo', filesystemPath: sourceHome }],
+        createdAt: new Date(), durableAsOf: new Date(),
+      });
+      const entries = await readZipEntries(await buffer(archive.stream));
+      if (damage === 'traversal') {
+        archive.manifest.files[0]!.originalPath = 'vaults/../../outside.md';
+        entries.set(SNAPSHOT_MANIFEST_PATH, Buffer.from(JSON.stringify(archive.manifest)));
+      }
+      if (damage === 'changed bytes') entries.set('vaults/demo/note.md', Buffer.from('modified bytes\n'));
+      if (damage === 'missing completion') entries.delete(SNAPSHOT_COMPLETION_PATH);
+      const parent = await temporaryDirectory('kb1-restore-unsafe-');
+      const target = join(parent, 'new-home');
+      await writeFile(join(parent, 'sentinel.md'), 'keep me');
+      await expect(restoreBytes(await zipEntries(entries, damage === 'symbolic link'), target)).rejects.toThrow();
+      await expect(stat(target)).rejects.toMatchObject({ code: 'ENOENT' });
+      expect(await readFile(join(parent, 'sentinel.md'), 'utf8')).toBe('keep me');
+    },
+  );
+
+  it('keeps the captured bytes and tree when source content, permissions, and roots change during delivery', async () => {
     const sourceHome = await temporaryDirectory('kb1-snapshot-changing-');
     const vaultRoot = join(sourceHome, 'vaults', 'demo');
-    await mkdir(vaultRoot, { recursive: true });
-    await writeFile(join(vaultRoot, 'before.md'), 'planned\n');
-
-    const archive = await createSnapshotArchive({
-      roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
-      createdAt: new Date(),
-      durableAsOf: new Date(),
-    });
-    await writeFile(join(vaultRoot, 'after.md'), 'not planned\n');
-
-    await expect(buffer(archive.stream)).rejects.toThrow(
-      'Snapshot source changed while archiving'
-    );
-  });
-
-  it('fails the ZIP stream when an initially absent root appears after planning', async () => {
-    const sourceHome = await temporaryDirectory('kb1-snapshot-new-root-');
+    const file = join(vaultRoot, 'before.md');
     const trashRoot = join(sourceHome, '.trash');
-    const archive = await createSnapshotArchive({
-      roots: [{ archivePath: '.trash', filesystemPath: trashRoot }],
-      createdAt: new Date(),
-      durableAsOf: new Date(),
-    });
-    await mkdir(join(trashRoot, 'deleted-vault'), { recursive: true });
-    await writeFile(join(trashRoot, 'deleted-vault', 'note.md'), 'appeared\n');
-
-    await expect(buffer(archive.stream)).rejects.toThrow(
-      'Snapshot source changed while archiving'
-    );
-  });
-
-  it('fails the ZIP stream when source permissions change after planning', async () => {
-    const sourceHome = await temporaryDirectory('kb1-snapshot-mode-changing-');
-    const vaultRoot = join(sourceHome, 'vaults', 'demo');
-    const file = join(vaultRoot, 'script.sh');
-    await mkdir(vaultRoot, { recursive: true });
-    await writeFile(file, '#!/bin/sh\n');
-    await chmod(file, 0o600);
-
-    const archive = await createSnapshotArchive({
-      roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
-      createdAt: new Date(),
-      durableAsOf: new Date(),
-    });
-    await chmod(file, 0o700);
-
-    await expect(buffer(archive.stream)).rejects.toThrow(
-      'Snapshot source changed while archiving'
-    );
-  });
-
-  it('fails the ZIP stream after a same-size rewrite with restored mtime', async () => {
-    const sourceHome = await temporaryDirectory('kb1-snapshot-content-changing-');
-    const vaultRoot = join(sourceHome, 'vaults', 'demo');
-    const file = join(vaultRoot, 'note.md');
     await mkdir(vaultRoot, { recursive: true });
     await writeFile(file, 'before\n');
+    await chmod(file, 0o600);
     const original = await stat(file);
-
     const archive = await createSnapshotArchive({
-      roots: [{ archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') }],
+      roots: [
+        { archivePath: 'vaults', filesystemPath: join(sourceHome, 'vaults') },
+        { archivePath: '.trash', filesystemPath: trashRoot },
+      ],
       createdAt: new Date(),
       durableAsOf: new Date(),
     });
     await writeFile(file, 'after!\n');
     await utimes(file, original.atime, original.mtime);
+    await chmod(file, 0o700);
+    await writeFile(join(vaultRoot, 'after.md'), 'not captured\n');
+    await mkdir(trashRoot);
+    await writeFile(join(trashRoot, 'deleted.md'), 'after capture\n');
 
-    await expect(buffer(archive.stream)).rejects.toThrow(
-      'Snapshot source changed while archiving'
-    );
+    const entries = await readZipEntries(await buffer(archive.stream));
+    expect(entries.get('vaults/demo/before.md')?.toString('utf8')).toBe('before\n');
+    expect(archive.manifest.files[0]?.mode).toBe(original.mode);
+    expect(entries.has('vaults/demo/after.md')).toBe(false);
+    expect(entries.has('.trash/deleted.md')).toBe(false);
+    expect(entries.has(SNAPSHOT_COMPLETION_PATH)).toBe(true);
   });
+
 });
 
 async function temporaryDirectory(prefix: string): Promise<string> {
@@ -341,7 +378,10 @@ async function readZipEntries(archive: Buffer): Promise<Map<string, Buffer>> {
   const zip = await fromBufferPromise(archive, { lazyEntries: true });
   const entries = new Map<string, Buffer>();
   for await (const entry of zip.eachEntry()) {
-    if (entry.fileName.endsWith('/')) continue;
+    if (entry.fileName.endsWith('/')) {
+      entries.set(entry.fileName, Buffer.alloc(0));
+      continue;
+    }
     const stream = await zip.openReadStreamPromise(entry);
     entries.set(entry.fileName, await buffer(stream));
   }
@@ -349,16 +389,30 @@ async function readZipEntries(archive: Buffer): Promise<Map<string, Buffer>> {
   return entries;
 }
 
-async function extractZip(entries: Map<string, Buffer>, targetRoot: string): Promise<void> {
-  const canonicalRoot = `${resolve(targetRoot)}/`;
-  for (const [entryPath, bytes] of entries) {
-    if (entryPath === SNAPSHOT_MANIFEST_PATH) continue;
-    const target = resolve(targetRoot, entryPath);
-    if (!target.startsWith(canonicalRoot)) {
-      throw new Error(`Archive entry escaped restore root: ${entryPath}`);
-    }
-    await mkdir(dirname(target), { recursive: true });
-    await writeFile(target, bytes);
+async function restoreBytes(bytes: Buffer, targetHome: string): Promise<void> {
+  const path = join(await temporaryDirectory('kb1-restore-input-'), 'snapshot.zip');
+  await writeFile(path, bytes);
+  await restoreSnapshotArchive({ archivePath: path, targetHome });
+}
+
+async function zipEntries(entries: Map<string, Buffer>, link = false): Promise<Buffer> {
+  const zip = new ZipFile();
+  for (const [path, bytes] of entries) {
+    if (path.endsWith('/')) zip.addEmptyDirectory(path);
+    else zip.addBuffer(bytes, path, { mode: link && path === 'vaults/demo/note.md' ? 0o120777 : 0o100600 });
+  }
+  zip.end();
+  return buffer(zip.outputStream);
+}
+
+async function supportsDistinctCase(parent: string): Promise<boolean> {
+  await writeFile(join(parent, 'case-probe'), 'a', { flag: 'wx' });
+  try {
+    await writeFile(join(parent, 'CASE-PROBE'), 'b', { flag: 'wx' });
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false;
+    throw error;
   }
 }
 

--- a/apps/daemon/src/snapshot-archive.ts
+++ b/apps/daemon/src/snapshot-archive.ts
@@ -1,17 +1,22 @@
-import { lstat, open, readdir } from 'node:fs/promises';
+import { copyFile, lstat, mkdtemp, open, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
-import type { Stats } from 'node:fs';
+import { constants, type Stats } from 'node:fs';
 import { Readable, Transform } from 'node:stream';
 
 import { ZipFile } from 'yazl';
 
-export const SNAPSHOT_ARCHIVE_SCHEMA_VERSION = 1;
+import { portableSnapshotPaths } from './snapshot-paths.js';
+
+export const SNAPSHOT_ARCHIVE_SCHEMA_VERSION = 2;
 export const SNAPSHOT_MANIFEST_PATH = 'kb1-snapshot.json';
 export const SNAPSHOT_COMPLETION_PATH = 'kb1-snapshot.complete';
+export const SNAPSHOT_RESTORE_HELP_PATH = 'kb1-restore.txt';
 
 export interface SnapshotArchiveFile {
   path: string;
+  originalPath?: string;
   sizeBytes: number;
   modifiedAt: string;
   mode: number;
@@ -23,10 +28,18 @@ export interface SnapshotArchiveManifest {
   createdAt: string;
   durableAsOf: string;
   files: SnapshotArchiveFile[];
+  directories: SnapshotArchiveDirectory[];
   totals: {
     files: number;
     bytes: number;
   };
+}
+
+export interface SnapshotArchiveDirectory {
+  path: string;
+  originalPath?: string;
+  modifiedAt: string;
+  mode: number;
 }
 
 export interface SnapshotArchive {
@@ -40,6 +53,7 @@ interface SnapshotRoot {
 }
 
 interface PlannedFile extends SnapshotArchiveFile {
+  sourceMode: number;
   filesystemPath: string;
   device: number;
   inode: number;
@@ -49,6 +63,7 @@ interface PlannedFile extends SnapshotArchiveFile {
 
 interface PlannedDirectory {
   path: string;
+  originalPath?: string;
   filesystemPath: string;
   modifiedAt: Date;
   device: number;
@@ -59,32 +74,44 @@ interface PlannedDirectory {
 }
 
 const LOCAL_KB1_DIRECTORY_NAMES = new Set(['cache', 'runtime', 'secrets', 'tmp']);
-const WINDOWS_RESERVED_BASENAME = /^(?:con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])(?:\.|$)/i;
-const WINDOWS_INVALID_CHARACTER = /[<>:"\\|?*\u0000-\u001f]/;
 
 /**
  * Build one portable ZIP containing every active vault plus the daemon trash.
  * Callers must flush live document sessions before invoking this function.
  *
- * Files are planned with lstat and reopened lazily as yazl consumes them. If a
- * file was replaced between planning and streaming, the stream fails instead
- * of silently producing a mixed snapshot. Hosted daemon writes are atomic
- * renames, so this detects the concurrent-write shape that matters there.
+ * Capture files into private temporary storage and validate the source before
+ * hashing/compression. Changes during capture fail closed; subsequent edits
+ * cannot invalidate the captured snapshot. Hosted writes are atomic renames.
  */
 export async function createSnapshotArchive(input: {
   roots: SnapshotRoot[];
   createdAt: Date;
   durableAsOf: Date;
   signal?: AbortSignal;
+  stagingHome?: string;
 }): Promise<SnapshotArchive> {
   throwIfSnapshotAborted(input.signal);
-  const plan = await planSnapshot(input.roots, input.signal);
-  throwIfSnapshotAborted(input.signal);
+  const stagingDirectory = await mkdtemp(join(input.stagingHome ?? tmpdir(), 'kb1-snapshot-source-'));
+  let plan: Awaited<ReturnType<typeof planSnapshot>>;
+  try {
+    plan = await planSnapshot(input.roots, input.signal);
+    await captureSnapshotFiles(plan, stagingDirectory, input.signal);
+    throwIfSnapshotAborted(input.signal);
+  } catch (error) {
+    await rm(stagingDirectory, { recursive: true, force: true });
+    throw error;
+  }
   const manifest: SnapshotArchiveManifest = {
     schemaVersion: SNAPSHOT_ARCHIVE_SCHEMA_VERSION,
     createdAt: input.createdAt.toISOString(),
     durableAsOf: input.durableAsOf.toISOString(),
     files: plan.files.map((file) => manifestFile(file)),
+    directories: plan.directories.map((directory) => ({
+      path: directory.path.replace(/\/$/, ''),
+      ...(directory.originalPath ? { originalPath: directory.originalPath } : {}),
+      modifiedAt: directory.modifiedAt.toISOString(),
+      mode: directory.mode,
+    })),
     totals: {
       files: plan.files.length,
       bytes: plan.files.reduce((total, file) => total + file.sizeBytes, 0),
@@ -113,10 +140,24 @@ export async function createSnapshotArchive(input: {
     input.signal?.removeEventListener('abort', abortHandler);
     for (const source of activeSources) source.destroy();
     activeSources.clear();
+    void rm(stagingDirectory, { recursive: true, force: true }).catch((error: unknown) => {
+      console.error('KB-1 snapshot capture cleanup failed.', error);
+    });
   });
   archive.addBuffer(
     Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, 'utf8'),
     SNAPSHOT_MANIFEST_PATH,
+    { mtime: input.createdAt, mode: 0o100600 },
+  );
+  archive.addBuffer(
+    Buffer.from('KB-1 recovery archive\n\n'
+      + 'Some names may use a ~kb1- prefix so every file can be safely unpacked on common filesystems.\n'
+      + 'kb1-snapshot.json records each originalPath. File contents are unchanged.\n'
+      + 'For a working vault with its exact original names and links, use the matching daemon release:\n'
+      + '  pnpm snapshot:restore --archive /path/to/snapshot.zip --target /path/to/new-home\n'
+      + 'The target must not exist. The restore command verifies hashes and refuses incompatible names.\n'
+      + 'Never extract over an existing or running daemon home.\n', 'utf8'),
+    SNAPSHOT_RESTORE_HELP_PATH,
     { mtime: input.createdAt, mode: 0o100600 },
   );
   for (const directory of plan.directories) {
@@ -130,7 +171,7 @@ export async function createSnapshotArchive(input: {
       file.path,
       {
         mtime: new Date(file.modifiedAt),
-        mode: file.mode,
+        mode: file.sourceMode,
         size: file.sizeBytes,
         compress: true,
       },
@@ -199,7 +240,7 @@ export async function createSnapshotArchive(input: {
         callback(snapshotAbortError(input.signal), Readable.from([]));
         return;
       }
-      void validateSnapshotPlan(plan, input.signal).then(
+      void validateSnapshotPlan({ files: plan.files, directories: [], missingRoots: [] }, input.signal).then(
         () => callback(null, Readable.from(completion)),
         (error: unknown) => callback(error, Readable.from([]))
       );
@@ -246,7 +287,19 @@ async function planSnapshot(roots: SnapshotRoot[], signal?: AbortSignal): Promis
   }
   files.sort((left, right) => left.path.localeCompare(right.path));
   directories.sort((left, right) => left.path.localeCompare(right.path));
-  validatePortableArchivePaths(files, directories);
+  const mapped = portableSnapshotPaths([
+    SNAPSHOT_MANIFEST_PATH,
+    SNAPSHOT_COMPLETION_PATH,
+    SNAPSHOT_RESTORE_HELP_PATH,
+    ...directories.map((directory) => directory.path.replace(/\/$/, '')),
+    ...files.map((file) => file.path),
+  ]);
+  for (const entry of [...files, ...directories]) {
+    const original = entry.path.replace(/\/$/, '');
+    const portable = mapped.get(original)!;
+    if (portable !== original) entry.originalPath = original;
+    entry.path = entry.path.endsWith('/') ? `${portable}/` : portable;
+  }
   return { files, directories, missingRoots };
 }
 
@@ -296,56 +349,14 @@ async function walkSnapshotRoot(
       modifiedAtMs: info.mtimeMs,
       changedAtMs: info.ctimeMs,
       mode: info.mode,
+      sourceMode: info.mode,
       device: info.dev,
       inode: info.ino,
     };
     files.push({
       ...plannedFile,
-      sha256: await hashSnapshotFile(plannedFile, signal),
+      sha256: '',
     });
-  }
-}
-
-function validatePortableArchivePaths(
-  files: PlannedFile[],
-  directories: PlannedDirectory[],
-): void {
-  const paths = [
-    SNAPSHOT_MANIFEST_PATH,
-    SNAPSHOT_COMPLETION_PATH,
-    ...directories.map((directory) => directory.path.replace(/\/$/, '')),
-    ...files.map((file) => file.path),
-  ];
-  const canonicalPaths = new Map<string, string>();
-
-  for (const path of paths) {
-    const segments = path.split('/');
-    for (const segment of segments) assertPortableArchiveSegment(segment);
-
-    // Windows and common macOS installations compare names without case, and
-    // macOS also normalizes canonically equivalent Unicode. Reject collisions
-    // up front so extraction cannot silently merge two source entries.
-    const canonicalPath = segments
-      .map((segment) => segment.normalize('NFC').toLocaleLowerCase('en-US'))
-      .join('/');
-    const existing = canonicalPaths.get(canonicalPath);
-    if (existing !== undefined) {
-      throw new Error(`Snapshot source contains colliding portable paths: ${existing} and ${path}`);
-    }
-    canonicalPaths.set(canonicalPath, path);
-  }
-}
-
-function assertPortableArchiveSegment(segment: string): void {
-  if (
-    segment.length === 0
-    || segment === '.'
-    || segment === '..'
-    || WINDOWS_INVALID_CHARACTER.test(segment)
-    || /[. ]$/.test(segment)
-    || WINDOWS_RESERVED_BASENAME.test(segment)
-  ) {
-    throw new Error(`Snapshot source contains a non-portable path segment: ${JSON.stringify(segment)}`);
   }
 }
 
@@ -373,11 +384,41 @@ function isPortableSnapshotPath(path: string): boolean {
 function manifestFile(file: PlannedFile): SnapshotArchiveFile {
   return {
     path: file.path,
+    ...(file.originalPath ? { originalPath: file.originalPath } : {}),
     sizeBytes: file.sizeBytes,
     modifiedAt: file.modifiedAt,
-    mode: file.mode,
+    mode: file.sourceMode,
     sha256: file.sha256,
   };
+}
+
+async function captureSnapshotFiles(
+  plan: Awaited<ReturnType<typeof planSnapshot>>,
+  stagingDirectory: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const capturedPaths: string[] = [];
+  for (const [index, file] of plan.files.entries()) {
+    throwIfSnapshotAborted(signal);
+    const path = join(stagingDirectory, String(index));
+    // Reflink where supported; Node falls back to a normal copy elsewhere.
+    // Never hard-link: in-place metadata/audit writes would alter the capture.
+    await copyFile(file.filesystemPath, path, constants.COPYFILE_FICLONE | constants.COPYFILE_EXCL);
+    capturedPaths.push(path);
+  }
+  await validateSnapshotPlan(plan, signal);
+  for (const [index, file] of plan.files.entries()) {
+    throwIfSnapshotAborted(signal);
+    const path = capturedPaths[index]!;
+    const captured = await lstat(path);
+    file.filesystemPath = path;
+    file.device = captured.dev;
+    file.inode = captured.ino;
+    file.modifiedAtMs = captured.mtimeMs;
+    file.changedAtMs = captured.ctimeMs;
+    file.mode = captured.mode;
+    file.sha256 = await hashSnapshotFile(file, signal);
+  }
 }
 
 async function validateSnapshotPlan(plan: {

--- a/apps/daemon/src/snapshot-paths.ts
+++ b/apps/daemon/src/snapshot-paths.ts
@@ -1,0 +1,77 @@
+import { createHash } from 'node:crypto';
+import { extname } from 'node:path';
+
+const ENCODED_SEGMENT_PREFIX = '~kb1-';
+const WINDOWS_RESERVED_BASENAME = /^(?:con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])(?:\.|$)/i;
+const WINDOWS_INVALID_CHARACTER = /[<>:"\\|?*\u0000-\u001f]/;
+
+/** ZIP paths are always relative POSIX paths, including on Windows. */
+export function assertSafeSnapshotPath(path: string): void {
+  if (path.includes('\\') || path.includes('\0') || path.split('/').some(
+    (segment) => segment.length === 0 || segment === '.' || segment === '..',
+  )) {
+    throw new Error(`Unsafe snapshot path: ${JSON.stringify(path)}`);
+  }
+}
+
+export function isPortableSnapshotSegment(segment: string): boolean {
+  return !WINDOWS_INVALID_CHARACTER.test(segment)
+    && !/[. ]$/.test(segment)
+    && !WINDOWS_RESERVED_BASENAME.test(segment);
+}
+
+/**
+ * Map only incompatible names and case/Unicode collisions. ZIP still owns
+ * compression and parsing; this is the archive's path-to-original-name glue.
+ * A reserved prefix keeps a customer's literal name from impersonating a
+ * generated name. Original paths, not hashes, are the restore authority.
+ */
+export function portableSnapshotPaths(paths: string[]): Map<string, string> {
+  const children = new Map<string, Set<string>>();
+  const declared = new Set<string>();
+  for (const path of paths) {
+    assertSafeSnapshotPath(path);
+    if (declared.has(path)) throw new Error(`Duplicate snapshot path: ${path}`);
+    declared.add(path);
+    let parent = '';
+    for (const segment of path.split('/')) {
+      const siblings = children.get(parent) ?? new Set<string>();
+      siblings.add(segment);
+      children.set(parent, siblings);
+      parent = parent ? `${parent}/${segment}` : segment;
+    }
+  }
+
+  const mapped = new Map<string, string>();
+  const visit = (parent: string, mappedParent: string): void => {
+    const siblings = [...(children.get(parent) ?? [])].sort();
+    const counts = new Map<string, number>();
+    for (const segment of siblings) {
+      const key = portableKey(segment);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    const used = new Set<string>();
+    for (const segment of siblings) {
+      const needsMapping = !isPortableSnapshotSegment(segment)
+        || (counts.get(portableKey(segment)) ?? 0) > 1
+        || segment.toLowerCase().startsWith(ENCODED_SEGMENT_PREFIX);
+      const extension = extname(segment);
+      const portable = needsMapping
+        ? `${ENCODED_SEGMENT_PREFIX}${createHash('sha256').update(segment).digest('hex')}${/^\.[a-z0-9]{1,10}$/i.test(extension) ? extension : ''}`
+        : segment;
+      const key = portableKey(portable);
+      if (used.has(key)) throw new Error('Snapshot name mapping produced a collision.');
+      used.add(key);
+      const originalPath = parent ? `${parent}/${segment}` : segment;
+      const mappedPath = mappedParent ? `${mappedParent}/${portable}` : portable;
+      mapped.set(originalPath, mappedPath);
+      visit(originalPath, mappedPath);
+    }
+  };
+  visit('', '');
+  return mapped;
+}
+
+function portableKey(segment: string): string {
+  return segment.normalize('NFC').toLocaleLowerCase('en-US');
+}

--- a/apps/daemon/src/snapshot-restore-cli.ts
+++ b/apps/daemon/src/snapshot-restore-cli.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+
+import { restoreSnapshotArchive } from './snapshot-restore.js';
+
+try {
+  const { values } = parseArgs({ options: { archive: { type: 'string' }, target: { type: 'string' } } });
+  if (!values.archive || !values.target) throw new Error('Usage: kb1-restore --archive snapshot.zip --target /path/to/new-home');
+  const result = await restoreSnapshotArchive({ archivePath: values.archive, targetHome: values.target });
+  console.log(`Restored ${result.files} files (${result.bytes} bytes) into ${result.targetHome}`);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/apps/daemon/src/snapshot-restore.ts
+++ b/apps/daemon/src/snapshot-restore.ts
@@ -1,0 +1,177 @@
+import { createHash } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { chmod, mkdir, rm, utimes } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { Transform } from 'node:stream';
+import { buffer } from 'node:stream/consumers';
+import { pipeline } from 'node:stream/promises';
+
+import { openPromise, type Entry, type ZipFile } from 'yauzl';
+import { z } from 'zod';
+
+import {
+  SNAPSHOT_COMPLETION_PATH,
+  SNAPSHOT_MANIFEST_PATH,
+  SNAPSHOT_RESTORE_HELP_PATH,
+} from './snapshot-archive.js';
+import { assertSafeSnapshotPath, isPortableSnapshotSegment } from './snapshot-paths.js';
+
+const pathMetadata = z.object({
+  path: z.string(),
+  originalPath: z.string().optional(),
+  modifiedAt: z.iso.datetime(),
+  mode: z.number().int().nonnegative(),
+});
+const manifestBase = z.object({
+  createdAt: z.iso.datetime(),
+  durableAsOf: z.iso.datetime(),
+  files: z.array(pathMetadata.extend({
+    sizeBytes: z.number().int().nonnegative(),
+    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+  })),
+  totals: z.object({
+    files: z.number().int().nonnegative(),
+    bytes: z.number().int().nonnegative(),
+  }),
+});
+const manifestSchema = z.discriminatedUnion('schemaVersion', [
+  manifestBase.extend({ schemaVersion: z.literal(1) }),
+  manifestBase.extend({ schemaVersion: z.literal(2), directories: z.array(pathMetadata) }),
+]);
+
+/** Restore into a new home only. Existing homes are never merged or replaced. */
+export async function restoreSnapshotArchive(input: {
+  archivePath: string;
+  targetHome: string;
+}): Promise<{ files: number; bytes: number; targetHome: string }> {
+  const targetHome = resolve(input.targetHome);
+  const zip = await openPromise(input.archivePath, {
+    lazyEntries: true,
+    autoClose: false,
+    strictFileNames: true,
+  });
+  let ownsTarget = false;
+  try {
+    const entries = new Map<string, Entry>();
+    for await (const entry of zip.eachEntry()) {
+      const path = entry.fileName.replace(/\/$/, '');
+      assertSafeSnapshotPath(path);
+      if (entries.has(entry.fileName)) throw new Error(`Duplicate ZIP entry: ${path}`);
+      const type = (entry.externalFileAttributes >>> 16) & 0xf000;
+      const expectedType = entry.fileName.endsWith('/') ? 0x4000 : 0x8000;
+      if (type !== 0 && type !== expectedType) throw new Error('Snapshot contains a link or special file.');
+      entries.set(entry.fileName, entry);
+    }
+    const manifest = manifestSchema.parse(JSON.parse(
+      await readSmallEntry(zip, entries, SNAPSHOT_MANIFEST_PATH, 64 * 1024 * 1024),
+    ));
+    const completion = await readSmallEntry(zip, entries, SNAPSHOT_COMPLETION_PATH, 128);
+    if (completion !== `${manifest.createdAt}\n`) throw new Error('Snapshot completion marker does not match.');
+    if (manifest.totals.files !== manifest.files.length
+      || manifest.totals.bytes !== manifest.files.reduce((sum, file) => sum + file.sizeBytes, 0)) {
+      throw new Error('Snapshot totals do not match its manifest.');
+    }
+
+    const directories = manifest.schemaVersion === 2
+      ? manifest.directories
+      : [...entries.values()].filter((entry) => entry.fileName.endsWith('/')).map((entry) => ({
+        path: entry.fileName.slice(0, -1),
+        originalPath: undefined,
+        modifiedAt: entry.getLastModDate().toISOString(),
+        mode: (entry.externalFileAttributes >>> 16) || 0o700,
+      }));
+    const expectedEntries = new Set([SNAPSHOT_MANIFEST_PATH, SNAPSHOT_COMPLETION_PATH, SNAPSHOT_RESTORE_HELP_PATH]);
+    const restorePaths = new Set<string>();
+    for (const [items, isDirectory] of [[directories, true], [manifest.files, false]] as const) {
+      for (const item of items) {
+        assertSafeSnapshotPath(item.path);
+        const path = item.originalPath ?? item.path;
+        assertRestorePath(path);
+        if (restorePaths.has(path)) throw new Error(`Duplicate restore path: ${path}`);
+        restorePaths.add(path);
+        const entryPath = isDirectory ? `${item.path}/` : item.path;
+        if (expectedEntries.has(entryPath)) throw new Error(`Duplicate manifest path: ${entryPath}`);
+        const entry = entries.get(entryPath);
+        if (!entry) throw new Error(`Snapshot is missing ${entryPath}`);
+        if (!isDirectory && entry.uncompressedSize !== (item as { sizeBytes: number }).sizeBytes) {
+          throw new Error(`Snapshot size does not match its manifest: ${entryPath}`);
+        }
+        expectedEntries.add(entryPath);
+      }
+    }
+    for (const path of entries.keys()) {
+      if (!expectedEntries.has(path)) throw new Error(`Snapshot contains an unlisted entry: ${path}`);
+    }
+
+    // Include implied parents for v1 ZIPs whose root is a nested directory.
+    const directoryPaths = new Set<string>();
+    for (const item of directories) addParents(directoryPaths, `${item.originalPath ?? item.path}/child`);
+    for (const item of manifest.files) addParents(directoryPaths, item.originalPath ?? item.path);
+    for (const file of manifest.files) {
+      if (directoryPaths.has(file.originalPath ?? file.path)) throw new Error('Snapshot file conflicts with a directory.');
+    }
+
+    await mkdir(targetHome, { mode: 0o700 });
+    ownsTarget = true;
+    // Each explicit directory is created once, without recursive merging.
+    // EEXIST catches case/Unicode aliases on the actual destination filesystem.
+    for (const path of [...directoryPaths].sort((a, b) => a.split('/').length - b.split('/').length || a.localeCompare(b))) {
+      await mkdir(join(targetHome, path), { mode: 0o700 });
+    }
+    for (const file of manifest.files) {
+      const target = join(targetHome, file.originalPath ?? file.path);
+      const hash = createHash('sha256');
+      let bytes = 0;
+      const verify = new Transform({
+        transform(chunk: Buffer, _encoding, callback) {
+          bytes += chunk.length;
+          hash.update(chunk);
+          callback(null, chunk);
+        },
+      });
+      await pipeline(
+        await zip.openReadStreamPromise(entries.get(file.path)!),
+        verify,
+        createWriteStream(target, { flags: 'wx', mode: 0o600 }),
+      );
+      if (bytes !== file.sizeBytes || hash.digest('hex') !== file.sha256) {
+        throw new Error(`Snapshot hash verification failed: ${file.path}`);
+      }
+      await chmod(target, file.mode & 0o777);
+      await utimes(target, new Date(file.modifiedAt), new Date(file.modifiedAt));
+    }
+    for (const directory of [...directories].sort((a, b) => b.path.split('/').length - a.path.split('/').length)) {
+      const target = join(targetHome, directory.originalPath ?? directory.path);
+      await chmod(target, directory.mode & 0o777);
+      await utimes(target, new Date(directory.modifiedAt), new Date(directory.modifiedAt));
+    }
+    return { ...manifest.totals, targetHome };
+  } catch (error) {
+    if (ownsTarget) await rm(targetHome, { recursive: true, force: true });
+    throw error;
+  } finally {
+    zip.close();
+  }
+}
+
+function assertRestorePath(path: string): void {
+  assertSafeSnapshotPath(path);
+  const segments = path.split('/');
+  if (segments[0] !== 'vaults' && segments[0] !== '.trash') {
+    throw new Error(`Snapshot path is outside the vault and trash roots: ${path}`);
+  }
+  if (process.platform === 'win32' && segments.some((segment) => !isPortableSnapshotSegment(segment))) {
+    throw new Error('Original snapshot names require a compatible filesystem, such as Linux.');
+  }
+}
+
+function addParents(paths: Set<string>, path: string): void {
+  const segments = path.split('/');
+  for (let length = 1; length < segments.length; length += 1) paths.add(segments.slice(0, length).join('/'));
+}
+
+async function readSmallEntry(zip: ZipFile, entries: Map<string, Entry>, path: string, limit: number): Promise<string> {
+  const entry = entries.get(path);
+  if (!entry || entry.uncompressedSize > limit) throw new Error(`Snapshot has a missing or oversized ${path}`);
+  return (await buffer(await zip.openReadStreamPromise(entry))).toString('utf8');
+}

--- a/apps/daemon/src/vault-registry.ts
+++ b/apps/daemon/src/vault-registry.ts
@@ -405,6 +405,7 @@ export class VaultRegistry {
   async createSnapshotArchive(
     now: Date = new Date(),
     signal?: AbortSignal,
+    stagingHome?: string,
   ): Promise<SnapshotArchive> {
     // This is deliberately captured before any flush begins. Concurrent edits
     // may land while a multi-vault snapshot is being prepared, so a later
@@ -430,6 +431,7 @@ export class VaultRegistry {
       createdAt: now,
       durableAsOf,
       signal,
+      ...(stagingHome ? { stagingHome } : {}),
     });
   }
 

--- a/docs/snapshot-format.md
+++ b/docs/snapshot-format.md
@@ -1,0 +1,82 @@
+# Snapshot archives and offline restore
+
+The daemon owns snapshot creation and interpretation. Cloud stores and relays
+opaque ZIP bytes. A backup does not change live vault paths or content.
+
+## Schema 2
+
+`kb1-snapshot.json` records `schemaVersion: 2`, `createdAt`, `durableAsOf`,
+`files`, `directories`, and source byte/file totals. Each file records its ZIP
+`path`, byte size, SHA-256, mode, and modification time. Each directory records
+its ZIP `path` without a trailing slash, mode, and modification time, including
+empty directories. An entry has `originalPath` when its archive path differs
+from its exact daemon-home-relative path. `kb1-snapshot.complete` contains the
+matching creation timestamp and is emitted only after source validation.
+
+Ordinary paths remain readable. A segment is mapped when Windows cannot
+represent it, when sibling names collide under case/Unicode normalization, or
+when it begins with the reserved `~kb1-` prefix. Its archive segment is `~kb1-`
+plus the SHA-256 of its original UTF-8 segment, retaining a short alphanumeric
+extension where possible. Descendants inherit their mapped parent path. The
+manifest, not a hash reversal, preserves original names. Duplicate paths or a
+mapping collision fail closed. ZIP creation/parsing and hashing use yazl,
+yauzl, and Node's crypto library; this mapping is the format-specific glue.
+
+An ordinary ZIP extractor shows all archived bytes, but renamed paths can
+affect links and metadata references. Use the restore command for a working
+daemon home. Original names that are impossible on Windows remain impossible
+there; use a compatible filesystem rather than silently renaming or losing
+customer data. Case-colliding names require a filesystem that distinguishes
+them. The original archive remains usable even when a restore target does not.
+
+## Restore into a new home
+
+From the matching daemon checkout with dependencies installed:
+
+```sh
+pnpm snapshot:restore --archive /path/to/snapshot.zip --target /tmp/kb1-restored-home
+KB1_HOME=/tmp/kb1-restored-home KB1_HOST=127.0.0.1 KB1_PORT=17390 pnpm dev:daemon
+```
+
+Choose a free local port and a target that does not exist. Packaged builds also
+provide `kb1-restore --archive ... --target ...`. The restore command accepts
+legacy schema 1 and schema 2. It validates the manifest, completion marker,
+entry inventory, original paths, sizes, and hashes; rejects links and path
+traversal; and creates files exclusively so an existing file or incompatible
+case alias cannot be overwritten. A failure removes only the destination home
+created by this invocation. The ZIP is never modified. Ownership and special
+permission bits are not restored; the new home is private to the operator.
+
+After restoration, inspect representative notes, attachments, and trash, then
+start the daemon and verify vault enumeration and a real edit/save. Recovery
+into a live production volume is a separate operator-approved cutover with a
+captured rollback point. Never use this command to merge into a live home.
+
+## Release compatibility
+
+Cloud versions that accept only snapshot schema 1 must be upgraded to accept
+schema 2 **before** rolling out this daemon. A Cloud code deployment and a
+managed-daemon fleet rollout are separate steps. The Cloud backup descriptor's
+own schema version is independent of the daemon archive schema.
+
+## Consistency and exclusions
+
+Snapshots flush dirty sessions, copy files into a private temporary capture,
+and validate the source before hashing and compression. A reflink is used when
+the filesystem supports it, with a normal copy as fallback. Edits after this
+capture cannot invalidate the archive. Changes during capture still fail the
+attempt; discard that ZIP and retry. The last successful backup must remain
+intact when a later attempt fails.
+
+Temporary storage can require the full uncompressed source plus the final ZIP
+when reflinks are unavailable. HTTP snapshots keep the capture inside the
+daemon-owned spool so restart cleanup covers interrupted work. Continuous
+mutation faster than the capture window can still prevent a snapshot; backup
+age and failures must be monitored rather than claiming guaranteed completion.
+A local 1,001-file / 12.9 MB probe completed 3/3 attempts with one edit per
+second after capture was introduced (2/3 before); ten edits per second still
+failed all three attempts. This is a synthetic observation, not a fleet SLO.
+
+Archives include active vaults, recoverable trash, and portable `.kb1` metadata.
+They exclude `.git` and daemon-local `.kb1/cache`, `runtime`, `tmp`, and `secrets`
+directories. They are not a backup of Cloud identity, billing, or D1 records.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "smoke:windows": "node scripts/windows-smoke.mjs",
     "smoke:yjs": "node scripts/yjs-smoke.mjs",
     "storybook": "pnpm --filter @kb-1/ui storybook",
+    "snapshot:restore": "tsx apps/daemon/src/snapshot-restore-cli.ts",
     "test": "pnpm test:scripts && nx run-many -t test",
     "test:scripts": "node --test scripts/*.test.mjs",
     "typecheck": "nx run-many -t typecheck"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,9 +127,15 @@ importers:
       ws:
         specifier: 8.21.0
         version: 8.21.0
+      yauzl:
+        specifier: 3.4.0
+        version: 3.4.0
       yazl:
         specifier: 3.3.1
         version: 3.3.1
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
@@ -146,9 +152,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.8
         version: 4.1.8(vitest@4.1.8)
-      yauzl:
-        specifier: 3.4.0
-        version: 3.4.0
       yjs:
         specifier: 13.6.31
         version: 13.6.31


### PR DESCRIPTION
Valid vault names such as `Meeting: launch.md` and `con.md` currently prevent whole-organization exports and backups. Snapshot schema 2 preserves their bytes under portable archive names and records exact original paths, including directories. The new offline restore command validates the archive and restores original names exclusively into a new home; it supports schemas 1 and 2 and fails on an incompatible destination instead of overwriting or renaming customer data.

Snapshot creation now captures files privately before hashing/compression and validates the source at that boundary. Later edits cannot invalidate a completed capture. Capture storage is cleaned with the daemon-owned spool. Source changes during capture still fail safely; non-reflink filesystems need temporary space for uncompressed data as well as the ZIP.

Validation: focused snapshot/restore coverage and full `pnpm check` passed on Node 24.18.0. Autoreview found no actionable issues. A local 1,001-file / 12.9 MB activity probe passed 3/3 attempts at one edit per second (2/3 before); ten edits per second still prevented all three captures. The limitation is documented, and backup health alerts are being added in the companion Cloud change.

Deployment dependency: deploy Cloud's schema-1-and-2 reader compatibility before rolling out this daemon. The Cloud companion PR and subsequent daemon-pointer PR remain separate. No deployment or live data change is included.
