### PR TITLE
Bound search memory and make testing proportional

### DIFF
--- a/apps/daemon/vitest.config.ts
+++ b/apps/daemon/vitest.config.ts
@@ -20,11 +20,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text'],
-      include: ['src/app.ts', 'src/request-helpers.ts', 'src/starter-kit.ts', 'src/ui-static.ts', 'src/vault-registry.ts'],
-      thresholds: {
-        lines: 90,
-        perFile: true
-      }
+      include: ['src/app.ts', 'src/request-helpers.ts', 'src/starter-kit.ts', 'src/ui-static.ts', 'src/vault-registry.ts']
     }
   }
 });

--- a/docs/architecture/invariants/engineering/tests-are-gated-and-real.md
+++ b/docs/architecture/invariants/engineering/tests-are-gated-and-real.md
@@ -1,59 +1,45 @@
-# Tests Are Gated And Real
+# Tests Protect Consequential Behavior
 
 ## Invariant
 
-Test suites for service and session code run against real resources, assert
-through two independent paths, and enforce coverage through build-failing
-gates. A test suite is a first-class deliverable, not an accompaniment.
+Tests protect customer-visible behavior, data durability, access boundaries, and
+known regressions. Verification is proportional to the consequence of a failure.
+Coverage reports help locate gaps; percentages and assertion counts are not the
+acceptance criteria.
 
 ## This Means
 
-- **Real resources.** Filesystem-touching tests run against real temp
-  directories (`mkdtemp`); no in-memory fs shims, no mocking the resource
-  under test. Processes under test bind real (ephemeral/temp) ports and are
-  killed by the test.
-- **Dual assertion.** Every mutation is verified BOTH through the
-  service/API read path AND by direct inspection of the underlying resource
-  (file content/stat, trash contents, audit JSONL rows). One without the
-  other is half a test.
-- **Gated coverage.** Vitest coverage thresholds are wired into `pnpm
-  check` so the build FAILS below them: pure-logic packages at 100%
-  statements/functions/lines (≥95% branches); route/session/service glue at
-  ≥90% lines. Every new production file lands inside a gate's include — a
-  file outside all gates is a violation, not an oversight.
-- **Truthful suppressions.** Every coverage-ignore comment carries a reason
-  that is accurate for ITS line (copy-paste drift is a violation), and
-  auditors review every ignore.
-- **Truthful names.** A test's name describes what it actually exercises;
-  a name claiming a library or behavior the test does not touch is a
-  violation (this happened: a test titled "using gray-matter detection"
-  tested a hand-rolled scanner).
-- **Property tests** defend algorithmic glue (validation, splice/diff
-  application) with randomized inputs including unicode/surrogate cases
-  near the operation site.
+- **Real resources where they matter.** Filesystem and persistence tests use
+  disposable real directories, and process tests own their ports and cleanup.
+  Never use a developer's real vault or shared state. Mock external boundaries
+  when appropriate, but do not mock away the resource whose behavior is under test.
+- **Independent durability evidence.** Save, collaboration, restart, recovery,
+  and other persistence-sensitive tests verify both the public read path and
+  persisted bytes when either alone could hide a real failure. Routine mutations
+  need the assertions that establish their contract, not a mandatory second path.
+- **Meaningful regressions.** Add a test when it catches a plausible bug, protects
+  an important contract, or reproduces a known failure. Reversible, low-impact
+  edits and implementation details do not automatically require new tests.
+- **Coverage as diagnosis.** Keep coverage reporting for review, without blanket
+  percentage gates or a requirement that every production file have a gate.
+  Investigate consequential untested behavior; do not add assertions or ignore
+  comments just to change a number. Existing ignores must describe their actual line.
+- **Truthful names.** Test names describe the behavior actually exercised.
+- **Focused property tests.** Retain randomized validation, Unicode, and
+  splice/diff checks where they expose input combinations that examples miss.
 
-## Good Examples
+## Verification And Review
 
-- `KB1_HOME=$(mktemp -d)` per suite; chmod-based persist-failure repros.
-- The splice property test: randomized docs/edits reproduce expected
-  content exactly.
-- Negative-testing a gate (raise threshold → build fails → revert) to prove
-  it enforces.
+Run the repository's required checks for the change. Reuse valid results from the
+same revision and environment; rerun affected checks after changes or failures.
+Do not repeat unchanged suites for reassurance or negative-test coverage tooling
+merely to prove it enforces a quota.
 
-## Violations
+Keep high-value persistence, restart, reconnection, revocation, isolation,
+provisioning, and deletion coverage. Remove or consolidate a test only after
+identifying the obsolete behavior, duplication, or implementation-only assertion;
+a high test count is not itself a reason to delete tests.
 
-- A new production file outside every coverage include.
-- A mutation test that asserts only the API response.
-- memfs/mock-fs for vault behavior; tests sharing a developer's real state.
-- An ignore comment whose reason describes a different line.
-
-## Exceptions
-
-None currently accepted.
-
-## Review Checklist
-
-- Is every new file inside a gate? Run the negative test on one gate.
-- Spot-check three mutations for dual assertion.
-- Read every new coverage-ignore reason against its line.
-- Do test names match what the bodies do?
+Reviewers should ask which failure each added test catches, whether the resources
+and assertions expose that failure, and what material gaps remain. A green suite
+is evidence for its tested behavior, not proof of production readiness.

--- a/packages/doc-session/vitest.config.ts
+++ b/packages/doc-session/vitest.config.ts
@@ -26,21 +26,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text'],
-      include: ['src/manager.ts', 'src/protocol.ts', 'src/session.ts', 'src/websocket.ts'],
-      thresholds: {
-        'src/manager.ts': {
-          lines: 95
-        },
-        'src/protocol.ts': {
-          lines: 95
-        },
-        'src/session.ts': {
-          lines: 90
-        },
-        'src/websocket.ts': {
-          lines: 90
-        }
-      }
+      include: ['src/manager.ts', 'src/protocol.ts', 'src/session.ts', 'src/websocket.ts']
     }
   }
 });

--- a/packages/local-mcp/vitest.config.ts
+++ b/packages/local-mcp/vitest.config.ts
@@ -8,10 +8,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text'],
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts'],
-      thresholds: {
-        lines: 95
-      }
+      exclude: ['src/**/*.test.ts']
     }
   }
 });

--- a/packages/tunnel-client/vitest.config.ts
+++ b/packages/tunnel-client/vitest.config.ts
@@ -19,13 +19,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text'],
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts'],
-      thresholds: {
-        statements: 90,
-        branches: 90,
-        functions: 90,
-        lines: 90,
-      },
+      exclude: ['src/**/*.test.ts']
     },
   },
 });

--- a/packages/tunnel-protocol/vitest.config.ts
+++ b/packages/tunnel-protocol/vitest.config.ts
@@ -8,13 +8,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text'],
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts'],
-      thresholds: {
-        statements: 90,
-        branches: 90,
-        functions: 90,
-        lines: 90,
-      },
+      exclude: ['src/**/*.test.ts']
     },
   },
 });

--- a/packages/vault-core/src/index.test.ts
+++ b/packages/vault-core/src/index.test.ts
@@ -2800,6 +2800,23 @@ describe("scan search", () => {
     ]);
   });
 
+  it("keeps full totals and context when paging across dense files", async () => {
+    await writeFileWithParents(path.join(root, "dense", "a.md"), "needle a1\nneedle a2\nneedle a3", "utf8");
+    await writeFileWithParents(path.join(root, "dense", "b.md"), "needle b1\nneedle b2\nneedle b3", "utf8");
+
+    const page = await searchVaultFiles(root, { q: "needle", under: "dense", offset: 2, limit: 2, context: 1 });
+    expect(page.total).toBe(6);
+    expect(page.results).toEqual([
+      { path: "dense/a.md", line: 3, lineText: "needle a3", context: { before: ["needle a2"], after: [] } },
+      { path: "dense/b.md", line: 1, lineText: "needle b1", context: { before: [], after: ["needle b2"] } },
+    ]);
+    const last = await searchVaultFiles(root, { q: "needle", under: "dense", offset: 5, limit: 2 });
+    expect(last.total).toBe(6);
+    expect(last.results.map((hit) => hit.lineText)).toEqual(["needle b3"]);
+    const beyond = await searchVaultFiles(root, { q: "needle", under: "dense", offset: 6 });
+    expect(beyond).toMatchObject({ total: 6, results: [] });
+  });
+
   it("searches from the vault root and excludes metadata and trash folders", async () => {
     await mkdir(path.join(root, ".git", "objects", "aa"), { recursive: true });
     await writeFile(

--- a/packages/vault-core/src/search.ts
+++ b/packages/vault-core/src/search.ts
@@ -56,7 +56,8 @@ export async function searchVaultFiles(root: string, input: SearchInput): Promis
   const limit = clampPositiveInteger(input.limit, DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT);
   const offset = clampNonNegativeInteger(input.offset);
   const context = clampNonNegativeInteger(input.context, DEFAULT_CONTEXT_LINES, MAX_CONTEXT_LINES);
-  const allHits: SearchHit[] = [];
+  const results: SearchHit[] = [];
+  let total = 0;
   const { files, truncated } = await collectSearchableFiles(root, under);
   const lowerQuery = query.toLocaleLowerCase();
 
@@ -66,7 +67,10 @@ export async function searchVaultFiles(root: string, input: SearchInput): Promis
     const lines = content.split('\n');
     for (const [index, lineText] of lines.entries()) {
       if (!lineText.toLocaleLowerCase().includes(lowerQuery)) continue;
-      allHits.push({
+      // Keep counting the full scan, but retain text/context only for this page.
+      const matchIndex = total++;
+      if (matchIndex < offset || results.length >= limit) continue;
+      results.push({
         path: filePath,
         line: index + 1,
         lineText,
@@ -83,9 +87,9 @@ export async function searchVaultFiles(root: string, input: SearchInput): Promis
     under,
     limit,
     offset,
-    total: allHits.length,
+    total,
     truncated,
-    results: allHits.slice(offset, offset + limit)
+    results
   };
 }
 

--- a/packages/vault-core/vitest.config.ts
+++ b/packages/vault-core/vitest.config.ts
@@ -23,13 +23,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text'],
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts'],
-      thresholds: {
-        statements: 100,
-        functions: 100,
-        lines: 100,
-        branches: 95
-      }
+      exclude: ['src/**/*.test.ts']
     }
   }
 });

--- a/packages/vault-service/vitest.config.ts
+++ b/packages/vault-service/vitest.config.ts
@@ -16,11 +16,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text'],
       include: ['src/**/*.ts'],
-      exclude: ['src/**/*.test.ts'],
-      thresholds: {
-        lines: 90,
-        perFile: true
-      }
+      exclude: ['src/**/*.test.ts']
     }
   }
 });


### PR DESCRIPTION
Dense searches retained every matching line and its context before slicing one page, so a 20-result request could allocate hundreds of thousands of result objects. Count all matches while retaining only the requested page, preserving ordering, context, total, limits and pagination.

Replace blanket coverage and dual-assertion quotas with behavior- and consequence-based verification. Keep coverage reports, required checks, real persistence evidence, and all existing regression tests. Add one focused cross-file pagination case covering a partial final page and an exhausted offset.

Validation: `pnpm check` passed on Node 24.18.0; focused search tests passed; structured autoreview found no actionable defects. A sequential local macOS comparison over 1,000 notes / 500,000 matching lines returned the same 20 results and total: elapsed 264 → 133 ms, end-of-run RSS 324 → 95 MiB. These are single synthetic runs, not production or peak-memory measurements.

Independent of snapshot PR #128. No search index, parallel file reads, dependency change or deployment. Cloud adopts daemon changes through its separate pointer PR after merge.
